### PR TITLE
Refactor the `CliContext` to not depend on commander

### DIFF
--- a/packages/anvil/src/context/CliContext.ts
+++ b/packages/anvil/src/context/CliContext.ts
@@ -1,40 +1,29 @@
 import { Context } from 'adonai'
-import { Command } from 'commander'
 import { AnyObject } from '@financial-times/anvil-types-generic'
 import { CliMessenger } from './CliMessenger'
 
 interface ConstructorArgs {
-  command: Command
+  args: AnyObject
+  flags: AnyObject
   messenger: CliMessenger
   workingDir: string
 }
 
 export class CliContext extends Context {
   paths = {
-    workingDir: '',
-    packageDir: ''
+    workingDir: ''
   }
 
   args: AnyObject = {}
-
   flags: AnyObject = {}
-
   messenger: CliMessenger
 
-  constructor({ workingDir, command, messenger }: ConstructorArgs) {
+  constructor({ workingDir, args, flags, messenger }: ConstructorArgs) {
     super()
 
-    this.paths.workingDir = workingDir
+    this.args = args
+    this.flags = flags
     this.messenger = messenger
-    this.flags = command.opts()
-
-    prepareCliArgs(this, command)
+    this.paths.workingDir = workingDir
   }
-}
-
-function prepareCliArgs(context: CliContext, command: any) {
-  const args = command.parent.args.slice(0, -1)
-  command._args.forEach((arg, idx) => {
-    context.args[arg.name] = args[idx]
-  })
 }

--- a/packages/anvil/src/operations/buildWebpack.ts
+++ b/packages/anvil/src/operations/buildWebpack.ts
@@ -10,11 +10,7 @@ export async function buildWebpack(context: CliContext) {
   context.messenger.setTitle('Compiling build')
   context.messenger.startProgressBar()
   const webpackConfig = context.amend('webpackConfig', getDefaultWebpackConfig(context))
-  await pack({
-    webpackConfig,
-    onProgress: (value) => {
-      context.messenger.updateProgressBar(value)
-    }
-  })
+  const onProgress = (value) => context.messenger.updateProgressBar(value)
+  await pack({ webpackConfig, onProgress })
   context.messenger.stopProgressBar()
 }


### PR DESCRIPTION
This PR integrates the refactorings done in #28 as it was easier to reapply them than to rebase.

closes #28