### PR TITLE
Add `ssr with hydration` example

### DIFF
--- a/examples/ssr-with-hydration/.npmrc
+++ b/examples/ssr-with-hydration/.npmrc
@@ -1,0 +1,2 @@
+shrinkwrap = false
+package-lock = false

--- a/examples/ssr-with-hydration/__test__/integration.test.js
+++ b/examples/ssr-with-hydration/__test__/integration.test.js
@@ -1,0 +1,63 @@
+const element = {
+  nav: {
+    homepageLink: '#homepageNavLink',
+    dogsPageLink: '#dogsPageNavLink',
+    termsPageLink: '#termsPageNavLink'
+  },
+  homepage: {
+    button: '#btn'
+  },
+  dogsPage: {
+    bulldogLink: '#bulldogLink'
+  },
+  dogImagesPage: {
+    dogImage: '#dogImage'
+  }
+}
+
+describe('examples/ssr-with-hydration', () => {
+  beforeEach(async () => {
+    await page.goto('http://localhost:3000', { waitUntil: 'load' })
+  })
+
+  it('should work as expected', async () => {
+    expect(await page.title()).toBe('Home | Anvil')
+    expect(await pageDescription()).toBe('The homepage')
+
+    await assertButtonOpensAlertBox()
+
+    await page.click(element.nav.dogsPageLink)
+
+    expect(await page.title()).toBe('Dogs | Anvil')
+    expect(await pageDescription()).toBe('The dogs list page')
+
+    await page.click(element.dogsPage.bulldogLink)
+
+    expect(await page.title()).toBe('Dog | Anvil')
+    expect(await pageDescription()).toBe('The dog page')
+
+    const totalImages = await getTotalDogImages()
+
+    expect(totalImages).toBeGreaterThan(0)
+  })
+})
+
+async function assertButtonOpensAlertBox() {
+  return new Promise((resolve) => {
+    page.on('dialog', async (dialog) => {
+      await dialog.dismiss()
+      resolve()
+    })
+    page.click(element.homepage.button)
+  })
+}
+
+async function getTotalDogImages() {
+  return page.evaluate(async (element) => {
+    return document.querySelectorAll(element.dogImagesPage.dogImage).length
+  }, element)
+}
+
+function pageDescription() {
+  return page.$eval("head > meta[name='description']", (element) => element.content)
+}

--- a/examples/ssr-with-hydration/anvil.config.js
+++ b/examples/ssr-with-hydration/anvil.config.js
@@ -1,0 +1,26 @@
+const esnext = require('@financial-times/anvil-plugin-esnext')
+const codeSplitting = require('@financial-times/anvil-plugin-code-splitting')
+
+module.exports = {
+  plugins: [
+    esnext.plugin(),
+    codeSplitting.plugin(),
+    plugin
+  ],
+  settings: {
+    build: {
+      entry: {
+        main: './app/client.js'
+      }
+    }
+  }
+}
+
+function plugin({ on }) {
+  on('webpackConfig', ({ resource: webpackConfig }) => {
+    webpackConfig.output.publicPath = '/assets/'
+  })
+  on('babelConfig', ({ resource: babelConfig }) => {
+    babelConfig.presets.push('@babel/preset-react')
+  })
+}

--- a/examples/ssr-with-hydration/app/client.js
+++ b/examples/ssr-with-hydration/app/client.js
@@ -1,0 +1,4 @@
+import routes from './routes'
+import { mount } from '../libs/ssr/client'
+
+mount({ routes })

--- a/examples/ssr-with-hydration/app/components/Page.js
+++ b/examples/ssr-with-hydration/app/components/Page.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { PageNavigation } from './PageNavigation'
+import { placeholder, createSlotterFor } from '@financial-times/anvil-ui-slots'
+
+Page.Body = placeholder()
+Page.Header = placeholder()
+Page.Footer = placeholder()
+
+export default function Page(props) {
+  const Slot = createSlotterFor(Page, props)
+
+  return (
+    <React.Fragment>
+      <header>
+        <Slot name="Header" />
+        <PageNavigation />
+      </header>
+      <main id="root">
+        <Slot name="Body" />
+      </main>
+      <footer>
+        <Slot name="Footer" />
+      </footer>
+    </React.Fragment>
+  )
+}

