### PR TITLE
Add vscode extensions recommendations and workspace settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ dist/
 Thumbs.db
 npm-debug.log
 package-lock.json
-.vscode
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
 .cache

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "orta.vscode-jest",
+    "esbenp.prettier-vscode",
+    "streetsidesoftware.code-spell-checker"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,25 @@
+{
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/coverge": true
+  },
+  "[javascript]": {
+    "editor.formatOnSave": true,
+    "editor.formatOnPaste": true
+  },
+  "[typescript]": {
+    "editor.formatOnSave": true,
+    "editor.formatOnPaste": true
+  },
+  "cSpell.allowCompoundWords": true,
+  "cSpell.spellCheckDelayMs": 300,
+  "cSpell.enabledLanguageIds": [
+    "javascript",
+    "javascriptreact",
+    "markdown",
+    "typescript",
+    "typescriptreact",
+    "yml"
+  ],
+  "cSpell.words": []
+}


### PR DESCRIPTION
I realise this is controversial, but I've created this PR to let you have a little try of two VScode features that may be helpful to promote better developer behaviours and improve the experience.

`extensions.json` will show a little popup when you open the project for the first time asking if you want the recommended extensions.

`settings.json` has some common settings.

I've suggested using the jest runner which is pretty neat, the Prettier formatter and the cSpell spell checker. The settings are to customise this experience (including adding words to the spelling dictionary).

Let me know your thoughts