### PR TITLE
Remove redundant pattern-matching methods from AssetLoader

### DIFF
--- a/packages/dotcom-server-asset-loader/src/AssetLoader.ts
+++ b/packages/dotcom-server-asset-loader/src/AssetLoader.ts
@@ -66,28 +66,6 @@ export class AssetLoader {
       loadManifest(path.resolve(this.options.fileSystemPath, this.options.manifestFileName))
   }
 
-  matchAssets(pattern: string | RegExp | Function): string[] {
-    return Object.keys(this.manifest).reduce((matches: string[], key: string) => {
-      if (typeof pattern === 'string' && key.includes(pattern)) {
-        matches.push(key)
-      }
-
-      if (pattern instanceof RegExp && pattern.test(key)) {
-        matches.push(key)
-      }
-
-      if (pattern instanceof Function && pattern(key)) {
-        matches.push(key)
-      }
-
-      return matches
-    }, [])
-  }
-
-  getHashedAssetsMatching(pattern: string | RegExp | Function): string[] {
-    return this.matchAssets(pattern).map((asset) => this.getHashedAsset(asset))
-  }
-
   getHashedAsset(asset: string): string {
     if (this.manifest.hasOwnProperty(asset)) {
       return this.manifest[asset]
@@ -106,10 +84,6 @@ export class AssetLoader {
 
   getPublicURL(asset: string): string {
     return this.formatPublicURL(this.getHashedAsset(asset))
-  }
-
-  getPublicURLOfHashedAssetsMatching(pattern: string | RegExp | Function): string[] {
-    return this.matchAssets(pattern).map((asset) => this.getPublicURL(asset))
   }
 
   //

--- a/packages/dotcom-server-asset-loader/src/__test__/AssetLoader.spec.ts
+++ b/packages/dotcom-server-asset-loader/src/__test__/AssetLoader.spec.ts
@@ -55,47 +55,6 @@ describe('dotcom-server-asset-loader/src/AssetLoader', () => {
     })
   })
 
-
-
-  describe('.matchAssets()', () => {
-    it('returns an array of matching file names from the manifest', () => {
-      const a = loader.matchAssets(/main/)
-      expect(a).toEqual(['main.js'])
-
-      const b = loader.matchAssets('main')
-      expect(b).toEqual(['main.js'])
-
-      const c = loader.matchAssets((filename) => filename === 'main.js')
-      expect(c).toEqual(['main.js'])
-    })
-  })
-
-  describe('.getHashedAssetsMatching(pattern)', () => {
-    it('returns an array of matching hashed file names from the manifest', () => {
-      const a = loader.getHashedAssetsMatching(/main/)
-      expect(a).toEqual(['main.12345.bundle.js'])
-
-      const b = loader.getHashedAssetsMatching('main')
-      expect(b).toEqual(['main.12345.bundle.js'])
-
-      const c = loader.getHashedAssetsMatching((filename) => filename === 'main.js')
-      expect(c).toEqual(['main.12345.bundle.js'])
-    })
-  })
-
-  describe('getPublicURLOfHashedAssetsMatching(pattern', () => {
-    it('returns the public urls of hashed assets whose entry file name matches the supplied pattern', () => {
-      const a = loader.getPublicURLOfHashedAssetsMatching(/main/)
-      expect(a).toEqual(['/public/assets/main.12345.bundle.js'])
-
-      const b = loader.getPublicURLOfHashedAssetsMatching('main')
-      expect(b).toEqual(['/public/assets/main.12345.bundle.js'])
-
-      const c = loader.getPublicURLOfHashedAssetsMatching((filename) => filename === 'main.js')
-      expect(c).toEqual(['/public/assets/main.12345.bundle.js'])
-    })
-  })
-
   describe('.getFileSystemPath()', () => {
     it('returns the file system path for the requested file', () => {
       const result = loader.getFileSystemPath('styles.css')


### PR DESCRIPTION
These methods are an artefact of a previous approach to referencing assets in the manifest