### PR TITLE
Revise test command for ssr-with-hydration example

### DIFF
--- a/examples/ssr-with-hydration/package.json
+++ b/examples/ssr-with-hydration/package.json
@@ -8,7 +8,7 @@
     "build": "page-kit build -d",
     "start": "node start.js",
     "start:dev": "nodemon start.js --ext js",
-    "test:app": "../../node_modules/.bin/jest",
+    "test": "../../node_modules/.bin/jest",
     "pretest": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
The Circle CI process calls the root `package.json` command `npm run test:examples` to run all the integration tests.

It currently returns `Found 5 packages with script "test"` (six are expected) because the test command for the `ssr-with-hydration` example is `"test:app"` and so does not match that pattern.

The PR brings its `test` command in line with the others, resulting in `Found 6 packages with script "test"`.