### PR TITLE
navigation bug fix

### DIFF
--- a/packages/anvil-ui-ft-header/src/components/navigation/partials.tsx
+++ b/packages/anvil-ui-ft-header/src/components/navigation/partials.tsx
@@ -65,7 +65,7 @@ const NavListLeft = ({ navItems }) => {
 
 const NavListRight = (props) => {
   // Serve the signed-in or anonymous user experience
-  const navbarKey = props.options.userNav ? 'navbar-right-anon' : 'navbar-right'
+  const navbarKey = props.options.userIsAnonymous ? 'navbar-right-anon' : 'navbar-right'
   const navbarOptions = props.data[navbarKey].items
   let navListRight = null
   if (props.options.userNav) {


### PR DESCRIPTION
Fixes a navigation bug that crept in during an earlier refactor. The navListRight data should vary on the `userIsAnonymous` property and be rendered only if `userNav` is true. 