### PR TITLE
Update the `Getting started` section of the `Extending webpack and babel` guide to reflect the current state of affairs

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,3 @@
+# Guides
+
+- [Extending webpack and babel](extending-webpack-and-babel.md)


### PR DESCRIPTION
- Updates the `Getting started` section to reflect the new `anvil.config.js` file format
- Add the list of the existing plugins