### PR TITLE
chore(deps): include enhanced-resolve peer dependency

### DIFF
--- a/packages/dotcom-build-bower-resolve/package.json
+++ b/packages/dotcom-build-bower-resolve/package.json
@@ -21,7 +21,8 @@
     "@financial-times/dotcom-page-kit-cli": "file:../dotcom-page-kit-cli"
   },
   "dependencies": {
-    "bower-resolve-webpack-plugin": "^1.0.5"
+    "bower-resolve-webpack-plugin": "^1.0.5",
+    "enhanced-resolve": "^4.1.0"
   },
   "engines": {
     "node": ">= 8.16.0"


### PR DESCRIPTION
Currently we get:

```
npm WARN bower-resolve-webpack-plugin@1.0.5 requires a peer of enhanced-resolve@^3.1.0 but none is installed. You must install peer dependencies yourself.
```

On `make install` of Page Kit projects.

We _could_ include the dependency in each app, but it seems better to manage this peer dependency in dotcom-build-bower-resolve.