### PR TITLE
Add a rule to npmignore to prevent testfiles from being published

### DIFF
--- a/packages/dotcom-build-bower-resolve/.npmignore
+++ b/packages/dotcom-build-bower-resolve/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-build-code-splitting/.npmignore
+++ b/packages/dotcom-build-code-splitting/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-build-css/.npmignore
+++ b/packages/dotcom-build-css/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-build-esnext/.npmignore
+++ b/packages/dotcom-build-esnext/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-build-js/.npmignore
+++ b/packages/dotcom-build-js/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-build-sass/.npmignore
+++ b/packages/dotcom-build-sass/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-middleware-app-context/.npmignore
+++ b/packages/dotcom-middleware-app-context/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-middleware-assets/.npmignore
+++ b/packages/dotcom-middleware-assets/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-middleware-navigation/.npmignore
+++ b/packages/dotcom-middleware-navigation/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-page-kit-cli/.npmignore
+++ b/packages/dotcom-page-kit-cli/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-page-kit-pluggable/.npmignore
+++ b/packages/dotcom-page-kit-pluggable/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-server-app-context/.npmignore
+++ b/packages/dotcom-server-app-context/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-server-asset-loader/.npmignore
+++ b/packages/dotcom-server-asset-loader/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-server-handlebars/.npmignore
+++ b/packages/dotcom-server-handlebars/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-server-navigation/.npmignore
+++ b/packages/dotcom-server-navigation/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-server-react-jsx/.npmignore
+++ b/packages/dotcom-server-react-jsx/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-server-resource-hints/.npmignore
+++ b/packages/dotcom-server-resource-hints/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-types-generic/.npmignore
+++ b/packages/dotcom-types-generic/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-types-navigation/.npmignore
+++ b/packages/dotcom-types-navigation/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-ui-app-context/.npmignore
+++ b/packages/dotcom-ui-app-context/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-ui-bootstrap/.npmignore
+++ b/packages/dotcom-ui-bootstrap/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-ui-flags/.npmignore
+++ b/packages/dotcom-ui-flags/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-ui-footer/.npmignore
+++ b/packages/dotcom-ui-footer/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-ui-header/.npmignore
+++ b/packages/dotcom-ui-header/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-ui-layout/.npmignore
+++ b/packages/dotcom-ui-layout/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-ui-polyfill-service/.npmignore
+++ b/packages/dotcom-ui-polyfill-service/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo

--- a/packages/dotcom-ui-shell/.npmignore
+++ b/packages/dotcom-ui-shell/.npmignore
@@ -1,5 +1,6 @@
 **/__fixtures__/**
 **/__stories__/**
 **/__test__/**
+**/__tests__/**
 tsconfig.json
 *.tsbuildinfo


### PR DESCRIPTION
Adds a safeguard to npmignore to prevent any files inside an `__tests__` directory from being published to npm. By convention test directories in this project are named `__test__`. 