### PR TITLE
add the document.currentScript polyfill

### DIFF
--- a/packages/anvil-ui-ft-polyfills/src/polyfillServiceURLs.ts
+++ b/packages/anvil-ui-ft-polyfills/src/polyfillServiceURLs.ts
@@ -8,7 +8,8 @@ export const core = formatURL([
   'es5',
   'es2015',
   'HTMLPictureElement',
-  'NodeList.prototype.forEach'
+  'NodeList.prototype.forEach',
+  'document.currentScript'
 ])
 
 export const enhanced = formatURL([
@@ -26,7 +27,8 @@ export const enhanced = formatURL([
   'fetch',
   'HTMLPictureElement',
   'IntersectionObserver',
-  'NodeList.prototype.forEach'
+  'NodeList.prototype.forEach',
+  'document.currentScript'
 ])
 
 function formatURL(features: string[]): string {


### PR DESCRIPTION
Adds the document.currentScript polyfill to our core and enhanced polyfills list as we're now using it in the anvil-ui bootstrap module but it is not supported by IE. 

https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript#Browser_compatibility