### PR TITLE
Fix `crossorigin` prop warning in `anvil-ui-ft-shell`

### DIFF
--- a/packages/anvil-ui-ft-shell/src/components/DocumentHead/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/anvil-ui-ft-shell/src/components/DocumentHead/__test__/__snapshots__/index.test.tsx.snap
@@ -29,7 +29,7 @@ Array [
     rel="preconnect"
   />,
   <link
-    crossorigin="use-credentials"
+    crossOrigin="use-credentials"
     href="https://session-next.ft.com"
     rel="preconnect"
   />,

--- a/packages/anvil-ui-ft-shell/src/components/DocumentHead/index.tsx
+++ b/packages/anvil-ui-ft-shell/src/components/DocumentHead/index.tsx
@@ -32,7 +32,7 @@ const DocumentHead = (props: TDocumentHeadProps) => (
 
     {/* resource hints */}
     <link rel="preconnect" href="https://spoor-api.ft.com" />
-    <link rel="preconnect" href="https://session-next.ft.com" crossorigin="use-credentials" />
+    <link rel="preconnect" href="https://session-next.ft.com" crossOrigin="use-credentials" />
     <link rel="preconnect" href="https://ads-api.ft.com" />
     <link rel="preconnect" href="https://www.googletagservices.com" />
 


### PR DESCRIPTION
This PR fixes a react `crossorigin` prop warning in `anvil-ui-ft-shell`