### PR TITLE
Adds syndicatable subnav item ids to the myFT subnav component

### DIFF
--- a/packages/dotcom-types-navigation/index.d.ts
+++ b/packages/dotcom-types-navigation/index.d.ts
@@ -47,6 +47,7 @@ export type TNavMenuItem = {
   label: string
   url: string | null
   submenu?: TNavMenu | TNavMenuWithColumns
+  id?: string
   selected?: boolean
   meganav?: TNavMeganav[]
   disableTracking?: boolean

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -1785,6 +1785,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
             >
               <li
                 className="o-header__subnav-item"
+                data-id={null}
               >
                 <a
                   className="o-header__subnav-link "
@@ -1796,6 +1797,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
               </li>
               <li
                 className="o-header__subnav-item"
+                data-id={null}
               >
                 <a
                   className="o-header__subnav-link "
@@ -1807,6 +1809,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
               </li>
               <li
                 className="o-header__subnav-item"
+                data-id={null}
               >
                 <a
                   className="o-header__subnav-link "
@@ -3624,6 +3627,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
             >
               <li
                 className="o-header__subnav-item"
+                data-id={null}
               >
                 <a
                   className="o-header__subnav-link "
@@ -3635,6 +3639,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
               </li>
               <li
                 className="o-header__subnav-item"
+                data-id={null}
               >
                 <a
                   className="o-header__subnav-link "
@@ -3646,6 +3651,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
               </li>
               <li
                 className="o-header__subnav-item"
+                data-id={null}
               >
                 <a
                   className="o-header__subnav-link "

--- a/packages/dotcom-ui-header/src/components/sub-navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sub-navigation/partials.tsx
@@ -73,9 +73,10 @@ const SubSections = ({ items }: { items: TNavMenuItem[] }) => {
       data-trackable="subsections">
       {items.map((item, index) => {
         const selected = item.selected ? 'o-header__subnav-link--highlight' : ''
+        const subnavItemId = { 'data-id': item.id ? `subnav-${item.id}` : null }
 
         return (
-          <li className="o-header__subnav-item" key={`item-${index}`}>
+          <li className="o-header__subnav-item" key={`item-${index}`} {...subnavItemId}>
             <a
               className={`o-header__subnav-link ${selected}`}
               href={item.url}


### PR DESCRIPTION
Adds a data-id attribute to subnav list items on the myFT pages. 

The attribute is present in [n-ui]( https://github.com/Financial-Times/n-ui/blob/master/components/n-ui/header/partials/subnav/template.html#L24) and is required by n-syndication. 