### PR TITLE
adds a data-o-component attribute to the layout rootElement

### DIFF
--- a/packages/anvil-ui-ft-layout/src/components/Layout.tsx
+++ b/packages/anvil-ui-ft-layout/src/components/Layout.tsx
@@ -68,7 +68,7 @@ export function Layout({
   const Preset = getLayoutPreset(header, footer)
 
   return (
-    <div className="n-layout o-typography--loading-sans o-typography--loading-sansBold o-typography--loading-display o-typography--loading-displayBold">
+    <div className="n-layout o-typography--loading-sans o-typography--loading-sansBold o-typography--loading-display o-typography--loading-displayBold" data-o-component="o-typography">
       <EnhanceFonts />
       <a
         data-trackable="a11y-skip-to-help"


### PR DESCRIPTION
oTypography expects a data-o-component attribute to be set on the rootElement that we initialise it on. We'll need to include this attribute before we can use our custom fonts in production.

https://github.com/Financial-Times/o-typography/blob/319e21be1cde31b163700cd29090c549006c70fb/src/js/typography.js#L144