### PR TITLE
Disable `ssr-with-hydration` test in the ci

### DIFF
--- a/examples/ssr-with-hydration/package.json
+++ b/examples/ssr-with-hydration/package.json
@@ -8,7 +8,7 @@
     "build": "anvil build -d",
     "start": "node start.js",
     "start:dev": "nodemon start.js --ext js",
-    "test": "../../node_modules/.bin/jest",
+    "test:app": "../../node_modules/.bin/jest",
     "pretest": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
This PR ensures that the `ssr-with-hydration` test does not run in the CI environment