### PR TITLE
Extend example copy in the kitchen sink app

### DIFF
--- a/examples/kitchen-sink/client/main.scss
+++ b/examples/kitchen-sink/client/main.scss
@@ -11,3 +11,7 @@
   @include oTypographySans($scale: 7);
 }
 
+.project-aim {
+  @include oTypographySans($scale: 3);
+  margin: 0 100px 0 100px;
+}

--- a/examples/kitchen-sink/server/controllers/home.js
+++ b/examples/kitchen-sink/server/controllers/home.js
@@ -54,6 +54,13 @@ module.exports = (_, response, next) => {
           <div align="center">
             <p className="hello">Hello, welcome to Page Kit.</p>
           </div>
+          <div>
+            <p className="project-aim">
+              The aim of this project is to provide a high quality, well tested, and thoroughly documented set
+              of tools for assembling and delivering modern websites with Node.js based upon the best industry
+              standards.
+            </p>
+          </div>
         </Layout>
       </Shell>
     )


### PR DESCRIPTION
Adds a paragraph of text to the kitchen-sink example app to make regressions in font styles easier to detect. 

<img width="876" alt="Screenshot 2019-07-10 at 08 53 18" src="https://user-images.githubusercontent.com/17549437/60951058-39f94900-a2f0-11e9-91c7-7253baf842ae.png">


