### PR TITLE
Bugfix ensure app runs in internet explorer

### DIFF
--- a/packages/anvil-ui-bootstrap/lib/bootstrap.js
+++ b/packages/anvil-ui-bootstrap/lib/bootstrap.js
@@ -3,7 +3,7 @@
   var isEnhanced = isEnhancedBrowser()
   var scriptsConfig = getScriptsConfig()
   var scriptsToLoad = []
-  var currentScript = document.currentScript
+  var currentScript = document.scripts[document.scripts.length - 1]
 
   doc.className = doc.className.replace('no-js', 'js')
 

--- a/packages/anvil-ui-ft-polyfills/src/polyfillServiceURLs.ts
+++ b/packages/anvil-ui-ft-polyfills/src/polyfillServiceURLs.ts
@@ -8,8 +8,7 @@ export const core = formatURL([
   'es5',
   'es2015',
   'HTMLPictureElement',
-  'NodeList.prototype.forEach',
-  'document.currentScript'
+  'NodeList.prototype.forEach'
 ])
 
 export const enhanced = formatURL([
@@ -27,8 +26,7 @@ export const enhanced = formatURL([
   'fetch',
   'HTMLPictureElement',
   'IntersectionObserver',
-  'NodeList.prototype.forEach',
-  'document.currentScript'
+  'NodeList.prototype.forEach'
 ])
 
 function formatURL(features: string[]): string {


### PR DESCRIPTION
Replaces the document.currentScript method with scripts lookup as the former is not supported in internet explorer. The bootstrap code runs before our polyfill script meaning we can't take advantage of polyfills to solve this one.

https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript#Browser_compatibility
