### PR TITLE
Replace dom-loaded with ready-state

### DIFF
--- a/docs/design-decisions/app-context.md
+++ b/docs/design-decisions/app-context.md
@@ -1,0 +1,17 @@
+# Design Decisions: App context
+
+App context is a combination of metadata about the current application and the page it is serving for use by client-side code. This is a change from the existing FT.com toolset.
+
+Previously metadata was embedded into the HTML as data attributes on the document element (`<html>`). This implementation had several problems:
+
+- What the metadata properties were and how they should be used was not defined anywhere.
+- The mechanism was often misused to pass additional information from server to client which lead to de facto standards emerging across different parts of FT.com.
+- We did not know who or what relies on this data meaning we were scared to change it, or fix it.
+- Several properties had changed in scope, either the name became irrelevant or the type of data had changed.
+
+To help resolve this our implementation of app context is based upon a schema which documents and guarantees the data. The schema also defines how the feature can be used to reduce the chance of it being re-purposed or misused. Because we don't always know who or what may be using the data the schema enables us communicate an official point of reference for them to follow.
+
+The new app context feature has also enabled us to refactor the [ads] and [tracking] component configuration to be deterministic rather than have each separately and arbitrarily scraping pages for information.
+
+[ads]: https://github.com/Financial-Times/n-ads/
+[tracking]: https://github.com/Financial-Times/n-tracking/

--- a/docs/design-decisions/app-context.md
+++ b/docs/design-decisions/app-context.md
@@ -9,9 +9,14 @@ Previously metadata was embedded into the HTML as data attributes on the documen
 - We did not know who or what relies on this data meaning we were scared to change it, or fix it.
 - Several properties had changed in scope, either the name became irrelevant or the type of data had changed.
 
-To help resolve this our implementation of app context is based upon a schema which documents and guarantees the data. The schema also defines how the feature can be used to reduce the chance of it being re-purposed or misused. Because we don't always know who or what may be using the data the schema enables us communicate an official point of reference for them to follow.
+To help resolve this our implementation of app context is based upon a schema which documents and guarantees the data. The schema also defines how the feature can be used to reduce the chances of it being re-purposed or misused. The schema also enables us provide an official reference for people to follow because we don't always know who or what may be using the data.
 
-The new app context feature has also enabled us to refactor the [ads] and [tracking] component configuration to be deterministic rather than have each separately and arbitrarily scraping pages for information.
+Finally, the app context feature has enabled us to refactor the [ads] and [tracking] components. They now provide their own, separate options, and are deterministic rather than each arbitrarily scraping pages for information.
 
 [ads]: https://github.com/Financial-Times/n-ads/
 [tracking]: https://github.com/Financial-Times/n-tracking/
+
+## Decision owners
+
+- Matt Hinchliffe
+- Ifeanyi Isitor

--- a/examples/ft-ui/client/main.js
+++ b/examples/ft-ui/client/main.js
@@ -1,6 +1,6 @@
-import domLoaded from 'dom-loaded'
+import readyState from 'ready-state'
 import * as layout from '@financial-times/dotcom-ui-layout'
 
-domLoaded.then(() => {
+readyState.domready.then(() => {
   layout.init()
 })

--- a/examples/ft-ui/package.json
+++ b/examples/ft-ui/package.json
@@ -20,11 +20,11 @@
     "sucrase": "^3.10.1"
   },
   "devDependencies": {
-    "@financial-times/dotcom-page-kit-cli": "file:../../packages/dotcom-page-kit-cli",
     "@financial-times/dotcom-build-bower-resolve": "file:../../packages/dotcom-build-bower-resolve",
     "@financial-times/dotcom-build-js": "file:../../packages/dotcom-build-js",
     "@financial-times/dotcom-build-sass": "file:../../packages/dotcom-build-sass",
-    "dom-loaded": "^1.2.0",
-    "nodemon": "^1.18.9"
+    "@financial-times/dotcom-page-kit-cli": "file:../../packages/dotcom-page-kit-cli",
+    "nodemon": "^1.18.9",
+    "ready-state": "^2.0.5"
   }
 }

