### PR TITLE
Update readme.md: Fixed link

### DIFF
--- a/packages/dotcom-build-sass/readme.md
+++ b/packages/dotcom-build-sass/readme.md
@@ -2,9 +2,8 @@
 
 This package extends the [Page Kit CLI build action][cli] (`page-kit build`) with a way to load and generate CSS files from [Sass] source code.
 
-[cli]: ../dotcom-page-kit-cli/readme.md
+[cli]: https://github.com/Financial-Times/dotcom-page-kit/blob/master/packages/dotcom-page-kit-cli/README.md#actions
 [Sass]: https://sass-lang.com/
-
 
 ## Getting started
 


### PR DESCRIPTION
Fixed a broken link to https://github.com/Financial-Times/dotcom-page-kit/blob/master/packages/dotcom-page-kit-cli/README.md#actions