### PR TITLE
Bump n-ads

### DIFF
--- a/examples/kitchen-sink/client/main.js
+++ b/examples/kitchen-sink/client/main.js
@@ -16,7 +16,8 @@ domLoaded.then(() => {
   ads
     .init(
       {
-        trackingCallback: console.log // eslint-disable-line no-console
+        trackingCallback: console.log, // eslint-disable-line no-console,
+        appContext: appContextClient.getAll()
       },
       flagsClient
     )

--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -18,7 +18,7 @@
     "@financial-times/dotcom-ui-flags": "file:../../packages/dotcom-ui-flags",
     "@financial-times/dotcom-ui-layout": "file:../../packages/dotcom-ui-layout",
     "@financial-times/dotcom-ui-shell": "file:../../packages/dotcom-ui-shell",
-    "@financial-times/n-ads": "^1.0.2",
+    "@financial-times/n-ads": "^3.1.0",
     "@financial-times/n-tracking": "^1.0.0-beta.1",
     "express": "^4.16.2",
     "react": "^16.8.6",


### PR DESCRIPTION
Bumped n-ads to latest version. n-ads v2 updates all the dependencies to latest version. n-ads v3 now requires `appContext` to be passed in as an option when being initialised.