### PR TITLE
don't output wrapper div if contents is a react node

### DIFF
--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Content.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Content.test.tsx.snap
@@ -1,17 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`dotcom-ui-shell/src/components/Content with component contents renders the components 1`] = `
-<div
-  style={
-    Object {
-      "display": "contents",
-    }
-  }
->
-  <p>
-    Hello, World!
-  </p>
-</div>
+<p>
+  Hello, World!
+</p>
 `;
 
 exports[`dotcom-ui-shell/src/components/Content with stringified contents renders the given HTML string without escaping 1`] = `

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -269,13 +269,6 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
         width="0"
       />
     </noscript>
-    <div
-      style={
-        Object {
-          "display": "contents",
-        }
-      }
-    />
     <script
       dangerouslySetInnerHTML={
         Object {

--- a/packages/dotcom-ui-shell/src/components/Content.tsx
+++ b/packages/dotcom-ui-shell/src/components/Content.tsx
@@ -12,7 +12,7 @@ function Contents({ contents }: TContentProps) {
   if (typeof contents === 'string') {
     return <div style={styles} dangerouslySetInnerHTML={{ __html: contents }} />
   } else {
-    return <div style={styles}>{contents}</div>
+    return contents
   }
 }
 

--- a/packages/dotcom-ui-shell/src/components/Content.tsx
+++ b/packages/dotcom-ui-shell/src/components/Content.tsx
@@ -13,8 +13,10 @@ function Content({ contents }: TContentProps) {
     return <div style={styles} dangerouslySetInnerHTML={{ __html: contents }} />
   }
 
-  if (React.isValidElement(contents)) {
-    return contents
+  // We could try and validate this but there are so many possibilities
+  // of node types and potentially nested arrays etc.
+  if (contents) {
+    return <React.Fragment>{contents}</React.Fragment>
   }
 
   return null

--- a/packages/dotcom-ui-shell/src/components/Content.tsx
+++ b/packages/dotcom-ui-shell/src/components/Content.tsx
@@ -8,12 +8,16 @@ const styles = {
   display: 'contents'
 }
 
-function Contents({ contents }: TContentProps) {
+function Content({ contents }: TContentProps) {
   if (typeof contents === 'string') {
     return <div style={styles} dangerouslySetInnerHTML={{ __html: contents }} />
-  } else {
+  }
+
+  if (React.isValidElement(contents)) {
     return contents
   }
+
+  return null
 }
 
-export default Contents
+export default Content


### PR DESCRIPTION
because `contents` is either a string or a `ReactNode`, we can be sure it's a `ReactNode` here and return it directly (having said that, it doesn't typecheck 🤔)