### PR TITLE
Update the labels for the storybook logo only demo

### DIFF
--- a/packages/dotcom-ui-header/src/__stories__/story.tsx
+++ b/packages/dotcom-ui-header/src/__stories__/story.tsx
@@ -9,7 +9,7 @@ import '../../styles.scss'
 import './demos.scss'
 
 const toggleUserStateOptions = () => boolean('Enable user nav actions', true)
-const toggleVariantOptions = () => radios('Choose variant', { simple: 'simple', normal: 'normal' }, 'simple')
+const toggleVariantOptions = () => radios('Choose variant', { default: 'simple', large: 'large' }, 'simple')
 const toggleLoggedIn = () => boolean('User is logged in', false)
 const toggleShowSubNav = () => boolean('Show the sub-navigation component', true)
 const toggleShowStickyHeader = () => boolean('Show the sticky header', true)


### PR DESCRIPTION
A small tidy-up to the labels we use to identify the layout variants in our header storybook. These labels better reflect how we refer to possible header variants in the rest of the codebase. 