### PR TITLE
Fix link to FT UI example app

### DIFF
--- a/packages/dotcom-ui-layout/README.md
+++ b/packages/dotcom-ui-layout/README.md
@@ -53,7 +53,7 @@ const outputHTML = ReactDOM.renderToString(document)
 
 For a full example for how to use this component please refer to the [FT UI example app][example].
 
-[example]: ../../examples/basic-ft-ui/readme.md
+[example]: ../../examples/ft-ui/readme.md
 
 ### Styles
 


### PR DESCRIPTION
Update the link to the FT UI example app README so that it points to the correct place.