### PR TITLE
removes the myFT subnav sign out link

### DIFF
--- a/examples/express-ft-header/server/controllers/home.js
+++ b/examples/express-ft-header/server/controllers/home.js
@@ -5,7 +5,6 @@ const document = require('../lib/document')
 const headerProps = {
   userIsAnonymous: false,
   userIsLoggedIn: true,
-  showSignOut: true,
   data: {}
 }
 

--- a/packages/anvil-ui-ft-header/src/components/crumbtrail/partials.tsx
+++ b/packages/anvil-ui-ft-header/src/components/crumbtrail/partials.tsx
@@ -5,7 +5,6 @@ const IncludeCrumbtrail = (props: THeaderProps) => (
   <Crumbtrail>
     <BreadCrumb breadcrumb={props.data.breadcrumb} />
     <SubSections subsections={props.data.subsections} />
-    {props.showSignOut ? <ShowSignOut /> : null}
   </Crumbtrail>
 )
 
@@ -92,13 +91,5 @@ const SubSections = ({ subsections }) => {
     </ul>
   )
 }
-
-const ShowSignOut = () => (
-  <div className="o-header__subnav-link--right">
-    <a className="o-header__subnav-link" href="/logout" data-trackable="Sign Out">
-      Sign out
-    </a>
-  </div>
-)
 
 export { IncludeCrumbtrail }

--- a/packages/anvil-ui-ft-header/src/index.tsx
+++ b/packages/anvil-ui-ft-header/src/index.tsx
@@ -21,11 +21,10 @@ import { THeaderProps } from './interfaces'
 
 const defaultProps: Partial<THeaderProps> = {
   showUserNav: true,
+  showSubNav: true,
   hideOutboundLinks: false,
   userIsAnonymous: true,
   userIsLoggedIn: false,
-  showSubNav: true,
-  showSignOut: false
 }
 
 function HeaderDefault(props: THeaderProps) {

--- a/packages/anvil-ui-ft-header/src/interfaces.d.ts
+++ b/packages/anvil-ui-ft-header/src/interfaces.d.ts
@@ -5,7 +5,6 @@ export interface THeaderProps {
   userIsLoggedIn?: boolean
   showUserNav?: boolean
   showSubNav?: boolean
-  showSignOut?: boolean
   data: {
     editions: TEditions
     drawer: TItemSubMenu

--- a/packages/anvil-ui-ft-header/src/story-data/storyData.ts
+++ b/packages/anvil-ui-ft-header/src/story-data/storyData.ts
@@ -18,7 +18,6 @@ const data: THeaderProps = {
   userIsAnonymous: false,
   userIsLoggedIn: true,
   showSubNav: true,
-  showSignOut: true,
   data: {
     navbar: navbarUk,
     'navbar-right': navbarRight,

--- a/packages/anvil-ui-ft-header/src/story.tsx
+++ b/packages/anvil-ui-ft-header/src/story.tsx
@@ -10,8 +10,6 @@ import './demos.scss'
 
 // falsey values are empty string because string coercion in storybook
 const toggleUserStateOptions = () => boolean('Enable user nav actions', true)
-// TODO: can we remove this?
-const toggleMyFTSignOutOptions = () => boolean('Show myFT sign out link', false)
 const toggleVariantOptions = () => radios('Choose variant', { simple: 'simple', normal: 'normal' }, 'simple')
 const toggleAnonymous = () => boolean('User is anonymous', true)
 
@@ -21,7 +19,6 @@ storiesOf('FT / Header', module)
     const knobs = {
       showUserNav: toggleUserStateOptions(),
       userIsAnonymous: toggleAnonymous(),
-      showSignOut: toggleMyFTSignOutOptions()
     }
 
     return (


### PR DESCRIPTION
Removes the 'sign out' link from the myFT subnav.

Th link was introduced in March 2018 by the GDPR team after some discussions around how users are sometimes confused about the difference between `myFT` and `account settings`. https://github.com/Financial-Times/next-myft-page/pull/1673

Looking at the code today it now seems like a strange addition which introduces inconsistency between the myFT and content pages.

⚠️ This change will need to be communicated to Customer Services before the myFT page is migrated from n-ui to Anvil as customers may notice the link disappearing. This should be highlighted in our migration guide. 

Glynn Phillips, James Webb and Simon Coxon have each been involved in this decision. 

<img width="430" alt="Screenshot 2019-03-15 at 16 54 40" src="https://user-images.githubusercontent.com/17549437/54448193-0bed6900-4743-11e9-9bb9-b45c1e0ec452.png">
