### PR TITLE
Correct footer text

### DIFF
--- a/packages/dotcom-ui-footer/src/components/partials.tsx
+++ b/packages/dotcom-ui-footer/src/components/partials.tsx
@@ -93,7 +93,7 @@ const CopyrightNotice = ({ withoutMarketsData = false }) => {
   return (
     <div className="o-footer__copyright" role="contentinfo">
       <small>
-        {`${marketsData} © THE FINANCIAL TIMES LTD. `}
+        {`${marketsData} © THE FINANCIAL TIMES LTD ${new Date().getFullYear()}. `}
         <abbr title="Financial Times" aria-label="F T">
           FT
         </abbr>{' '}


### PR DESCRIPTION
I wonder if the last trademark (`‘Financial Times’`) should be in quotes when the others are not. 🤔

> © The Financial Times Ltd., FT and Financial Times are trademarks of The Financial Times Ltd.

And if we should be using an Oxford comma:

> © The Financial Times Ltd., FT, and Financial Times are trademarks of The Financial Times Ltd.

Do we know who we can ask for the exact copy?

#### Before:
![before](https://user-images.githubusercontent.com/10484515/69433234-25639d80-0d33-11ea-9467-bf4a9a8c26dd.png)

#### After:
![after](https://user-images.githubusercontent.com/10484515/69433237-27c5f780-0d33-11ea-8231-e43e4f1f0dc3.png)
