### PR TITLE
A11y: Fix subscribe link styled to look like a button to behave like one

### DIFF
--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -106,7 +106,14 @@ const NavListRightAnon = ({ items, variant }: { items: TNavMenuItem[]; variant?:
         </a>
       </li>
       <li className="o-header__nav-item">
-        <a className="o-header__nav-button" href={second.url} data-trackable={second.label} {...setTabIndex}>
+        <a
+          className="o-header__nav-button"
+          // Added as the result of a DAC audit. This will be confusing for users of voice activation software
+          // as it looks like a button but behaves like a link without this role.
+          role="button"
+          href={second.url}
+          data-trackable={second.label}
+          {...setTabIndex}>
           {second.label}
         </a>
       </li>


### PR DESCRIPTION
As requested [here](https://github.com/Financial-Times/n-ui/pull/1486#issuecomment-525249726).

This was confusing for users of voice activation software as it looks like a button but behaved like a link.

[Trello ticket](https://trello.com/c/RvFGcUpz/143-dacelementroleissue1)