### PR TITLE
Rename the ReactRenderer component to PageKitReactJSX

### DIFF
--- a/examples/express-with-jsx/server/app.js
+++ b/examples/express-with-jsx/server/app.js
@@ -1,13 +1,13 @@
 import express from 'express'
 import { homePageController } from './controllers/home'
-import { ReactRenderer } from '@financial-times/dotcom-server-react-jsx'
+import { PageKitReactJSX } from '@financial-times/dotcom-server-react-jsx'
 
 export const app = express()
 
 app.locals.siteName = 'Good Cats'
 
 // Add React as a view engine so controllers may use response.render()
-const renderer = new ReactRenderer({ useStaticRendering: true })
+const renderer = new PageKitReactJSX({ useStaticRendering: true })
 app.engine('.jsx', renderer.engine)
 
 app.use('/public', express.static('./public'))

--- a/packages/dotcom-server-react-jsx/readme.md
+++ b/packages/dotcom-server-react-jsx/readme.md
@@ -21,9 +21,9 @@ _Please note_ that you will need to extend Node's `require()` function to enable
 
 ```diff
 const express = require('express')
-+ const { ReactRenderer } = require('@financial-times/dotcom-server-react-jsx')
++ const { PageKitReactJSX } = require('@financial-times/dotcom-server-react-jsx')
 
-+ const renderer = new ReactRenderer(options)
++ const renderer = new PageKitReactJSX(options)
 + app.engine('.jsx', renderer.engine)
 ```
 
@@ -51,8 +51,8 @@ _Please note_ that where to lookup template files can be configured using Expres
 This module can be used without integrating it fully into your application. This may be suitable for applications which are not built with Express or for ad-hoc template rendering needs. This is intended to provide some convenient extra functionality over React's built-in render methods.
 
 ```diff
-+ const { ReactRenderer } = require('@financial-times/dotcom-server-react-jsx')
-+ const renderer = new ReactRenderer(options)
++ const { PageKitReactJSX } = require('@financial-times/dotcom-server-react-jsx')
++ const renderer = new PageKitReactJSX(options)
 ```
 
 When using this module as a standalone library you will need to find template files, provide all data, and handle the rendered output manually.

--- a/packages/dotcom-server-react-jsx/src/PageKitReactJSX.ts
+++ b/packages/dotcom-server-react-jsx/src/PageKitReactJSX.ts
@@ -4,19 +4,19 @@ import interopRequire from './interopRequire'
 import { Request, Response, NextFunction } from 'express'
 import { Renderable, RenderCallback } from './types'
 
-export interface TReactRendererOptions {
+export interface TPageKitReactJSXOptions {
   useStaticRendering?: boolean
 }
 
-const defaultOptions: TReactRendererOptions = {
+const defaultOptions: TPageKitReactJSXOptions = {
   useStaticRendering: false
 }
 
-export class ReactRenderer {
-  public options: TReactRendererOptions
+export class PageKitReactJSX {
+  public options: TPageKitReactJSXOptions
   public engine: Function
 
-  constructor(userOptions: TReactRendererOptions = {}) {
+  constructor(userOptions: TPageKitReactJSXOptions = {}) {
     this.options = { ...defaultOptions, ...userOptions }
     this.engine = this.renderView.bind(this)
   }

--- a/packages/dotcom-server-react-jsx/src/index.ts
+++ b/packages/dotcom-server-react-jsx/src/index.ts
@@ -1,1 +1,1 @@
-export * from './ReactRenderer'
+export * from './PageKitReactJSX'


### PR DESCRIPTION
Housekeeping PR to rename the ReactRenderer component to PageKitReactJSX.