### PR TITLE
Remove Account Settings and Portfolio from nav bar

### DIFF
--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -73,25 +73,9 @@ const NavListLeft = (props: THeaderProps) => (
 )
 
 const NavListRight = (props: THeaderProps) => {
-  if (props.userIsLoggedIn) {
-    return <NavListRightLoggedIn items={props.data['navbar-right'].items} />
-  } else {
+  if (!props.userIsLoggedIn) {
     return <NavListRightAnon items={props.data['navbar-right-anon'].items} />
   }
-}
-
-const NavListRightLoggedIn = ({ items }: { items: TNavMenuItem[] }) => {
-  return (
-    <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
-      {items.map((item, index) => (
-        <li className="o-header__nav-item" key={`link-${index}`}>
-          <a className="o-header__nav-link" href={item.url} data-trackable={item.label}>
-            {item.label}
-          </a>
-        </li>
-      ))}
-    </ul>
-  )
 }
 
 const NavListRightAnon = ({ items, variant }: { items: TNavMenuItem[]; variant?: string }) => {


### PR DESCRIPTION
They are now in the nav bar of myFT so don't need to be in the main one.


Related: https://github.com/Financial-Times/n-ui/pull/1496
[Trello](https://trello.com/c/J7m239TK/3782-release-navonmyft-to-all-users)