### PR TITLE
Add 'views' to partialPaths default options

### DIFF
--- a/packages/dotcom-server-handlebars/readme.md
+++ b/packages/dotcom-server-handlebars/readme.md
@@ -122,7 +122,7 @@ An object listing directories and patterns used to dynamically find and load par
 ```js
 {
   './views/partials': '**/*.{hbs,html}',
-  './bower_components': '*/{templates,components,partials}/**/*.{hbs,html}',
+  './bower_components': '*/{templates,components,partials,views}/**/*.{hbs,html}',
   './node_modules/@financial-times': '*/{templates,components,partials,views}/**/*.{hbs,html}'
 }
 ```

--- a/packages/dotcom-server-handlebars/src/PageKitHandlebars.ts
+++ b/packages/dotcom-server-handlebars/src/PageKitHandlebars.ts
@@ -55,7 +55,7 @@ const defaultOptions: TPageKitHandlebarsOptions = {
   partials: {},
   partialPaths: {
     './views/partials': '**/*.{hbs,html}',
-    './bower_components': '*/{templates,components,partials}/**/*.{hbs,html}',
+    './bower_components': '*/{templates,components,partials,views}/**/*.{hbs,html}',
     './node_modules/@financial-times': '*/{templates,components,partials,views}/**/*.{hbs,html}'
   }
 }


### PR DESCRIPTION
I am working on the migration of [`next-product`](https://github.com/Financial-Times/next-product) from `n-ui` to Page Kit.

`next-product` uses a Handlebars partial from [`n-swg`](https://github.com/Financial-Times/n-swg) ('Subscribe with Google').

The relative path for this partial (from `next-product`'s perspective) is: `./node_modules/@financial-times/n-swg/views/button.html`.

The [default options for the partialPaths attribute](https://github.com/Financial-Times/dotcom-page-kit/blob/03b662f9214d77180c1074fd7f20a5e08f0c149b/packages/dotcom-server-handlebars/src/PageKitHandlebars.ts#L56-L60) when instantiating the instance of `PageKitHandlebars` look like this:
```
  partialPaths: {
    './views/partials': '**/*.{hbs,html}',
    './bower_components': '*/{templates,components,partials}/**/*.{hbs,html}',
    './node_modules/@financial-times': '*/{templates,components,partials}/**/*.{hbs,html}'
  }
```

Adding `views` to the last of those paths (done in this PR) will allow the `n-swg/views/button.html` partial to be matched by the pattern.

(I could have achieved this by providing custom options when instantiating the instance of `PageKitHandlebars`, but the app may depend on these defaults, whether now or in the future, meaning I would have needed to provide both those with this minor modification, making this PR the simpler solution. Plus `/views` seems like it may be a common dir name for Handlebars partials and that adding it will be prudent in any case.)