### PR TITLE
Prevent string of 'null' displayed in legal footer variant

### DIFF
--- a/packages/dotcom-ui-footer/src/components/partials.tsx
+++ b/packages/dotcom-ui-footer/src/components/partials.tsx
@@ -89,11 +89,11 @@ const MoreFromFT = () => (
 )
 
 const CopyrightNotice = ({ withoutMarketsData = false }) => {
-  const marketsData = withoutMarketsData ? null : 'Markets data delayed by at least 15 minutes.'
+  const marketsData = withoutMarketsData ? '' : 'Markets data delayed by at least 15 minutes. '
   return (
     <div className="o-footer__copyright" role="contentinfo">
       <small>
-        {`${marketsData} © THE FINANCIAL TIMES LTD ${new Date().getFullYear()}. `}
+        {`${marketsData}© THE FINANCIAL TIMES LTD ${new Date().getFullYear()}. `}
         <abbr title="Financial Times" aria-label="F T">
           FT
         </abbr>{' '}


### PR DESCRIPTION
### Legal variant
#### Before:
`null © THE FINANCIAL TIMES LTD 2019`
![before](https://user-images.githubusercontent.com/10484515/70798698-89f8a200-1d9f-11ea-9687-0875716283ee.png)

#### After:
`© THE FINANCIAL TIMES LTD 2019`
![after](https://user-images.githubusercontent.com/10484515/70798713-9250dd00-1d9f-11ea-950f-4340a41d5f0c.png)

### Default variant
#### Before:
`Markets data delayed by at least 15 minutes. © THE FINANCIAL TIMES LTD 2019`
![Screenshot 2019-12-13 at 12 00 47](https://user-images.githubusercontent.com/10484515/70798964-3c306980-1da0-11ea-9a3e-1df167753002.png)

#### After:
`Markets data delayed by at least 15 minutes. © THE FINANCIAL TIMES LTD 2019`
![Screenshot 2019-12-13 at 12 00 47](https://user-images.githubusercontent.com/10484515/70798964-3c306980-1da0-11ea-9a3e-1df167753002.png)