### PR TITLE
add drawer and meganav elements to express-ft-header integration tests

### DIFF
--- a/examples/express-ft-header/__test__/integration.test.js
+++ b/examples/express-ft-header/__test__/integration.test.js
@@ -27,4 +27,20 @@ describe('examples/express-ft-header', () => {
     expect(response.text).toContain('data-trackable="World"')
     expect(response.text).toContain('data-trackable="Markets"')
   })
+
+  it('populates drawer elements with navigation data', () => {
+    expect(response.text).toContain('o-header__drawer-menu--primary')
+    expect(response.text).toContain('o-header__drawer-menu--user')
+    expect(response.text).toContain('o-header__drawer-current-edition')
+    expect(response.text).toContain('data-trackable="edition-switcher"')
+  })
+
+  it('populates meganav elements with navigation data', () => {
+    expect(response.text).toContain('data-trackable="meganav | World"')
+    expect(response.text).toContain('data-trackable="meganav | Markets"')
+    expect(response.text).toContain('data-trackable="meganav | Opinion"')
+    expect(response.text).toContain('o-header__mega-heading')
+    expect(response.text).toContain('o-header__mega-content')
+    expect(response.text).toContain('o-header__mega-item')
+  })
 })

--- a/examples/express-ft-header/server/controllers/home.js
+++ b/examples/express-ft-header/server/controllers/home.js
@@ -1,5 +1,5 @@
 const ReactDOMServer = require('react-dom/server')
-const { HeaderDefault } = require('@financial-times/anvil-ui-ft-header')
+const { HeaderDefault, Drawer } = require('@financial-times/anvil-ui-ft-header')
 const document = require('../lib/document')
 
 const headerProps = {
@@ -17,17 +17,15 @@ const headerProps = {
   data: {}
 }
 
-module.exports = (_, response, next) => {
-  headerProps.editions = response.locals.editions
+const render = (component) => ReactDOMServer.renderToStaticMarkup(component)
 
-  // TODO Tidy up: Set data to response.locals.navigation.main once editions are fixed
-  headerProps.data.navbar = response.locals.navigation['navbar']
-  headerProps.data['navbar-simple'] = response.locals.navigation['navbar-simple']
-  headerProps.data['navbar-right'] = response.locals.navigation['navbar-right']
-  headerProps.data['navbar-right-anon'] = response.locals.navigation['navbar-right-anon']
+module.exports = (_, response, next) => {
+  headerProps.data = response.locals.navigation
+  // TODO - This should not be editionsUk
+  headerProps.data.editionsUk = response.locals.editions
 
   try {
-    const html = ReactDOMServer.renderToStaticMarkup(HeaderDefault(headerProps))
+    const html = [render(HeaderDefault(headerProps)), render(Drawer(headerProps))].join()
     const page = document(html)
     response.send(page)
   } catch (error) {


### PR DESCRIPTION
Adds integration tests to the express-ft-header example app to test for the presence of the drawer menu and meganav components. 