### PR TITLE
Test the tagged release CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
           command: npx athloi version ${CIRCLE_TAG}
       - run:
           name: NPM publish
-          command: npx athloi publish -- --access=public
+          command: npx athloi publish -- --access=public --dry-run
 
 workflows:
 


### PR DESCRIPTION
A PR to test the publish workflow of the Page Kit CI. The `--dry-run` flag has been added to the `publish -run` step to prevent publishing to NPM when a tagged release of this branch is merged.

https://docs.npmjs.com/cli/publish#description