### PR TITLE
Remove 'top' as a oHeader sass option

### DIFF
--- a/packages/dotcom-ui-header/styles.scss
+++ b/packages/dotcom-ui-header/styles.scss
@@ -6,7 +6,7 @@ $system-code: 'page-kit-header' !default;
 // We don't need the sub-brand or transparent header styles so disable them.
 // TODO: move drawer styles into a separate stylesheet which can be lazy loaded?
 @import "o-header/main";
-@include oHeader(('top', 'nav', 'subnav', 'search', 'megamenu', 'drawer', 'anon', 'sticky', 'simple'));
+@include oHeader(('nav', 'subnav', 'search', 'megamenu', 'drawer', 'anon', 'sticky', 'simple'));
 
 @import "src/header";
 


### PR DESCRIPTION
Removes 'top' as a sass option in dotcom-ui-header as it's no longer an option on oHeader https://github.com/Financial-Times/o-header#sass, This doesn't seem to affect prod but was causing errors when building storybook locally. 