### PR TITLE
Add filter to only bump versions of dotcom-* packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ${HOME}/.npmrc
       - run:
           name: Bump version
-          command: npx athloi version ${CIRCLE_TAG}
+          command: npx athloi version ${CIRCLE_TAG} --filter "dotcom-*"
       - run:
           name: NPM publish
           command: npx athloi publish -- --access=public


### PR DESCRIPTION
Adds a filter to prevent the publish > bump version step from applying version number changes to example packages.