### PR TITLE
Asset loader tweaks

### DIFF
--- a/packages/anvil-server-asset-loader/readme.md
+++ b/packages/anvil-server-asset-loader/readme.md
@@ -71,6 +71,10 @@ The `AssetLoader` class accepts the following parameters. All parameters are opt
 
 The name of the asset manifest file. This will be resolved relative to the `fileSystemPath`. Defaults to `"manifest.json"`.
 
+### `manifest`
+
+An object mapping file names to hashed file name, to be used as the [manifest](#creating-a-manifest-file). If specified, the manifest will not be looked up using the `fileSystemPath`  and `manifestFileName`. 
+
 ### `publicPath`
 
 The public-facing URL for the static assets. This is used when formatting publicly accessible URLs to assets for the browser or user to download. This should begin with a slash or protocol (e.g. `https://`) but no trailing slash is necessary. 

--- a/packages/anvil-server-asset-loader/src/__test__/index.spec.ts
+++ b/packages/anvil-server-asset-loader/src/__test__/index.spec.ts
@@ -1,4 +1,4 @@
-import AssetLoader from '../'
+import AssetLoader, { AssetLoaderOptions } from '../'
 
 const manifest = {
   'styles.css': 'styles.12345.bundle.css',
@@ -25,7 +25,7 @@ function createAssetLoader({
   publicPath = 'public/assets',
   fileSystemPath = '/internal/path/to/assets',
   ...otherOptions
-} = {}) {
+}: AssetLoaderOptions = {}) {
   return new AssetLoader({ publicPath, fileSystemPath, ...otherOptions })
 }
 
@@ -38,6 +38,15 @@ describe('anvil-server-asset-loader', () => {
 
   afterEach(() => {
     jest.restoreAllMocks()
+  })
+
+  describe('constructor', () => {
+    it('uses the supplied manifest instead of looking it up', () => {
+      const manifest = { foo: 'bar' }
+      const loader = createAssetLoader({ manifest })
+      const result = loader.getHashedAsset('foo')
+      expect(result).toBe(manifest.foo)
+    })
   })
 
   describe('.getHashedAsset()', () => {

--- a/packages/anvil-server-asset-loader/src/index.ts
+++ b/packages/anvil-server-asset-loader/src/index.ts
@@ -25,6 +25,11 @@ export interface AssetLoaderOptions {
    * @default false
    */
   cacheFileContents?: boolean
+
+  /**
+   * The asset manifest
+   */
+  manifest?: { [asset: string]: string }
 }
 
 const defaultOptions: AssetLoaderOptions = {
@@ -40,7 +45,9 @@ class AssetLoader {
 
   constructor(userOptions: AssetLoaderOptions) {
     this.options = { ...defaultOptions, ...userOptions }
-    this.manifest = loadManifest(path.resolve(this.options.fileSystemPath, this.options.manifestFileName))
+    this.manifest =
+      userOptions.manifest ||
+      loadManifest(path.resolve(this.options.fileSystemPath, this.options.manifestFileName))
   }
 
   matchAssets(pattern: string | RegExp | Function): string[] {


### PR DESCRIPTION
- Ensure that the asset loader does not error when an asset is not in the manifest
- Add ability to supply manifest to asset loader (to facilitate easy testing)