### PR TITLE
fix storybook user-is-logged-in render fail

### DIFF
--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -76,6 +76,7 @@ const NavListRight = (props: THeaderProps) => {
   if (!props.userIsLoggedIn) {
     return <NavListRightAnon items={props.data['navbar-right-anon'].items} />
   }
+  return null
 }
 
 const NavListRightAnon = ({ items, variant }: { items: TNavMenuItem[]; variant?: string }) => {


### PR DESCRIPTION
Storybook would fail to render if we ticked user is logged in. this is because we weren't returning anything for this component. if we return null it is happy.