--- a/examples/kitchen-sink/client/main.js
+++ b/examples/kitchen-sink/client/main.js
@@ -1,11 +1,11 @@
-import domLoaded from 'dom-loaded'
+import readyState from 'ready-state'
 import * as flags from '@financial-times/dotcom-ui-flags'
 import * as layout from '@financial-times/dotcom-ui-layout'
 import * as appContext from '@financial-times/dotcom-ui-app-context'
 import * as tracking from '@financial-times/n-tracking'
 import * as ads from '@financial-times/n-ads'
 
-domLoaded.then(() => {
+readyState.domready.then(() => {
   const flagsClient = flags.init()
   const appContextClient = appContext.init()
 

--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -32,8 +32,8 @@
     "@financial-times/dotcom-build-code-splitting": "file:../../packages/dotcom-build-code-splitting",
     "@financial-times/dotcom-build-sass": "file:../../packages/dotcom-build-sass",
     "@sucrase/jest-plugin": "^2.0.0",
-    "dom-loaded": "^1.2.0",
-    "nodemon": "^1.18.9"
+    "nodemon": "^1.18.9",
+    "ready-state": "^2.0.5"
   },
   "jest": {
     "transform": {

--- a/packages/dotcom-build-code-splitting/src/plugin.ts
+++ b/packages/dotcom-build-code-splitting/src/plugin.ts
@@ -72,13 +72,13 @@ export function plugin() {
   function addSharedStableCodeSplitting() {
     // split packages used by all pages (i.e. used by Page Kit) into a shared bundle
     return createBundleWithPackages('shared.stable', [
-      'dom-loaded',
       'focus-visible',
       'fontfaceobserver',
       'ftdomdelegate',
       'morphdom',
       'n-topic-search',
-      'n-ui-foundations'
+      'n-ui-foundations',
+      'ready-state'
     ])
   }
 

--- a/packages/dotcom-ui-bootstrap/readme.md
+++ b/packages/dotcom-ui-bootstrap/readme.md
@@ -23,17 +23,17 @@ After installing the package you should add `no-js` and `core` class names to yo
 + <html class="no-js core">
 ```
 
-Because the bootstrap is intended to load scripts asynchronously and as early as possible you should always check that the DOM is ready before initialising your client-side code. We recommend using the [dom-ready] library which provides a promise-based interface for this:
+Because the bootstrap is intended to load scripts asynchronously and as early as possible you should always check that the DOM is ready before initialising your client-side code. We recommend using the [ready-state] library which provides a promise-based interface for this:
 
 ```js
-import domLoaded from 'dom-loaded'
+import readyState from 'ready-state'
 
-domLoaded.then(() => {
+readyState.domready.then(() => {
   console.log('Ready!')
 })
 ```
 
-[dom-loaded]: https://github.com/sindresorhus/dom-loaded
+[ready-state]: https://www.npmjs.com/package/ready-state
 
 ### Server-side integration
 

--- a/scripts/generate-storybook-config.js
+++ b/scripts/generate-storybook-config.js
@@ -31,4 +31,3 @@ function prepareConfigFileContents(paths) {
     .readFileSync(TEMPLATE_FILE, { encoding: 'utf8' })
     .replace('/* PLACEHOLDER */', storiesContents)
 }
-


### PR DESCRIPTION
Fixes: https://github.com/Financial-Times/dotcom-page-kit/issues/740.

Once this PR is approved I will make the necessary changes in the migration docs: https://github.com/Financial-Times/dotcom-page-kit/wiki/Migrating-from-n%E2%80%93ui-to-Page-Kit.

@apaleslimghost Re. your [comment](https://github.com/Financial-Times/n-tracking/pull/39/files#r373430152) in this n-tracking PR:
- Should we also be using the `ready-state` package in that repo (or have Page Kit wrap it in a function that it can use)?
- Do we also need to identify which other apps that consume Page Kit likewise need this change applied?

#### New dependencies:
- [npm: ready-state](https://www.npmjs.com/package/ready-state).