### PR TITLE
Render drawer and skip-links only when required.

### DIFF
--- a/packages/dotcom-ui-layout/src/components/Layout.tsx
+++ b/packages/dotcom-ui-layout/src/components/Layout.tsx
@@ -90,32 +90,36 @@ export function Layout({
         href="https://www.ft.com/accessibility">
         Accessibility help
       </a>
-      <a data-trackable="a11y-skip-to-navigation" className="n-layout__skip-link" href="#site-navigation">
-        Skip to navigation
-      </a>
+
+      {drawer ? (
+        <a data-trackable="a11y-skip-to-navigation" className="n-layout__skip-link" href="#site-navigation">
+          Skip to navigation
+        </a>
+      ) : null}
+
       <a data-trackable="a11y-skip-to-content" className="n-layout__skip-link" href="#site-content">
         Skip to content
       </a>
-      <a data-trackable="a11y-skip-to-footer" className="n-layout__skip-link" href="#site-footer">
-        Skip to footer
-      </a>
+
+      {footer ? (
+        <a data-trackable="a11y-skip-to-footer" className="n-layout__skip-link" href="#site-footer">
+          Skip to footer
+        </a>
+      ) : null}
 
       <div className="n-layout__row n-layout__row--header">
         <Template className="n-layout__header-before">{headerBefore}</Template>
         {headerComponent || header || null}
         <Template className="n-layout__header-after">{headerAfter}</Template>
       </div>
-
       <div className="n-layout__row n-layout__row--content">
         <Template>{contents || children}</Template>
       </div>
-
       <div className="n-layout__row n-layout__row--footer">
         <Template className="n-layout__footer-before">{footerBefore}</Template>
         {footerComponent || footer || null}
         <Template className="n-layout__footer-after">{footerAfter}</Template>
       </div>
-
       {drawer}
     </div>
   )


### PR DESCRIPTION
closes #654 

1. Ensure drawer is only present when header is not custom or 'logo-only'
The drawer html was present whenever a header component was used, however when we use 'logo-only', we don't want the Drawer in the html.

2. Only include the necessary skip-links.
Not all skip-links are required at all times. If the footer is not present, don't contain the footer skip-link. If the drawer is not present (i.e. it's logo-only or custom) then don't contain the header skip-link.