### PR TITLE
Revert "Remove Account Settings and Portfolio from nav bar"

### DIFF
--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -73,10 +73,26 @@ const NavListLeft = (props: THeaderProps) => (
 )
 
 const NavListRight = (props: THeaderProps) => {
-  if (!props.userIsLoggedIn) {
+  if (props.userIsLoggedIn) {
+    return <NavListRightLoggedIn items={props.data['navbar-right'].items} />
+  } else {
     return <NavListRightAnon items={props.data['navbar-right-anon'].items} />
   }
   return null
+}
+
+const NavListRightLoggedIn = ({ items }: { items: TNavMenuItem[] }) => {
+  return (
+    <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
+      {items.map((item, index) => (
+        <li className="o-header__nav-item" key={`link-${index}`}>
+          <a className="o-header__nav-link" href={item.url} data-trackable={item.label}>
+            {item.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  )
 }
 
 const NavListRightAnon = ({ items, variant }: { items: TNavMenuItem[]; variant?: string }) => {


### PR DESCRIPTION
Reverts Financial-Times/dotcom-page-kit#594

We now want to put this back in the nav bar. We flamingoed up when reading the AB test data. ooops.

