### PR TITLE
improve footer storybook radios and origami options

### DIFF
--- a/packages/anvil-ui-ft-footer/src/story.tsx
+++ b/packages/anvil-ui-ft-footer/src/story.tsx
@@ -5,33 +5,27 @@ import { withKnobs, radios } from '@storybook/addon-knobs'
 import { OrigamiBuildService } from '@financial-times/anvil-ui-origami-build-service'
 import sampleData from './storyData'
 
-const themeOptions = ['Theme', { dark: 'dark', light: 'light' }, 'dark']
+const toggleTheme = () => radios('Theme', { dark: 'dark', light: 'light' }, 'dark')
+
+const OrigamiDependecies = {
+  'o-footer': '^6.0.10',
+  'o-fonts': '^3.2.0',
+  'o-normalise': '^1.6.2'
+}
 
 storiesOf('FT / Footer', module)
   .addDecorator(withKnobs)
   .add('footer', () => {
-    const toggleTheme = radios(...themeOptions)
     return (
-      <OrigamiBuildService
-        dependencies={{
-          'o-footer': '^6.0.10',
-          'o-fonts': '^3.2.0',
-          'o-normalise': '^1.6.2'
-        }}>
-        <Footer {...sampleData} theme={toggleTheme} />
+      <OrigamiBuildService dependencies={OrigamiDependecies}>
+        <Footer {...sampleData} theme={toggleTheme()} />
       </OrigamiBuildService>
     )
   })
   .add('legal footer', () => {
-    const toggleTheme = radios(...themeOptions)
     return (
-      <OrigamiBuildService
-        dependencies={{
-          'o-footer': '^6.0.10',
-          'o-fonts': '^3.2.0',
-          'o-normalise': '^1.6.2'
-        }}>
-        <LegalFooter {...sampleData} theme={toggleTheme} />
+      <OrigamiBuildService dependencies={OrigamiDependecies}>
+        <LegalFooter {...sampleData} theme={toggleTheme()} />
       </OrigamiBuildService>
     )
   })


### PR DESCRIPTION
Some improvements to the FT footer storybook. 

 - Simplifies the radio buttons
 - Pulls origami dependencies into a single object