### PR TITLE
allow css-loader to resolve @imports

### DIFF
--- a/packages/dotcom-build-sass/src/plugin.ts
+++ b/packages/dotcom-build-sass/src/plugin.ts
@@ -128,9 +128,9 @@ export function plugin({ includePaths }: TPluginOptions = {}) {
 
   function getCssLoaderOptions() {
     return {
-      // Disable Webpack from resolving @import because Sass should
-      // have already resolved and concatenated these files.
-      import: false,
+      // Allow css-loader to resolve @import because the sass-loader
+      // does not successfully resolve files with a .css extension.
+      import: true,
       // Disable Webpack from resolving url() because we do not
       // currently use this functionality.
       url: false


### PR DESCRIPTION
We've run into a problem in the next-myft-page and next-article Page Kit migrations where the sass-loader plugin is unable to resolve imports with `.css` extensions. x-dash components output their styles as css so importing these stylesheets currently throws errors. 

Setting this property in the `cssLoaderOptions` allows the css-loader to resolve these imports. Their contents can then be added to the concatenated `public/styles.css` bundle.

An alternative solution would be to update [this regex](https://github.com/Financial-Times/dotcom-page-kit/blob/a4e8696281f937d88ca6513efe10d4d4e306a7a7/packages/dotcom-build-sass/src/plugin.ts#L34) so that the sass-loader is able to resolve `.css` files at that point instead. 

Thoughts?