### PR TITLE
Eslint to ignore public directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ dist/
 coverage/
 node_modules/
 bower_components/
+public/


### PR DESCRIPTION
Currently if you have production build assets in your file system, eslint will error due to `console.log`s found in the built assets:

![image (7)](https://user-images.githubusercontent.com/35195024/65529608-5b7cd080-deee-11e9-9f6b-bd9b75e5f9f5.png)

This seems to not happen with the development build because the bundled code is a `string` being passed into a function. 

#### Fix:
Set eslint to ignore the `/public` directory (it's already ignoring `/dist` directories). 
