### PR TITLE
Add @babel/preset-env defaults

### DIFF
--- a/packages/anvil/README.md
+++ b/packages/anvil/README.md
@@ -53,6 +53,7 @@ Usage via configuration file:
 
 ```json
 {
+  "plugins": [...],
   "settings": {
     "entry": {
       "main": "./path/to/entry.js"
@@ -72,6 +73,27 @@ anvil build --outputPath ./path/to/dist
 ```
 
 Files will be created using the pattern `[name].js` in development mode and `[name].[contenthash].js` in production mode.
+
+##### Targets
+
+A value that describes the environments you support / target for your project. It accepts the same values that the `targets` property of `@babel/preset-env` accepts, and it defaults to the [browserslist-compatible] query `> 1%, ie 11, bb 10, ff ESR`. See the [`@babel/preset-env` documentation] for more information about targets
+
+Usage via configuration file:
+
+```json
+{
+  "plugins": [...],
+  "settings": {
+    "targets": {
+      "chrome": "58",
+      "ie": "11"
+    }
+  }
+}
+```
+
+[browserslist-compatible]: https://github.com/browserslist/browserslist
+[`@babel/preset-env` documentation]: https://babeljs.io/docs/en/babel-preset-env#targets
 
 ##### Development and production modes
 

--- a/packages/anvil/src/operations/getBabelConfig.ts
+++ b/packages/anvil/src/operations/getBabelConfig.ts
@@ -7,8 +7,16 @@ import { CliContext } from '../entities/CliContext'
  * to construct a preset that can be specified in a .babelrc file. When used in as a preset,
  * there will be no args supplied to the function, hence why the `cli` arg is optional.
  */
+
 export function getBabelConfig(cli?: CliContext) {
-  const presetEnvOpts = {}
+  const defaultTargets = '> 1%, ie 11, bb 10, ff ESR'
+  const presetEnvOpts = {
+    targets: cli.config.settings.targets || defaultTargets,
+    useBuiltIns: false,
+    // Exclude transforms that make all code slower
+    // See https://github.com/facebook/create-react-app/pull/5278
+    exclude: ['transform-typeof-symbol']
+  }
 
   const babelConfig = {
     presets: [[require.resolve('@babel/preset-env'), presetEnvOpts]],


### PR DESCRIPTION
This PR adds some `@babel/preset-env` defaults to core.