### PR TITLE
remove hardcoded UK edition references

### DIFF
--- a/examples/express-ft-header/server/controllers/home.js
+++ b/examples/express-ft-header/server/controllers/home.js
@@ -21,8 +21,7 @@ const render = (component) => ReactDOMServer.renderToStaticMarkup(component)
 
 module.exports = (_, response, next) => {
   headerProps.data = response.locals.navigation
-  // TODO - This should not be editionsUk
-  headerProps.data.editionsUk = response.locals.editions
+  headerProps.data.editions = response.locals.editions
 
   try {
     const html = [render(HeaderDefault(headerProps)), render(Drawer(headerProps))].join()

--- a/packages/anvil-middleware-ft-edition/src/__test__/index.spec.ts
+++ b/packages/anvil-middleware-ft-edition/src/__test__/index.spec.ts
@@ -1,7 +1,7 @@
 import { init as subject } from '../index'
 import httpMocks from 'node-mocks-http'
 
-const editionsUk = {
+const editions = {
   current: expect.objectContaining({ id: 'uk' }),
   others: [expect.objectContaining({ id: 'international' })]
 }
@@ -42,7 +42,7 @@ describe('anvil-middleware-ft-edition', () => {
     })
     it('sets the edition to uk as default', () => {
       instance(requestMock, responseMock, next)
-      expect(responseMock.locals.editions).toEqual(expect.objectContaining(editionsUk))
+      expect(responseMock.locals.editions).toEqual(expect.objectContaining(editions))
     })
     it('sets the edition to international if passed a valid query string', () => {
       requestMock.query.edition = 'international'

--- a/packages/anvil-ui-ft-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/anvil-ui-ft-header/src/components/drawer/topLevelPartials.tsx
@@ -6,7 +6,7 @@ const IncludeDrawer = (props) => <Drawer {...props} />
 
 const Drawer = (props: Props) => {
   // TODO refactor editions and sections data from improved navigation model
-  const editions = props.data.editionsUk
+  const editions = props.data.editions
   const sections = props.data.drawer.items
   const userMenu = props.data.user
 

--- a/packages/anvil-ui-ft-header/src/interfaces.d.ts
+++ b/packages/anvil-ui-ft-header/src/interfaces.d.ts
@@ -11,8 +11,7 @@ export interface Props {
     showSignOut: boolean
   }
   data: {
-    editionsUk: TEditions
-    editionsInternational: TEditions
+    editions: TEditions
     drawer: TItemSubMenu
     navbar: TItemSubMenu
     'navbar-right': TItemSubMenu

--- a/packages/anvil-ui-ft-header/src/story-data/storyData.ts
+++ b/packages/anvil-ui-ft-header/src/story-data/storyData.ts
@@ -5,7 +5,6 @@ import navbarRightAnon from './navbarRightAnon.json'
 import drawerUk from './drawerUk.json'
 import crumbtrail from './crumbtrailUk.json'
 import editionsUk from './editionsUk.json'
-import editionsInternational from './editionsInternational.json'
 import user from './user.json'
 
 const breadcrumb = crumbtrail.ancestors.concat(crumbtrail.item)
@@ -31,8 +30,7 @@ export default {
     drawer: drawerUk,
     breadcrumb,
     subsections,
-    editionsUk,
-    editionsInternational,
+    editions: editionsUk,
     user
   }
 }


### PR DESCRIPTION
This PR removes the references to `editionsUk` which were included before the navigation and editions work was complete. The `editions` property is set by the anvil-middleware-ft-navigation package and includes editions data foe the correct region. 