### PR TITLE
Fix asset loader `getPublicURL()` public path formatting issue

### DIFF
--- a/packages/anvil-server-asset-loader/src/__test__/index.spec.ts
+++ b/packages/anvil-server-asset-loader/src/__test__/index.spec.ts
@@ -21,14 +21,19 @@ jest.mock('../helpers/loadFile', () => {
   }
 })
 
+function createAssetLoader({
+  publicPath = 'public/assets',
+  fileSystemPath = '/internal/path/to/assets',
+  ...otherOptions
+} = {}) {
+  return new AssetLoader({ publicPath, fileSystemPath, ...otherOptions })
+}
+
 describe('anvil-server-asset-loader', () => {
   let loader
 
   beforeEach(() => {
-    loader = new AssetLoader({
-      publicPath: 'public/assets',
-      fileSystemPath: '/internal/path/to/assets'
-    })
+    loader = createAssetLoader()
   })
 
   afterEach(() => {
@@ -72,6 +77,12 @@ describe('anvil-server-asset-loader', () => {
     it('returns the public path for the requested file', () => {
       const result = loader.getPublicURL('styles.css')
       expect(result).toEqual('public/assets/styles.12345.bundle.css')
+    })
+
+    it('should correctly format the url when the public path has not been set', () => {
+      const loader = createAssetLoader({ publicPath: '' })
+      const result = loader.getPublicURL('styles.css')
+      expect(result).toEqual('styles.12345.bundle.css')
     })
   })
 

--- a/packages/anvil-server-asset-loader/src/index.ts
+++ b/packages/anvil-server-asset-loader/src/index.ts
@@ -81,7 +81,7 @@ class AssetLoader {
   getPublicURL(asset: string): string {
     const hashedAsset = this.getHashedAsset(asset)
     // Do not use path.join() as separator is platform specific
-    return `${this.options.publicPath}/${hashedAsset}`
+    return this.options.publicPath ? `${this.options.publicPath}/${hashedAsset}` : hashedAsset
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue regarding the asset loader getPublicURL() method not correctly formatting the url when the public path has not been specified. In such a situation, it prefixes the path with a forward slash. Actual usage, however, has revealed that rather than prefixing the url with a forward slash, it should instead return the asset name as is, when the public path has not been set.