### PR TITLE
Upgrade to typescript@3.4 and enable incremental builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "style-loader": "^0.23.1",
     "supertest": "^3.4.2",
     "ts-jest": "^24.0.0",
-    "typescript": "^3.3.3"
+    "typescript": "^3.4.1"
   },
   "engines": {
     "node": ">= 10.13.0"

--- a/packages/anvil-cli/package.json
+++ b/packages/anvil-cli/package.json
@@ -14,7 +14,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-middleware-assets/package.json
+++ b/packages/anvil-middleware-assets/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-middleware-ft-ab-state/package.json
+++ b/packages/anvil-middleware-ft-ab-state/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-middleware-ft-edition/package.json
+++ b/packages/anvil-middleware-ft-edition/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-middleware-ft-navigation/package.json
+++ b/packages/anvil-middleware-ft-navigation/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-pluggable/package.json
+++ b/packages/anvil-pluggable/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-plugin-bower-resolve/package.json
+++ b/packages/anvil-plugin-bower-resolve/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-plugin-code-splitting/package.json
+++ b/packages/anvil-plugin-code-splitting/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs --module commonjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-plugin-css/package.json
+++ b/packages/anvil-plugin-css/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-plugin-esnext/package.json
+++ b/packages/anvil-plugin-esnext/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-plugin-ft-js-bundle-splitting/package.json
+++ b/packages/anvil-plugin-ft-js-bundle-splitting/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs --module commonjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-plugin-ft-js/package.json
+++ b/packages/anvil-plugin-ft-js/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs --module commonjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-plugin-sass/package.json
+++ b/packages/anvil-plugin-sass/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-server-asset-loader/package.json
+++ b/packages/anvil-server-asset-loader/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-server-ft-handlebars/package.json
+++ b/packages/anvil-server-ft-handlebars/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-server-ft-navigation/package.json
+++ b/packages/anvil-server-ft-navigation/package.json
@@ -12,7 +12,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-server-ft-preset/package.json
+++ b/packages/anvil-server-ft-preset/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-server-jsx-renderer/package.json
+++ b/packages/anvil-server-jsx-renderer/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs --module commonjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-server-react-renderer/package.json
+++ b/packages/anvil-server-react-renderer/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-server-resource-hints/package.json
+++ b/packages/anvil-server-resource-hints/package.json
@@ -11,7 +11,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-ui-bootstrap/package.json
+++ b/packages/anvil-ui-bootstrap/package.json
@@ -12,7 +12,7 @@
     "clean:node_modules": "rm -rf node_modules",
     "clean:install": "npm run clean && npm i",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs --module commonjs --target es5",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-ui-ft-flags/package.json
+++ b/packages/anvil-ui-ft-flags/package.json
@@ -14,7 +14,7 @@
     "clean:install": "npm run clean && npm i",
     "build:node": "npm run tsc -- --outDir ./dist/node",
     "build:browser": "npm run tsc -- --outDir ./dist/browser --module es2015 --target ES5",
-    "build": "npm run clean:dist && npm run build:node && npm run build:browser",
+    "build": "npm run build:node && npm run build:browser",
     "dev": "npm run clean:dist && npm run build -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-ui-ft-footer/package.json
+++ b/packages/anvil-ui-ft-footer/package.json
@@ -14,7 +14,7 @@
     "clean:node_modules": "rm -rf node_modules",
     "clean:install": "npm run clean && npm i",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs --module commonjs --target es5",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-ui-ft-header/package.json
+++ b/packages/anvil-ui-ft-header/package.json
@@ -13,7 +13,7 @@
     "clean:dist": "rm -rf dist",
     "clean:node_modules": "rm -rf node_modules",
     "clean:install": "npm run clean && npm i",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs --module commonjs --target es5",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },

--- a/packages/anvil-ui-ft-layout/package.json
+++ b/packages/anvil-ui-ft-layout/package.json
@@ -14,7 +14,7 @@
     "clean:install": "npm run clean && npm i",
     "build:node": "npm run tsc -- --outDir ./dist/node --module commonjs --target es5",
     "build:browser": "npm run tsc -- --outDir ./dist/browser --module esNext --target es5",
-    "build": "npm run clean:dist && npm run build:node && npm run build:browser",
+    "build": "npm run build:node && npm run build:browser",
     "dev": "npm run build -- --watch"
   },
   "keywords": [],

--- a/packages/anvil-ui-ft-shell/package.json
+++ b/packages/anvil-ui-ft-shell/package.json
@@ -12,7 +12,7 @@
     "clean:node_modules": "rm -rf node_modules",
     "clean:install": "npm run clean && npm i",
     "build:cjs": "npm run tsc -- --outDir ./dist/cjs",
-    "build": "npm run clean:dist && npm run build:cjs",
+    "build": "npm run build:cjs",
     "dev": "npm run clean:dist && npm run build:cjs -- --watch"
   },
   "keywords": [],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
+    "incremental": true,                      /* Enable incremental builds */
     "target": "es2018",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["dom", "es2018"],                 /* Specify library files to be included in the compilation. */


### PR DESCRIPTION
This PR upgrades to `typescript@3.4` and enables incremental builds (as per #234). Note that in order to enable incremental builds, the `dist` folder is no longer being cleaned (i.e., deleted) prior to building. Something to keep in mind as we try this out.

closes #234