### PR TITLE
Storybook on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           command: npm run test:examples
       - run:
           name: Run storybook
-          command: npm run storybook
+          command: npm run storybook:ci
 
   publish:
     <<: *container_config_node

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "prettier": "prettier --write '**/*.{ts,tsx,js,jsx,json}'",
     "script:update": "node scripts/update-dep",
     "storybook": "npm run storybook:generate && npm run storybook:start",
+    "storybook:ci": "npm run storybook:generate && npm run storybook:start:ci",
+    "storybook:generate": "node ./.storybook/scripts/generateConfig",
     "storybook:start": "start-storybook -p 9001 -c .storybook",
-    "storybook:generate": "node ./.storybook/scripts/generateConfig"
+    "storybook:start:ci": "start-storybook -c .storybook --ci --smoke-test"
   },
   "lint-staged": {
     "**/*.{ts,tsx,js,jsx}": [


### PR DESCRIPTION
Adds storybook to the test step on CI. 

The --ci flag tells storybook not to open in a browser 
The -smoke-test flag tells storybook to exit after a successful start

Storybook CLI options: https://storybook.js.org/docs/configurations/cli-options/#for-start-storybook

Closes https://github.com/Financial-Times/anvil/issues/405