### PR TITLE
Adds a webpack bail rule to dotcom-page-kit-cli

### DIFF
--- a/packages/dotcom-page-kit-cli/src/operations/getWebpackConfig.ts
+++ b/packages/dotcom-page-kit-cli/src/operations/getWebpackConfig.ts
@@ -43,6 +43,7 @@ export function getWebpackConfig({ options, config, publish, cli }: CliContext) 
       ]
     },
     plugins: [new CleanWebpackPlugin(cleanWebpackPluginOptions), new ManifestPlugin(manifestPluginOptions)],
-    devtool: isDevMode ? 'cheap-module-eval-source-map' : 'source-map'
+    devtool: isDevMode ? 'cheap-module-eval-source-map' : 'source-map',
+    bail: isDevMode ? false : true
   })
 }


### PR DESCRIPTION
Adds a bail rule to the cli webpack config so that webpack failures will cause the build step to fail in production mode.

https://webpack.js.org/configuration/other-options/#bail