--- a/examples/ssr-with-hydration/app/components/PageNavigation.js
+++ b/examples/ssr-with-hydration/app/components/PageNavigation.js
@@ -1,0 +1,24 @@
+import React from 'react'
+export function PageNavigation() {
+  return (
+    <nav>
+      <ul>
+        <li>
+          <a id="homepageNavLink" href="/">
+            Home
+          </a>
+        </li>
+        <li>
+          <a id="dogsPageNavLink" href="/dogs">
+            Dogs
+          </a>
+        </li>
+        <li>
+          <a id="termsPageNavLink" href="/terms">
+            Terms
+          </a>
+        </li>
+      </ul>
+    </nav>
+  )
+}

--- a/examples/ssr-with-hydration/app/pages/DogImages.js
+++ b/examples/ssr-with-hydration/app/pages/DogImages.js
@@ -1,0 +1,36 @@
+import React from 'react'
+
+export default {
+  title: 'Dog',
+  description: 'The dog page',
+  component: DogImagesPage,
+  getInitialProps: async ({ req }) => ({
+    breed: req.params.breed,
+    breedImages: await fetchDogImages(req.params.breed)
+  }),
+  getDependencies: async () => ({
+    Page: (await import('../components/Page')).default
+  })
+}
+
+function DogImagesPage({ breed, breedImages, Page }) {
+  return (
+    <Page>
+      <Page.Header>
+        <h1>Dog Breeds</h1>
+      </Page.Header>
+      <Page.Body>
+        <p>Images of {breed}:</p>
+        {breedImages.map((img) => (
+          <img id="dogImage" src={img} key={img} />
+        ))}
+      </Page.Body>
+    </Page>
+  )
+}
+
+function fetchDogImages(breed) {
+  return fetch(`https://dog.ceo/api/breed/${breed}/images`)
+    .then((response) => response.json())
+    .then((result) => result.message)
+}

