### PR TITLE
Fix concurrent building issue

### DIFF
--- a/examples/basic-app/package.json
+++ b/examples/basic-app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "example-app",
+  "scope": "example",
   "private": true,
   "version": "1.0.0",
   "main": "index.js",

--- a/examples/ft-app/package.json
+++ b/examples/ft-app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ft-app",
+  "scope": "example",
   "private": true,
   "version": "1.0.0",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "description": "The aim of this project is to provide a high quality, well tested, and thoroughly documented, modern asset pipeline and application shell for Node.js applications based upon the latest industry standards.",
   "scripts": {
     "test": "jest",
-    "build": "athloi run build",
+    "build": "athloi run build --filter scope:'\"anvil\"' --concurrency 100",
     "checktypes": "tsc --noEmit",
     "clean": "git clean -fxd -e .vscode",
     "clean:install": "npm run clean && npm install",
-    "dev": "athloi run dev --concurrency 10",
+    "dev": "athloi run dev --concurrency 100",
     "lint": "eslint . --ext .js,.ts,.tsx,.jsx",
     "postinstall": "athloi exec npm i",
     "prettier": "prettier --write '**/*.{ts,tsx,js,jsx,json}'"

--- a/packages/anvil-plugin-babel/package.json
+++ b/packages/anvil-plugin-babel/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-babel",
+  "scope": "anvil",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-plugin-css/package.json
+++ b/packages/anvil-plugin-css/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-css",
+  "scope": "anvil",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-plugin-entry/package.json
+++ b/packages/anvil-plugin-entry/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-entry",
+  "scope": "anvil",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-plugin-esnext/package.json
+++ b/packages/anvil-plugin-esnext/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-esnext",
+  "scope": "anvil",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-plugin-ft-bower/package.json
+++ b/packages/anvil-plugin-ft-bower/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-ft-bower",
+  "scope": "anvil",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-plugin-ft-js/package.json
+++ b/packages/anvil-plugin-ft-js/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-ft-js",
+  "scope": "anvil",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-server-asset-loader/package.json
+++ b/packages/anvil-server-asset-loader/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@financial-times/anvil-server-asset-loader",
+  "scope": "anvil",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-types-adonai/package.json
+++ b/packages/anvil-types-adonai/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@financial-times/anvil-types-adonai",
+  "scope": "anvil",
   "version": "0.0.0",
   "description": "",
   "main": "index.d.ts",

--- a/packages/anvil-types-build/package.json
+++ b/packages/anvil-types-build/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@financial-times/anvil-types-build",
+  "scope": "anvil",
   "version": "0.0.0",
   "description": "",
   "main": "index.d.ts",

--- a/packages/anvil-types-generic/package.json
+++ b/packages/anvil-types-generic/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@financial-times/anvil-types-generic",
+  "scope": "anvil",
   "version": "0.0.0",
   "description": "",
   "main": "index.d.ts",

--- a/packages/anvil-utils/package.json
+++ b/packages/anvil-utils/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@financial-times/anvil-utils",
+  "scope": "anvil",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil/package.json
+++ b/packages/anvil/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@financial-times/anvil",
+  "scope": "anvil",
   "version": "0.0.0",
   "description": "The anvil CLI",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
The problem is that when building concurrently via `athloi run build --concurrency 100`, an error occurs because it is triggering and `"build": "anvil build"` in the example packages before the `anvil` package that it depends on has itself been built. To fix this, a `scope` property has been added to the `package.json` file of each package so that packages can be filtered by it when using athloi. All packages in the `/packages` folder get a scope of `anvil` while all packages in in the `/examples` folder get a scope if `examples`. This now allows the build command to become `athloi run build --concurency 100 --filter scope:'"anvil"'`.