### PR TITLE
generates a separate webpack runtime bundle

### DIFF
--- a/packages/anvil-plugin-ft-js-bundle-splitting/src/plugin.ts
+++ b/packages/anvil-plugin-ft-js-bundle-splitting/src/plugin.ts
@@ -41,6 +41,11 @@ export function plugin() {
   function createSharedBundleSplittingConfig(name: string, packagesToInclude: string[]) {
     return {
       optimization: {
+        // Creates a separate bundle for webpack runtime.
+        // Specifying the name prevents multiple runtime bundles from being created.
+        runtimeChunk: {
+          name: 'runtime'
+        },
         splitChunks: {
           cacheGroups: {
             [name]: {


### PR DESCRIPTION
Closes https://github.com/Financial-Times/anvil/issues/274

Adds a `runtimeChunk` option so that the webpack runtime code is added to a separate bundle and not included in the bundles generated for each entrypoint. 

Including the `name` property prevents duplicate webpack runtime bundles from being generated for each entrypoint.