### PR TITLE
add the nodeList forEach polyfill

### DIFF
--- a/packages/anvil-ui-ft-polyfills/src/polyfillServiceURLs.ts
+++ b/packages/anvil-ui-ft-polyfills/src/polyfillServiceURLs.ts
@@ -3,7 +3,13 @@ import querystring from 'querystring'
 // Please see https://polyfill.io/v3/url-builder/ for information about which
 // features are available and how they may be used.
 
-export const core = formatURL(['default', 'es5', 'es2015', 'HTMLPictureElement'])
+export const core = formatURL([
+  'default',
+  'es5',
+  'es2015',
+  'HTMLPictureElement',
+  'NodeList.prototype.forEach'
+])
 
 export const enhanced = formatURL([
   // What Andrew Betts decided is "default"
@@ -19,7 +25,8 @@ export const enhanced = formatURL([
   'EventSource',
   'fetch',
   'HTMLPictureElement',
-  'IntersectionObserver'
+  'IntersectionObserver',
+  'NodeList.prototype.forEach'
 ])
 
 function formatURL(features: string[]): string {


### PR DESCRIPTION
Adds the `NodeList.prototype.forEach` polyfill to our lists of core an enhanced polyfills to support the use of `document.querySelectorAll()` which returns a nodeList of elements. 