### PR TITLE
Rename the HandlebarsRenderer component to PageKitHandlebars

### DIFF
--- a/examples/express-with-handlebars/server/app.js
+++ b/examples/express-with-handlebars/server/app.js
@@ -1,13 +1,13 @@
 const express = require('express')
 const homePageController = require('./controllers/home')
-const { HandlebarsRenderer } = require('@financial-times/dotcom-server-handlebars')
+const { PageKitHandlebars } = require('@financial-times/dotcom-server-handlebars')
 
 const app = (module.exports = express())
 
 app.locals.siteName = 'Good Dogs'
 
 // Add Handlebars as a view engine so controllers may use response.render()
-const renderer = new HandlebarsRenderer({
+const renderer = new PageKitHandlebars({
   cache: process.env.NODE_ENV === 'production'
 })
 

--- a/packages/dotcom-server-handlebars/readme.md
+++ b/packages/dotcom-server-handlebars/readme.md
@@ -26,9 +26,9 @@ _Please note_ the template file extension registered with your application shoul
 
 ```diff
 const express = require('express')
-+ const { HandlebarsRenderer } = require('@financial-times/dotcom-server-handlebars')
++ const { PageKitHandlebars } = require('@financial-times/dotcom-server-handlebars')
 
-+ const renderer = new HandlebarsRenderer(options)
++ const renderer = new PageKitHandlebars(options)
 + app.engine('.html', renderer.engine)
 ```
 
@@ -57,8 +57,8 @@ _Please note_ that where to lookup template files can be configured using Expres
 This module can be used without integrating it fully into your application. This may be suitable for applications which are not built with Express or for ad-hoc template rendering needs.
 
 ```diff
-+ const { HandlebarsRenderer } = require('@financial-times/dotcom-server-handlebars')
-+ const renderer = new HandlebarsRenderer(options)
++ const { PageKitHandlebars } = require('@financial-times/dotcom-server-handlebars')
++ const renderer = new PageKitHandlebars(options)
 ```
 
 When using this module as a standalone library you will need to find template files, provide all data, and handle the rendered output manually.

--- a/packages/dotcom-server-handlebars/src/PageKitHandlebars.ts
+++ b/packages/dotcom-server-handlebars/src/PageKitHandlebars.ts
@@ -5,7 +5,7 @@ import findPartialFiles from './findPartialFiles'
 import loadFileContents from './loadFileContents'
 import { TRenderCallback, TPartialTemplates, TFilePaths } from './types'
 
-export type THandlebarsRendererOptions = {
+export type TPageKitHandlebarsOptions = {
   /**
    * An instance of Handlebars to use.
    * @default require('handlebars')
@@ -45,7 +45,7 @@ export type THandlebarsRendererOptions = {
   cache?: boolean
 }
 
-const defaultOptions: THandlebarsRendererOptions = {
+const defaultOptions: TPageKitHandlebarsOptions = {
   rootDirectory: process.cwd(),
   helpers: {},
   partials: {},
@@ -56,13 +56,13 @@ const defaultOptions: THandlebarsRendererOptions = {
   }
 }
 
-export class HandlebarsRenderer {
-  public options: THandlebarsRendererOptions
+export class PageKitHandlebars {
+  public options: TPageKitHandlebarsOptions
   public engine: this['renderView']
 
   private cache: Map<string, any> = new Map()
 
-  constructor(userOptions: THandlebarsRendererOptions = {}) {
+  constructor(userOptions: TPageKitHandlebarsOptions = {}) {
     this.options = mixinDeep({}, defaultOptions, userOptions)
 
     // Create a point for Express to mount as a view engine

--- a/packages/dotcom-server-handlebars/src/__test__/HandlebarsRenderer.spec.ts
+++ b/packages/dotcom-server-handlebars/src/__test__/HandlebarsRenderer.spec.ts
@@ -1,11 +1,11 @@
 import path from 'path'
-import { HandlebarsRenderer as Subject } from '../HandlebarsRenderer'
+import { PageKitHandlebars as Subject } from '../PageKitHandlebars'
 
 // NOTE: Tests are run from the repository root directory so we need to set the CWD
 const root = path.join(__dirname, '__fixtures__')
 const view = path.resolve(root, 'views/view.hbs')
 
-describe('dotcom-server-handlebars/src/HandlebarsRenderer', () => {
+describe('dotcom-server-handlebars/src/PageKitHandlebars', () => {
   let instance
 
   beforeEach(() => {

--- a/packages/dotcom-server-handlebars/src/helpers/readme.md
+++ b/packages/dotcom-server-handlebars/src/helpers/readme.md
@@ -8,11 +8,11 @@ This package contains a suite of helpers to enable the migration of applications
 
 ## Usage
 
-When using this package you can import the `helpers` property and provide it as an option when creating a new `HandlebarsRenderer` instance. Please note that helpers will not be appended to the global Handlebars instance.
+When using this package you can import the `helpers` property and provide it as an option when creating a new `PageKitHandlebars` instance. Please note that helpers will not be appended to the global Handlebars instance.
 
 ```js
-const { HandlebarsRenderer, helpers } = require('@financial-times/dotcom-server-handlebars')
-const renderer = new HandlebarsRenderer({ helpers })
+const { PageKitHandlebars, helpers } = require('@financial-times/dotcom-server-handlebars')
+const renderer = new PageKitHandlebars({ helpers })
 ```
 
 Alternatively if you want to use the helpers with an existing Handlebars instance:

--- a/packages/dotcom-server-handlebars/src/index.ts
+++ b/packages/dotcom-server-handlebars/src/index.ts
@@ -1,3 +1,3 @@
 import * as helpers from './helpers'
-export * from './HandlebarsRenderer'
+export * from './PageKitHandlebars'
 export { helpers }


### PR DESCRIPTION
Housekeeping PR to rename the HandlebarsRenderer component to PageKitHandlebars.