### PR TITLE
Rename `scope=anvil` to `scope=package`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "description": "The aim of this project is to provide a high quality, well tested, and thoroughly documented, modern asset pipeline and application shell for Node.js applications based upon the latest industry standards.",
   "scripts": {
     "test": "jest",
-    "build": "athloi run build --filter scope:'\"anvil\"' --concurrency 100",
+    "build": "athloi run build --filter scope:'\"package\"' --concurrency 100",
     "checktypes": "tsc --noEmit",
     "clean": "git clean -fxd -e .vscode",
-    "clean:dist": "athloi run clean:dist --filter scope:'\"anvil\"' --concurrency 100",
+    "clean:dist": "athloi run clean:dist --filter scope:'\"package\"' --concurrency 100",
     "clean:install": "npm run clean && npm install",
     "dev": "athloi run dev --concurrency 100",
     "lint": "eslint . --ext .js,.ts,.tsx,.jsx",

--- a/packages/anvil-middleware-ft-edition/package.json
+++ b/packages/anvil-middleware-ft-edition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-middleware-ft-edition",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-middleware-ft-navigation/package.json
+++ b/packages/anvil-middleware-ft-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-middleware-ft-navigation",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-plugin-babel/package.json
+++ b/packages/anvil-plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-babel",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-plugin-code-splitting/package.json
+++ b/packages/anvil-plugin-code-splitting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-code-splitting",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-plugin-css/package.json
+++ b/packages/anvil-plugin-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-css",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-plugin-entry/package.json
+++ b/packages/anvil-plugin-entry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-entry",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-plugin-esnext/package.json
+++ b/packages/anvil-plugin-esnext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-esnext",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-plugin-ft-bower/package.json
+++ b/packages/anvil-plugin-ft-bower/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-ft-bower",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-plugin-ft-css/package.json
+++ b/packages/anvil-plugin-ft-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-ft-css",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-plugin-ft-js/package.json
+++ b/packages/anvil-plugin-ft-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-plugin-ft-js",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-server-asset-loader/package.json
+++ b/packages/anvil-server-asset-loader/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@financial-times/anvil-server-asset-loader",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",
-  "types": "src/index.d.ts",
+  "types": "src/index.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "tsc": "../../node_modules/.bin/tsc",

--- a/packages/anvil-types-build/package.json
+++ b/packages/anvil-types-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-types-build",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "index.d.ts",

--- a/packages/anvil-types-generic/package.json
+++ b/packages/anvil-types-generic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-types-generic",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "index.d.ts",

--- a/packages/anvil-ui-ft-footer/package.json
+++ b/packages/anvil-ui-ft-footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-ui-ft-footer",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-ui-ft-header/package.json
+++ b/packages/anvil-ui-ft-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-ui-ft-header",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-ui-ft-layout/package.json
+++ b/packages/anvil-ui-ft-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-ui-ft-layout",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-ui-ft-shell/package.json
+++ b/packages/anvil-ui-ft-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-ui-ft-shell",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil-utils/package.json
+++ b/packages/anvil-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil-utils",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",

--- a/packages/anvil/package.json
+++ b/packages/anvil/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/anvil",
-  "scope": "anvil",
+  "scope": "package",
   "version": "0.0.0",
   "description": "The anvil CLI",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
This PR renames `scope=anvil` to `scope=package` in the package.json so that the convention will be that if package is in the`/examples` folder, it will have a scope of `example`, and if the package is in the `/packages` folder, it will have a scope of `package` etc.