### PR TITLE
Add showLogoLink option to logo only header

### DIFF
--- a/packages/dotcom-ui-header/README.md
+++ b/packages/dotcom-ui-header/README.md
@@ -26,7 +26,7 @@ This package provides several UI components to render different parts and styles
 
 - `<Header />` the full header with navigation with lots of options. See [header elements](#header-elements) for a breakdown of its parts.
 - `<Drawer />` the navigation drawer which should be rendered separately from the header, preferably near the bottom of the document.
-- `<LogoOnly />` a simple masthead displaying the logo image which does require any configuration. Doesn't link to the homepage by default, pass in a `showLogoLink={true}` prop to make it link through.
+- `<LogoOnly />` a simple masthead displaying the logo image which doesn't require any configuration. Doesn't link to the homepage by default, pass in a `showLogoLink={true}` prop to make it link through.
 
 
 ```jsx

--- a/packages/dotcom-ui-header/README.md
+++ b/packages/dotcom-ui-header/README.md
@@ -26,7 +26,7 @@ This package provides several UI components to render different parts and styles
 
 - `<Header />` the full header with navigation with lots of options. See [header elements](#header-elements) for a breakdown of its parts.
 - `<Drawer />` the navigation drawer which should be rendered separately from the header, preferably near the bottom of the document.
-- `<LogoOnly>` a simple masthead displaying the logo image which does require any configuration.
+- `<LogoOnly />` a simple masthead displaying the logo image which does require any configuration. Doesn't link to the homepage by default, pass in a `showLogoLink={true}` prop to make it link through.
 
 
 ```jsx

--- a/packages/dotcom-ui-header/src/__stories__/story.tsx
+++ b/packages/dotcom-ui-header/src/__stories__/story.tsx
@@ -10,6 +10,7 @@ import './demos.scss'
 
 const toggleUserStateOptions = () => boolean('Enable user nav actions', true)
 const toggleVariantOptions = () => radios('Choose variant', { default: 'simple', large: 'large' }, 'simple')
+const toggleShowLogoLink = () => boolean('Render with the logo having a link', false)
 const toggleLoggedIn = () => boolean('User is logged in', false)
 const toggleShowSubNav = () => boolean('Show the sub-navigation component', true)
 const toggleShowStickyHeader = () => boolean('Show the sticky header', true)
@@ -75,6 +76,6 @@ storiesOf('FT / Header', module)
     )
   })
   .add('Logo only', () => {
-    const knobs = { variant: toggleVariantOptions() }
+    const knobs = { variant: toggleVariantOptions(), showLogoLink: toggleShowLogoLink() }
     return <LogoOnly {...knobs} />
   })

--- a/packages/dotcom-ui-header/src/index.tsx
+++ b/packages/dotcom-ui-header/src/index.tsx
@@ -87,11 +87,11 @@ function Header(props: THeaderProps) {
 
 Header.defaultProps = defaultProps
 
-function LogoOnly(props: Pick<THeaderProps, 'variant'>) {
+function LogoOnly(props: Pick<THeaderProps, 'variant' | 'showLogoLink'>) {
   return (
     <HeaderWrapper {...props}>
       <TopWrapper>
-        <TopColumnCenterNoLink />
+        {props.showLogoLink ? <TopColumnCenter /> : <TopColumnCenterNoLink />}
       </TopWrapper>
     </HeaderWrapper>
   )

--- a/packages/dotcom-ui-header/src/interfaces.d.ts
+++ b/packages/dotcom-ui-header/src/interfaces.d.ts
@@ -8,6 +8,7 @@ export type THeaderOptions = {
   showUserNavigation?: boolean
   showStickyHeader?: boolean
   showMegaNav?: boolean
+  showLogoLink?: boolean
 }
 
 export type THeaderProps = THeaderOptions & {


### PR DESCRIPTION
Please let me know if I've missed anything but as far as I can tell, this option will be able to be passed through using the `headerOptions` of the `Layout` component.