### PR TITLE
Add a `getHashedAssetsMatching(pattern)` method to the asset loader

### DIFF
--- a/packages/anvil-server-asset-loader/readme.md
+++ b/packages/anvil-server-asset-loader/readme.md
@@ -54,6 +54,10 @@ Returns the absolute file system path to an output file for the given the source
 
 Loads the contents of an output file for the given the source file name.
 
+### `getHashedAssetsMatching(pattern: string | RegExp | Function)`
+
+Returns an array of output file names whose source file name matches the supplied pattern.
+
 ### `matchAssets(pattern: string | RegExp | Function)`
 
 Match source file names based on a pattern which may be useful when output is split into multiple files.

--- a/packages/anvil-server-asset-loader/src/__test__/index.spec.ts
+++ b/packages/anvil-server-asset-loader/src/__test__/index.spec.ts
@@ -50,6 +50,19 @@ describe('anvil-server-asset-loader', () => {
 
   describe('.matchAssets()', () => {
     it('returns an array of matching file names from the manifest', () => {
+      const a = loader.getHashedAssetsMatching(/main/)
+      expect(a).toEqual(['main.12345.bundle.js', 'vendor~main~secondary.12345.bundle.js'])
+
+      const b = loader.getHashedAssetsMatching('main')
+      expect(b).toEqual(['main.12345.bundle.js', 'vendor~main~secondary.12345.bundle.js'])
+
+      const c = loader.getHashedAssetsMatching((filename) => filename === 'main.js')
+      expect(c).toEqual(['main.12345.bundle.js'])
+    })
+  })
+
+  describe('.getHashedAssetsMatching(pattern)', () => {
+    it('returns an array of matching hashed file names from the manifest', () => {
       const a = loader.matchAssets(/main/)
       expect(a).toEqual(['main.js', 'vendor~main~secondary.js'])
 

--- a/packages/anvil-server-asset-loader/src/index.ts
+++ b/packages/anvil-server-asset-loader/src/index.ts
@@ -61,6 +61,10 @@ class AssetLoader {
     }, [])
   }
 
+  getHashedAssetsMatching(pattern: string | RegExp | Function): string[] {
+    return this.matchAssets(pattern).map((thing) => this.getHashedAsset(thing))
+  }
+
   getHashedAsset(asset: string): string {
     if (this.manifest.hasOwnProperty(asset)) {
       return this.manifest[asset]


### PR DESCRIPTION
This PR adds to the asset loader, a `getHashedAssetsMatching(pattern)` method that returns an array of output file names whose source file name matches the supplied pattern.