### PR TITLE
Header integrates StickyHeader by default

### DIFF
--- a/packages/anvil-ui-ft-header/src/index.tsx
+++ b/packages/anvil-ui-ft-header/src/index.tsx
@@ -35,10 +35,11 @@ const defaultProps: Partial<THeaderProps> = {
   disableSticky: false
 }
 
-function Header(props: THeaderProps) {
+function MainHeader(props: THeaderProps) {
   const navItems = props.data.navbar.items
   const includeUserActionsNav = props.showUserNav && props.userIsAnonymous ? UserActionsNav(props) : null
   const includeSubNavigation = props.data.breadcrumb && props.data.subsections ? SubNavigation(props) : null
+
   return (
     <HeaderWrapper {...props}>
       {includeUserActionsNav}
@@ -58,13 +59,7 @@ function Header(props: THeaderProps) {
   )
 }
 
-Header.defaultProps = defaultProps
-
-function Drawer(props: THeaderProps) {
-  return <IncludeDrawer {...props} />
-}
-
-Drawer.defaultProps = defaultProps
+MainHeader.defaultProps = defaultProps
 
 function StickyHeader(props: THeaderProps) {
   return props.disableSticky ? null : (
@@ -81,6 +76,21 @@ function StickyHeader(props: THeaderProps) {
 
 StickyHeader.defaultProps = defaultProps
 
+/**
+ *
+ * @param props
+ */
+function Header(props: THeaderProps) {
+  return (
+    <React.Fragment>
+      <StickyHeader {...props} />
+      <MainHeader {...props} />
+    </React.Fragment>
+  )
+}
+
+Header.defaultProps = defaultProps
+
 function LogoOnly(props?) {
   return (
     <HeaderWrapper {...props}>
@@ -93,4 +103,10 @@ function LogoOnly(props?) {
 
 LogoOnly.defaultProps = defaultProps
 
-export { THeaderProps, Header, Drawer, StickyHeader, LogoOnly }
+function Drawer(props: THeaderProps) {
+  return <IncludeDrawer {...props} />
+}
+
+Drawer.defaultProps = defaultProps
+
+export { THeaderProps, Header, MainHeader, StickyHeader, LogoOnly, Drawer }

--- a/packages/anvil-ui-ft-layout/src/__stories__/story.tsx
+++ b/packages/anvil-ui-ft-layout/src/__stories__/story.tsx
@@ -30,7 +30,7 @@ storiesOf('FT / Layout', module)
       <OnReady callback={initUiComponents}>
         <Layout props={headerProps}>
           <main className="demo">
-            <p className="demo__message">Defaults: only passing data</p>
+            <p className="demo__message demo__message--scroll">Defaults: only passing data</p>
           </main>
         </Layout>
       </OnReady>
@@ -69,7 +69,7 @@ storiesOf('FT / Layout', module)
       <OnReady callback={initUiComponents}>
         <Layout props={props} footer={false}>
           <main className="demo">
-            <p className="demo__message">No footer</p>
+            <p className="demo__message demo__message--scroll">No footer</p>
           </main>
         </Layout>
       </OnReady>
@@ -85,7 +85,7 @@ storiesOf('FT / Layout', module)
           headerAfter={<Extra>Header after</Extra>}
           footerAfter={<Extra>Footer after</Extra>}>
           <main className="demo">
-            <p className="demo__message">Custom content slots</p>
+            <p className="demo__message demo__message--scroll">Custom content slots</p>
           </main>
         </Layout>
       </OnReady>

--- a/packages/anvil-ui-ft-layout/src/layout.tsx
+++ b/packages/anvil-ui-ft-layout/src/layout.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
 import {
-  HeaderDefault,
-  HeaderSticky,
+  Header,
+  StickyHeader,
   LogoOnly,
   Drawer,
   THeaderProps
@@ -10,8 +10,8 @@ import {
 import { Footer, LegalFooter } from '@financial-times/anvil-ui-ft-footer/component'
 
 export enum AnvilHeader {
-  Standard = HeaderDefault,
-  Sticky = HeaderSticky,
+  Standard = Header,
+  Sticky = StickyHeader,
   Logo = LogoOnly
 }
 


### PR DESCRIPTION
It's hard to imagine a scenario in which the header would not need a sticky feature, so this PR is intended to act as a discussion point on whether it shouldn't simply be integrated.

NOTE: because this builds off the as-yet unmerged #243, the significant changes are the ones in this commit: https://github.com/Financial-Times/anvil/pull/260/commits/c73ac5d2d56f3b421b3033eafaf6ebbd599c3c3d