### PR TITLE
reinstate n-ui-foundations styles for search typeahead

### DIFF
--- a/packages/anvil-ui-ft-header/styles.scss
+++ b/packages/anvil-ui-ft-header/styles.scss
@@ -2,5 +2,6 @@ $o-header-is-silent: false;
 @import "o-header";
 @import "src/header";
 @import "n-topic-search";
+@import "n-ui-foundations";
 
 @include nTopicSearch;


### PR DESCRIPTION
I deleted this line yesterday thinking it was unimportant but it turns out we need it for search typeahead.