### PR TITLE
Package rename part 12 (config types)

### DIFF
--- a/packages/dotcom-page-kit-cli/src/entities/CliContext.ts
+++ b/packages/dotcom-page-kit-cli/src/entities/CliContext.ts
@@ -1,10 +1,10 @@
 import { CliPrompt } from './CliPrompt'
 import { AnyObject } from '@financial-times/dotcom-types-generic'
-import { AnvilConfig } from '../types/AnvilConfig'
+import { PageKitConfig } from '../types/PageKitConfig'
 import { Pluggable, Plugin } from '@financial-times/dotcom-page-kit-pluggable'
 
 interface ConstructorArgs {
-  config: AnvilConfig
+  config: PageKitConfig
   plugins: Plugin[]
   prompt?: CliPrompt
   workingDir: string
@@ -14,7 +14,7 @@ export class CliContext extends Pluggable {
   cli = this
   args: AnyObject = {}
   prompt: CliPrompt
-  config: AnvilConfig
+  config: PageKitConfig
   options: AnyObject = {}
   workingDir: string
 
@@ -27,6 +27,6 @@ export class CliContext extends Pluggable {
   }
 }
 
-function normaliseConfig(config: Partial<AnvilConfig> = {}) {
+function normaliseConfig(config: Partial<PageKitConfig> = {}) {
   return { plugins: [], settings: {}, ...config }
 }

--- a/packages/dotcom-page-kit-cli/src/operations/executeCli.ts
+++ b/packages/dotcom-page-kit-cli/src/operations/executeCli.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { CliPrompt } from '../entities/CliPrompt'
 import { CliContext } from '../entities/CliContext'
-import { AnvilConfig } from '../types/AnvilConfig'
+import { PageKitConfig } from '../types/PageKitConfig'
 import { getCommanderProgram } from './getCommanderProgram'
 
 interface Args {
@@ -13,7 +13,7 @@ export async function executeCli({ argv, workingDir }: Args) {
   const prompt = new CliPrompt()
 
   try {
-    const config: AnvilConfig = getWorkingDirConfig(workingDir)
+    const config: PageKitConfig = getWorkingDirConfig(workingDir)
     const plugins = config.plugins
     const cli = new CliContext({ prompt, config, workingDir, plugins })
 

--- a/packages/dotcom-page-kit-cli/src/types/PageKitConfig.d.ts
+++ b/packages/dotcom-page-kit-cli/src/types/PageKitConfig.d.ts
@@ -1,6 +1,6 @@
 import { Plugin } from '@financial-times/dotcom-page-kit-pluggable'
 
-export interface AnvilConfig {
+export interface PageKitConfig {
   plugins: Plugin[]
   settings?: {
     build?: {


### PR DESCRIPTION
As per #460 this PR renames the AnvilConfig type declaration to PageKitConfig and updates references to the former throughout the project.