### PR TITLE
Documentation - Add missing link to Page Kit CLI 

### DIFF
--- a/docs/guides/extending-webpack-and-babel.md
+++ b/docs/guides/extending-webpack-and-babel.md
@@ -56,7 +56,7 @@ function babelPlugin ({ on }) => {
 }
 ```
 
-See the [Page Kit CLI package] for more information on the `page-kit.config.js` file
+See the [Page Kit CLI package](https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-page-kit-cli) for more information on the `page-kit.config.js` file
 
 ## Amending supplementary resources
 


### PR DESCRIPTION
### Description: 

Noticed that there was what looked like a missing link for the Page Kit CLI package and would be handy to have it here as seems to have been intended. 

No code changes included in this PR.