### PR TITLE
move ariaCurrent into the correct scope

### DIFF
--- a/packages/anvil-ui-ft-header/src/components/sub-navigation/partials.tsx
+++ b/packages/anvil-ui-ft-header/src/components/sub-navigation/partials.tsx
@@ -68,7 +68,6 @@ const BreadCrumb = ({ breadcrumb }) => {
 }
 
 const SubSections = ({ subsections }) => {
-  const ariaCurrent = subsections && subsections.selected ? { 'aria-current': true } : null
   return (
     <ul
       className="o-header__subnav-list o-header__subnav-list--subsections"
@@ -77,6 +76,7 @@ const SubSections = ({ subsections }) => {
       {subsections.map((item, index) => {
         const id = item.id ? `data-id=subnav-${item.id}` : null
         const selected = item.selected ? 'o-header__subnav-link--highlight' : null
+        const ariaCurrent = item.selected ? { 'aria-current': true } : null
         return (
           <li className="o-header__subnav-item" {...id} key={`item-${index}`}>
             <a


### PR DESCRIPTION
Addresses final point in https://github.com/Financial-Times/anvil/issues/209
Moves the `ariaCurrent` attribute into the correct scope in the `SubSections` component.