### PR TITLE
add crumbtrail component with storybook

### DIFF
--- a/packages/anvil-ui-ft-header/src/components/crumbtrail/partials.tsx
+++ b/packages/anvil-ui-ft-header/src/components/crumbtrail/partials.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+
+const IncludeCrumbtrail = ({ props }) => (
+  <Crumbtrail>
+    <BreadCrumb breadcrumb={props.breadcrumb} />
+    <SubSections subsections={props.subsections} />
+    <ShowSignOut showSignOut={props.showSignOut} />
+  </Crumbtrail>
+)
+
+const Crumbtrail = (props) => (
+  <div
+    className="o-header__subnav"
+    role="navigation"
+    aria-label="Sub navigation"
+    data-o-header-subnav
+    data-trackable="header-subnav">
+    <div className="o-header__container">
+      <div className="o-header__subnav-wrap-outside">
+        <div className="o-header__subnav-wrap-inside" data-o-header-subnav-wrapper>
+          <div className="o-header__subnav-content" />
+          {props.children}
+        </div>
+      </div>
+      {/* Implements crumbtrail scrolling at smaller viewports */}
+      <button
+        className="o-header__subnav-button o-header__subnav-button--left"
+        title="scroll left"
+        aria-label="scroll left"
+        aria-hidden="true"
+        disabled
+      />
+      <button
+        className="o-header__subnav-button o-header__subnav-button--right"
+        title="scroll right"
+        aria-label="scroll right"
+        aria-hidden="true"
+        disabled
+      />
+    </div>
+  </div>
+)
+
+const BreadCrumb = ({ breadcrumb }) => {
+  return (
+    <ol
+      className="o-header__subnav-list o-header__subnav-list--breadcrumb"
+      aria-label="Breadcrumb"
+      data-trackable="breadcrumb">
+      {breadcrumb.map((item, index) => {
+        const selected = item.selected ? 'o-header__subnav-link--highlight' : null
+        const ariaCurrent = item.selected ? { 'aria-current': true } : null
+        return (
+          <li className="o-header__subnav-item" key={`item-${index}`}>
+            <a
+              className={`o-header__subnav-link ${selected}`}
+              href={item.url}
+              {...ariaCurrent}
+              data-trackable={item.label}>
+              {item.label}
+            </a>
+          </li>
+        )
+      })}
+    </ol>
+  )
+}
+
+const SubSections = ({ subsections }) => {
+  const ariaCurrent = subsections && subsections.selected ? { 'aria-current': true } : null
+  return (
+    <ul
+      className="o-header__subnav-list o-header__subnav-list--subsections"
+      aria-label="Subsections"
+      data-trackable="subsections">
+      {subsections.map((item, index) => {
+        const id = item.id ? `data-id=subnav-${item.id}` : null
+        const selected = item.selected ? 'o-header__subnav-link--highlight' : null
+        return (
+          <li className="o-header__subnav-item" {...id} key={`item-${index}`}>
+            <a
+              className={`o-header__subnav-link ${selected}`}
+              href={item.url}
+              {...ariaCurrent}
+              data-trackable={item.label}>
+              {item.label}
+            </a>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+const ShowSignOut = ({ showSignOut }) => {
+  return showSignOut ? (
+    <div className="o-header__subnav-link--right">
+      <a className="o-header__subnav-link" href="/logout" data-trackable="Sign Out">
+        Sign out
+      </a>
+    </div>
+  ) : null
+}
+
+export { IncludeCrumbtrail }

--- a/packages/anvil-ui-ft-header/src/index.tsx
+++ b/packages/anvil-ui-ft-header/src/index.tsx
@@ -7,6 +7,7 @@ import {
   TopColumnRight
 } from './components/top/partials'
 import { NavListLeft, NavListRight, Nav } from './components/navigation/partials'
+import { IncludeCrumbtrail } from './components/crumbtrail/partials'
 
 export function Header(props) {
   // TODO Figure out how we should be handling UK v international
@@ -36,6 +37,28 @@ export function LogoOnly() {
       <TopWrapper>
         <TopColumnCenter />
       </TopWrapper>
+    </HeaderSimple>
+  )
+}
+
+export function HeaderWithCrumbtrail(props) {
+  const navbarOptionsLeft = props['navbar-uk'].items
+  const navbarRight = props['navbar-right'].items
+  const navbarRightAnon = props['navbar-right-anon'].items
+  const navbarOptionsRight = props.userNav ? navbarRight : navbarRightAnon
+  const incudeCrumbtrail = props.breadcrumb && props.subsections ? IncludeCrumbtrail({ props }) : null
+  return (
+    <HeaderSimple>
+      <TopWrapper>
+        <TopColumnLeft />
+        <TopColumnCenter />
+        <TopColumnRight />
+      </TopWrapper>
+      <Nav>
+        <NavListLeft navbarOptionsLeft={navbarOptionsLeft} />
+        <NavListRight navbarOptionsRight={navbarOptionsRight} />
+      </Nav>
+      {incudeCrumbtrail}
     </HeaderSimple>
   )
 }

--- a/packages/anvil-ui-ft-header/src/story-data/crumbtrail-uk.ts
+++ b/packages/anvil-ui-ft-header/src/story-data/crumbtrail-uk.ts
@@ -1,0 +1,50 @@
+export default {
+  item: {
+    label: 'UK',
+    url: '/world/uk',
+    submenu: {
+      label: null,
+      items: [
+        {
+          label: 'UK Business & Economy',
+          url: '/uk-business-economy',
+          submenu: null
+        },
+        {
+          label: 'UK Politics & Policy',
+          url: '/world/uk/politics',
+          submenu: null
+        },
+        {
+          label: 'UK Companies',
+          url: '/companies/uk',
+          submenu: null
+        }
+      ]
+    }
+  },
+  siblings: [],
+  children: [
+    {
+      label: 'UK Business & Economy',
+      url: '/uk-business-economy',
+      submenu: null
+    },
+    {
+      label: 'UK Politics & Policy',
+      url: '/world/uk/politics',
+      submenu: null
+    },
+    {
+      label: 'UK Companies',
+      url: '/companies/uk',
+      submenu: null
+    }
+  ],
+  ancestors: [
+    {
+      label: 'World',
+      url: '/world'
+    }
+  ]
+}

--- a/packages/anvil-ui-ft-header/src/story-data/storyData.ts
+++ b/packages/anvil-ui-ft-header/src/story-data/storyData.ts
@@ -1,10 +1,18 @@
 import navbarUk from './navbar-uk'
 import navbarRight from './navbar-right'
 import navbarRightAnon from './navbar-right-anon'
+import crumbtrail from './crumbtrail-uk'
+
+const breadcrumb = crumbtrail.ancestors.concat(crumbtrail.item)
+const subsections = crumbtrail.children
 
 export default {
   userNav: true,
   'navbar-uk': navbarUk,
   'navbar-right': navbarRight,
-  'navbar-right-anon': navbarRightAnon
+  'navbar-right-anon': navbarRightAnon,
+  breadcrumb: breadcrumb,
+  subsections: subsections,
+  showSubNav: true,
+  showSignOut: true
 }

--- a/packages/anvil-ui-ft-header/src/story.tsx
+++ b/packages/anvil-ui-ft-header/src/story.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
-import { Header, LogoOnly } from '.'
+import { Header, HeaderWithCrumbtrail, LogoOnly } from '.'
 import { storiesOf } from '@storybook/react'
 import { withKnobs, boolean } from '@storybook/addon-knobs'
 import { OrigamiBuildService } from '@financial-times/anvil-ui-origami-build-service'
 import storyData from './story-data/storyData'
 
 const userStateOptions = ['User is logged in', true]
+const showSignOutOptions = ['Show sign out link', true]
 
 storiesOf('FT / Header', module)
   .addDecorator(withKnobs)
@@ -19,6 +20,24 @@ storiesOf('FT / Header', module)
           'o-normalise': '^1.6.2'
         }}>
         <Header {...storyData} userNav={toggleUserState} />
+      </OrigamiBuildService>
+    )
+  })
+  .add('with-crumbtrail', () => {
+    const toggleUserStateOptions = boolean(...userStateOptions)
+    const toggleSignOutOptions = boolean(...showSignOutOptions)
+    return (
+      <OrigamiBuildService
+        dependencies={{
+          'o-header': '^7.7.0',
+          'o-fonts': '^3.2.0',
+          'o-normalise': '^1.6.2'
+        }}>
+        <HeaderWithCrumbtrail
+          {...storyData}
+          userNav={toggleUserStateOptions}
+          showSignOut={toggleSignOutOptions}
+        />
       </OrigamiBuildService>
     )
   })


### PR DESCRIPTION
Adds a crumbtrail element to the ft-header component with storybook implementation. 

<img width="1280" alt="screenshot 2019-02-01 at 10 26 42" src="https://user-images.githubusercontent.com/17549437/52119553-51c9f400-2611-11e9-929d-70eca79e5a8f.png">