--- a/examples/ssr-with-hydration/app/pages/DogsList.js
+++ b/examples/ssr-with-hydration/app/pages/DogsList.js
@@ -1,0 +1,45 @@
+import React from 'react'
+
+export default {
+  title: 'Dogs',
+  description: 'The dogs list page',
+  component: DogsListPage,
+  getInitialProps: async () => ({
+    breeds: await fetchDogBreeds()
+  }),
+  getDependencies: async () => ({
+    Page: (await import('../components/Page')).default
+  })
+}
+
+function DogsListPage({ breeds, Page }) {
+  return (
+    <Page>
+      <Page.Header>
+        <h1>Dog Breeds</h1>
+      </Page.Header>
+      <Page.Body>
+        <p>A list of dog breeds:</p>
+        <ul>
+          {breeds.map((breed) => (
+            <li key={breed}>
+              <a id={`${breed}Link`} href={`/dogs/${breed}`}>
+                {breed}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </Page.Body>
+    </Page>
+  )
+}
+
+DogsListPage.defaultProps = {
+  breeds: []
+}
+
+function fetchDogBreeds() {
+  return fetch('https://dog.ceo/api/breeds/list/all')
+    .then((response) => response.json())
+    .then((result) => Object.keys(result.message))
+}

--- a/examples/ssr-with-hydration/app/pages/Home.js
+++ b/examples/ssr-with-hydration/app/pages/Home.js
@@ -1,0 +1,29 @@
+import React from 'react'
+
+export default {
+  title: 'Home',
+  description: 'The homepage',
+  component: Homepage,
+  getDependencies: async () => ({
+    Page: (await import('../components/Page')).default
+  })
+}
+
+function Homepage({ Page }) {
+  return (
+    <Page>
+      <Page.Header>
+        <h1>Home</h1>
+      </Page.Header>
+      <Page.Body>
+        <button id="btn" onClick={handleBtnClick}>
+          Click me
+        </button>
+      </Page.Body>
+    </Page>
+  )
+}
+
+function handleBtnClick() {
+  alert('This is the home page...')
+}

--- a/examples/ssr-with-hydration/app/pages/Terms.js
+++ b/examples/ssr-with-hydration/app/pages/Terms.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export default {
+  title: 'Terms',
+  description: 'The terms page',
+  component: TermsPage
+}
+
+function TermsPage() {
+  return (
+    <React.Fragment>
+      <h1>Terms</h1>
+      <p>Some terms text...</p>
+    </React.Fragment>
+  )
+}

--- a/examples/ssr-with-hydration/app/routes.js
+++ b/examples/ssr-with-hydration/app/routes.js
@@ -1,0 +1,22 @@
+export default [
+  {
+    name: 'home',
+    path: '/',
+    component: () => import('./pages/Home')
+  },
+  {
+    name: 'dogs',
+    path: '/dogs',
+    component: () => import('./pages/DogsList')
+  },
+  {
+    name: 'dog-images',
+    path: '/dogs/:breed',
+    component: () => import('./pages/DogImages')
+  },
+  {
+    name: 'terms',
+    path: '/terms',
+    component: () => import('./pages/Terms')
+  }
+]

--- a/examples/ssr-with-hydration/app/server.js
+++ b/examples/ssr-with-hydration/app/server.js
@@ -1,0 +1,48 @@
+import path from 'path'
+import React from 'react'
+import Shell from '@financial-times/anvil-ui-ft-shell'
+import routes from './routes'
+import express from 'express'
+import AssetLoader from '@financial-times/anvil-server-asset-loader'
+import { renderToString } from 'react-dom/server'
+import { getInitialProps, getDependencies, getScriptsToLoad } from '../libs/ssr/server'
+
+const app = express()
+const port = 3000
+const assets = new AssetLoader({
+  fileSystemPath: path.resolve('./dist'),
+  manifestFileName: 'manifest.json'
+})
+
+const enhancedScriptsToLoad = getScriptsToLoad(assets)
+
+app.use('/assets', express.static(path.resolve('./dist')))
+
+routes.forEach(async (route) => {
+  app.get(route.path, async (req, res) => {
+    const Page = (await route.component()).default
+    const initialProps = await getInitialProps(Page, req)
+    const dependencies = await getDependencies(Page)
+
+    const props = {
+      siteTitle: 'Anvil',
+      pageTitle: Page.title,
+      description: Page.description,
+      initialProps: { $$page: route.name, ...initialProps },
+      enhancedScriptsToLoad
+    }
+
+    const markup = renderToString(
+      <Shell {...props}>
+        <div id="app">
+          <Page.component {...props.initialProps} {...dependencies} />
+        </div>
+      </Shell>
+    )
+    res.send(`<!DOCTYPE html>${markup}`)
+  })
+})
+
+app.listen(port, () => {
+  console.log(`Listening on PORT:${port}`) // eslint-disable-line no-console
+})

--- a/examples/ssr-with-hydration/jest-puppeteer.config.js
+++ b/examples/ssr-with-hydration/jest-puppeteer.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  server: {
+    command: 'npm run start',
+    port: 3000
+  },
+  launch: {
+    // https://discuss.circleci.com/t/puppeteer-fails-on-circleci/22650
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  }
+}

--- a/examples/ssr-with-hydration/libs/ssr/client.js
+++ b/examples/ssr-with-hydration/libs/ssr/client.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { hydrate } from 'react-dom'
+
+export async function mount(options) {
+  const { routes, elementId = 'app' } = options
+  const { $$page, ...initialProps } = getInitialPropsFromDom(options)
+
+  for (let route of routes) {
+    if (route.name === $$page) {
+      const Page = (await route.component()).default
+      const dependencies = await getDependencies(Page)
+      hydrate(<Page.component {...initialProps} {...dependencies} />, document.getElementById(elementId))
+      break
+    }
+  }
+}
+
+function getInitialPropsFromDom({ initialPropsElementId = 'initial-props' }) {
+  return JSON.parse(document.getElementById(initialPropsElementId).innerHTML)
+}
+
+async function getDependencies(page) {
+  if (!page.getDependencies) return {}
+  return await page.getDependencies()
+}

--- a/examples/ssr-with-hydration/libs/ssr/server.js
+++ b/examples/ssr-with-hydration/libs/ssr/server.js
@@ -1,0 +1,17 @@
+export function getScriptsToLoad(assetLoader) {
+  return [
+    assetLoader.getPublicURL('runtime.js'),
+    ...assetLoader.getPublicURLOfHashedAssetsMatching(/npm\.(.*)\.js/),
+    assetLoader.getPublicURL('main.js')
+  ]
+}
+
+export async function getInitialProps({ getInitialProps }, req) {
+  if (!getInitialProps) return {}
+  return await getInitialProps({ req })
+}
+
+export async function getDependencies({ getDependencies }) {
+  if (!getDependencies) return {}
+  return await getDependencies()
+}

--- a/examples/ssr-with-hydration/package.json
+++ b/examples/ssr-with-hydration/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "example-ssr-with-hydration",
+  "private": true,
+  "version": "0.0.0",
+  "main": "app.js",
+  "license": "MIT",
+  "scripts": {
+    "build": "anvil build -d",
+    "start": "node start.js",
+    "start:dev": "nodemon start.js --ext js",
+    "test": "../../node_modules/.bin/jest",
+    "pretest": "npm run build"
+  },
+  "dependencies": {
+    "@financial-times/anvil-middleware-assets": "file:../../packages/anvil-middleware-assets",
+    "@financial-times/anvil-plugin-code-splitting": "file:../../packages/anvil-plugin-code-splitting",
+    "@financial-times/anvil-server-asset-loader": "file:../../packages/anvil-server-asset-loader",
+    "@financial-times/anvil-ui-ft-shell": "file:../../packages/anvil-ui-ft-shell",
+    "express": "^4.16.2",
+    "isomorphic-fetch": "^2.2.1",
+    "react": "^16.8.3",
+    "react-dom": "^16.8.3",
+    "sucrase": "^3.8.0"
+  },
+  "devDependencies": {
+    "@babel/preset-react": "^7.0.0",
+    "@financial-times/anvil": "file:../../packages/anvil",
+    "@financial-times/anvil-plugin-esnext": "file:../../packages/anvil-plugin-esnext",
+    "@financial-times/anvil-ui-slots": "file:../../packages/anvil-ui-slots",
+    "nodemon": "^1.18.7"
+  },
+  "jest": {
+    "preset": "jest-puppeteer"
+  }
+}

--- a/examples/ssr-with-hydration/readme.md
+++ b/examples/ssr-with-hydration/readme.md
@@ -1,0 +1,23 @@
+# Example Rendering with anvil-ui-ft-shell
+
+This package demonstrates the use of anvil to create a react app that renders pages on the server while also hydrating them on the client. Some notable things that it features are as follows:
+
+- The use of `anvil-ui-ft-shell` `initialProps` functionality
+- Dynamic imports
+- Custom plugins
+
+### Running the app
+
+First run the following command to build the client side assets
+
+```
+npm run build
+```
+
+Then run the following command to start the app
+
+```
+npm run start
+```
+
+Then open `localhost:3000` in your browser

--- a/examples/ssr-with-hydration/start.js
+++ b/examples/ssr-with-hydration/start.js
@@ -1,0 +1,3 @@
+require('sucrase/register')
+require('isomorphic-fetch')
+require('./app/server')


### PR DESCRIPTION
This PR adds an example app (with integration tests) that demonstrates the use of anvil to create a react app that renders pages on the server while also hydrating them on the client.