### PR TITLE
Apply base of https://www.ft.com to font + manifest URLs

### DIFF
--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/DocumentHead.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/DocumentHead.test.tsx.snap
@@ -71,7 +71,7 @@ Array [
     sizes="180x180"
   />,
   <link
-    href="/__assets/creatives/manifest/manifest-v6.json"
+    href="https://www.ft.com/__assets/creatives/manifest/manifest-v6.json"
     rel="manifest"
   />,
 ]

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
       sizes="180x180"
     />
     <link
-      href="/__assets/creatives/manifest/manifest-v6.json"
+      href="https://www.ft.com/__assets/creatives/manifest/manifest-v6.json"
       rel="manifest"
     />
     <link
@@ -101,25 +101,25 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
     <link
       as="font"
       crossOrigin="anonymous"
-      href="/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Regular.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Regular.woff"
       rel="preload"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Semibold.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Semibold.woff"
       rel="preload"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Regular.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Regular.woff"
       rel="preload"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Bold.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Bold.woff"
       rel="preload"
     />
     <script

--- a/packages/dotcom-ui-shell/src/components/DocumentHead.tsx
+++ b/packages/dotcom-ui-shell/src/components/DocumentHead.tsx
@@ -79,7 +79,7 @@ DocumentHead.defaultProps = {
   robots: 'index,follow,max-snippet:200,max-image-preview:large',
   siteTitle: 'Financial Times',
   twitterSite: '@FinancialTimes',
-  manifestFile: '/__assets/creatives/manifest/manifest-v6.json',
+  manifestFile: 'https://www.ft.com/__assets/creatives/manifest/manifest-v6.json',
   additionalMetadata: null
 }
 

--- a/packages/dotcom-ui-shell/src/components/Shell.tsx
+++ b/packages/dotcom-ui-shell/src/components/Shell.tsx
@@ -37,10 +37,10 @@ function Shell(props: TShellProps) {
     ...props.scripts,
     ...props.resourceHints,
     // TODO: abstract font URLs into 'core branding' package
-    '/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Regular.woff',
-    '/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Semibold.woff',
-    '/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Regular.woff',
-    '/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Bold.woff'
+    'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Regular.woff',
+    'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Semibold.woff',
+    'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Regular.woff',
+    'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Bold.woff'
   ]
 
   return (


### PR DESCRIPTION
Manifest assets and fonts will not be served on base URL provided dynamically when running locally or on Heroku review apps, so an absolute path is required to ensure the resource hints (fonts) and document head links (manifest) are available at time of speculative parsing of the document.