### PR TITLE
storybook should inject polyfills according to the module type

### DIFF
--- a/.storybook/.browserslistrc
+++ b/.storybook/.browserslistrc
@@ -1,0 +1,4 @@
+last 2 Chrome versions
+last 2 FF versions
+last 2 Edge versions
+Safari >= 12

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -20,6 +20,11 @@ module.exports = (baseConfig) => {
   const jsRule = baseConfig.module.rules.find((rule) => rule.test.test('.jsx'))
   jsRule.exclude = excludePaths
 
+  // HACK: Instruct Babel to check module type before injecting Core JS polyfills
+  // https://github.com/i-like-robots/broken-webpack-bundle-test-case
+  const babelConfig = jsRule.use.find(({ loader }) => loader === 'babel-loader')
+  babelConfig.options.sourceType = 'unambiguous'
+
   // Add support for TypeScript source code
   // https://storybook.js.org/configurations/typescript-config/
   baseConfig.module.rules.push({


### PR DESCRIPTION
Updates storybook's webpack.config and adds a storybook .browserslistrc file to instruct Babel to check the module type before injecting polyfills. This prevents us from accidentally serving files with a mix of commonJS and ES6 syntax.