### PR TITLE
implement disableSticky as a header option

### DIFF
--- a/packages/anvil-ui-ft-header/README.md
+++ b/packages/anvil-ui-ft-header/README.md
@@ -52,6 +52,7 @@ All variants with the exception of `LogoOnly` require a props object to be passe
 | userIsLoggedIn    | boolean | true     | false    | Marks a user as logged in - set in n-express                                                                      |
 | showUserNav       | boolean | true     | true     | Show user navigation options - `Portfolio` and `Account Settings` or `Sign in` and `Subscribe`                    |
 | showSubNav        | boolean | true     | true     | Show the crumbtrail element or the myFT subnav element                                                            |
+| disableSticky     | boolean | true     | false    | Prevents the HeaderSticky component from rendering                                                                |
 | data              | object  | false    |          | Navigation data for rendering the header components - takes the shape of [Data Props](#data-props)                |
 
 

--- a/packages/anvil-ui-ft-header/src/__stories__/story-data/index.ts
+++ b/packages/anvil-ui-ft-header/src/__stories__/story-data/index.ts
@@ -19,6 +19,7 @@ const data: THeaderProps = {
   userIsAnonymous: false,
   userIsLoggedIn: true,
   showSubNav: true,
+  disableSticky: true,
   data: {
     navbar: navbarUk,
     'navbar-right': navbarRight,

--- a/packages/anvil-ui-ft-header/src/__stories__/story.tsx
+++ b/packages/anvil-ui-ft-header/src/__stories__/story.tsx
@@ -8,10 +8,10 @@ import storyData from './story-data'
 import '../../styles.scss'
 import './demos.scss'
 
-// falsey values are empty string because string coercion in storybook
 const toggleUserStateOptions = () => boolean('Enable user nav actions', true)
 const toggleVariantOptions = () => radios('Choose variant', { simple: 'simple', normal: 'normal' }, 'simple')
 const toggleAnonymous = () => boolean('User is anonymous', true)
+const toggleDisableSticky = () => boolean('Disable sticky header', false)
 
 storiesOf('FT / Header', module)
   .addDecorator(withKnobs)
@@ -43,7 +43,8 @@ storiesOf('FT / Header', module)
   .add('Sticky header', () => {
     const knobs = {
       showUserNav: toggleUserStateOptions(),
-      userIsAnonymous: toggleAnonymous()
+      userIsAnonymous: toggleAnonymous(),
+      disableSticky: toggleDisableSticky()
     }
 
     return (

--- a/packages/anvil-ui-ft-header/src/components/sticky/partials.tsx
+++ b/packages/anvil-ui-ft-header/src/components/sticky/partials.tsx
@@ -1,4 +1,4 @@
-/* WARN: This file looks similar to '../top/partials */
+/* WARN: This file looks similar to ../top/partials */
 /* This is the sticky header variant */
 
 import React from 'react'

--- a/packages/anvil-ui-ft-header/src/index.tsx
+++ b/packages/anvil-ui-ft-header/src/index.tsx
@@ -25,7 +25,8 @@ const defaultProps: Partial<THeaderProps> = {
   showSubNav: true,
   hideOutboundLinks: false,
   userIsAnonymous: true,
-  userIsLoggedIn: false
+  userIsLoggedIn: false,
+  disableSticky: false
 }
 
 function HeaderDefault(props: THeaderProps) {
@@ -60,7 +61,7 @@ function Drawer(props: THeaderProps) {
 Drawer.defaultProps = defaultProps
 
 function HeaderSticky(props: THeaderProps) {
-  return (
+  return props.disableSticky ? null : (
     <StickyHeader {...props}>
       <TopWrapperSticky>
         <TopColumnLeftSticky context="sticky" />

--- a/packages/anvil-ui-ft-header/src/interfaces.d.ts
+++ b/packages/anvil-ui-ft-header/src/interfaces.d.ts
@@ -5,6 +5,7 @@ export interface THeaderProps {
   userIsLoggedIn?: boolean
   showUserNav?: boolean
   showSubNav?: boolean
+  disableSticky?: boolean
   data: {
     editions: TEditions
     drawer: TItemSubMenu


### PR DESCRIPTION
Implements the `disableSticky` header option in anvil-ui-ft-header for n-ui parity. 

Current implementation: https://github.com/Financial-Times/n-ui/blob/7a4e10428f1eb3c0dbcfa7eeb59a6a17f5c3f7e4/components/n-ui/header/template.html#L40-L48