### PR TITLE
updates aria-current util to use 'page' as the value

### DIFF
--- a/packages/anvil-ui-ft-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/anvil-ui-ft-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -142,8 +142,8 @@ exports[`anvil-ui-ft-header/src/components/Drawer renders as a logged in user 1`
             className="o-header__drawer-menu-toggle-wrapper"
           >
             <a
-              aria-current={true}
-              aria-label="Current page World"
+              aria-current="page"
+              aria-label="World current page"
               className="o-header__drawer-menu-link o-header__drawer-menu-link--selected o-header__drawer-menu-link--parent"
               data-trackable="World"
               href="/world"
@@ -1414,8 +1414,8 @@ exports[`anvil-ui-ft-header/src/components/Drawer renders as an anonymous user 1
             className="o-header__drawer-menu-toggle-wrapper"
           >
             <a
-              aria-current={true}
-              aria-label="Current page World"
+              aria-current="page"
+              aria-label="World current page"
               className="o-header__drawer-menu-link o-header__drawer-menu-link--selected o-header__drawer-menu-link--parent"
               data-trackable="World"
               href="/world"

--- a/packages/anvil-ui-ft-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/anvil-ui-ft-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -181,8 +181,8 @@ exports[`anvil-ui-ft-header/src/components/MainHeader renders as a logged in use
           className="o-header__nav-item"
         >
           <a
-            aria-current={true}
-            aria-label="Current page World"
+            aria-current="page"
+            aria-label="World current page"
             className="o-header__nav-link o-header__nav-link--primary"
             data-trackable="World"
             href="/world"
@@ -1758,8 +1758,8 @@ exports[`anvil-ui-ft-header/src/components/MainHeader renders as a logged in use
                 className="o-header__subnav-item"
               >
                 <a
-                  aria-current={true}
-                  aria-label="Current page UK"
+                  aria-current="page"
+                  aria-label="UK current page"
                   className="o-header__subnav-link o-header__subnav-link--highlight"
                   data-trackable="UK"
                   href="/world/uk"
@@ -2010,8 +2010,8 @@ exports[`anvil-ui-ft-header/src/components/MainHeader renders as an anonymous us
           className="o-header__nav-item"
         >
           <a
-            aria-current={true}
-            aria-label="Current page World"
+            aria-current="page"
+            aria-label="World current page"
             className="o-header__nav-link o-header__nav-link--primary"
             data-trackable="World"
             href="/world"
@@ -3587,8 +3587,8 @@ exports[`anvil-ui-ft-header/src/components/MainHeader renders as an anonymous us
                 className="o-header__subnav-item"
               >
                 <a
-                  aria-current={true}
-                  aria-label="Current page UK"
+                  aria-current="page"
+                  aria-label="UK current page"
                   className="o-header__subnav-link o-header__subnav-link--highlight"
                   data-trackable="UK"
                   href="/world/uk"

--- a/packages/anvil-ui-ft-header/src/utils.ts
+++ b/packages/anvil-ui-ft-header/src/utils.ts
@@ -1,3 +1,5 @@
-export const ariaSelected = (item) => {
-  return item.selected ? { 'aria-label': `Current page ${item.label}`, 'aria-current': true } : null
+import { HTMLAttributes } from 'react'
+
+export const ariaSelected = (item): HTMLAttributes<HTMLElement> | null => {
+  return item.selected ? { 'aria-label': `${item.label} current page`, 'aria-current': 'page' } : null
 }


### PR DESCRIPTION
Updates the ariaSelected util to set `aria-current` to `'page'` instead of `true`. The change more clearly indicates to screen readers that the current link is inside a navigation block.