### PR TITLE
stop excluding node_modules in the babel-loader ruleset

### DIFF
--- a/packages/anvil-cli/src/operations/getWebpackConfig.ts
+++ b/packages/anvil-cli/src/operations/getWebpackConfig.ts
@@ -32,8 +32,8 @@ export function getWebpackConfig({ options, config, publish, cli }: CliContext) 
       rules: [
         publish(hooks.WEBPACK_JS_RULE, {
           test: [/\.(js|jsx|mjs)$/],
-          // NOTE: Do not exclude bower_components directory because Origami components
-          // installed with Bower are ES6/source code
+          // NOTE: Do not exclude bower_components or node_modules directories
+          // https://github.com/Financial-Times/anvil/issues/366
           exclude: [],
           use: {
             loader: require.resolve('babel-loader'),


### PR DESCRIPTION
Updates our shared webpack config to transpile node_modules. 

Earlier implementations transpiled source code and bower_components but excluded node_modules as it was assumed that node_modules would already be ES5 / browser-compatible. This is no longer a safe assumption so we will now pass all modules to the babel plugin for transpilation. 

The performance impact of this change is negligible and the uniform approach removes the need to maintain a manual list of dependencies that will need to be included in the transpile step.

Closes https://github.com/Financial-Times/anvil/issues/366