### PR TITLE
Ensure sticky header always has the --simple style variant

### DIFF
--- a/packages/dotcom-ui-header/src/components/sticky/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sticky/partials.tsx
@@ -7,7 +7,7 @@ import { THeaderProps } from '../../interfaces'
 
 const StickyHeaderWrapper = (props: THeaderProps & { children: React.ReactNode }) => (
   <header
-    className={`o-header o-header--${props.variant || 'simple'} o-header--sticky o--if-js`}
+    className={`o-header o-header--simple o-header--sticky o--if-js`}
     data-o-component="o-header"
     data-o-header--sticky
     aria-hidden="true">


### PR DESCRIPTION
A 'large-logo' variant can be passed to the header element to show the masthead-style header. This should not be consumed by the sticky header which should always have the default `--simple` style. 