### PR TITLE
add viewport addon to storybook

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,2 +1,3 @@
 import '@storybook/addon-knobs/register'
 import '@storybook/addon-options/register'
+import '@storybook/addon-viewport/register'

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@financial-times/athloi": "^1.0.0-beta.17",
     "@storybook/addon-knobs": "^4.1.12",
     "@storybook/addon-options": "^4.1.12",
+    "@storybook/addon-viewport": "^4.1.12",
     "@storybook/react": "^4.1.12",
     "@types/jest": "^24.0.0",
     "@types/node": "^10.12.26",


### PR DESCRIPTION
Adds the storybook viewport addon to our anvil storybook settings for viewing changes as they'd appear on different devices. 

<img width="1086" alt="Screenshot 2019-03-11 at 16 21 59" src="https://user-images.githubusercontent.com/17549437/54139593-d29ebb80-4419-11e9-8361-7eb4667cd608.png">
