### PR TITLE
apply className changes to the rootElement consistently

### DIFF
--- a/packages/anvil-ui-ft-layout/src/font-loading.ts
+++ b/packages/anvil-ui-ft-layout/src/font-loading.ts
@@ -6,10 +6,7 @@ function loadCustomFonts() {
   if (/(^|\s)o-typography-fonts-loaded=1(;|$)/.test(document.cookie)) {
     var fontLabels = ['sans', 'sansBold', 'display', 'displayBold']
     for (var i = 0; i < fontLabels.length; i++) {
-      rootElement.className = document.documentElement.className.replace(
-        'o-typography--loading-' + fontLabels[i],
-        ''
-      )
+      rootElement.className = rootElement.className.replace('o-typography--loading-' + fontLabels[i], '')
     }
   }
 }


### PR DESCRIPTION
Fixes a typo which caused the rootElement, `<div className="n-layout">` to be removed from the DOM and caused a visual bug involving additional whitespace in the app. 

<img width="1266" alt="Screenshot 2019-06-04 at 12 16 45" src="https://user-images.githubusercontent.com/17549437/58884272-f3ed0c00-86d7-11e9-8802-ecf37168093c.png">
