### PR TITLE
Apply Prettier

### DIFF
--- a/examples/ft-ui/__test__/logged-in-user.test.js
+++ b/examples/ft-ui/__test__/logged-in-user.test.js
@@ -7,11 +7,12 @@ describe('examples/ft-ui', () => {
   describe('Header link elements', () => {
     it('renders the expected loggin-in user Header link elements', async () => {
       await expect(page).toMatchElement('.o-header__top-column--right a[href="/myft"]', { text: 'myFT' })
-      await expect(
-        page
-      ).toMatchElement('.o-header__nav-list--right a[href="https://myaccount.ft.com/details/core/view"]', {
-        text: 'Account Settings'
-      })
+      await expect(page).toMatchElement(
+        '.o-header__nav-list--right a[href="https://myaccount.ft.com/details/core/view"]',
+        {
+          text: 'Account Settings'
+        }
+      )
       await expect(
         page
       ).toMatchElement(

--- a/packages/dotcom-ui-layout/src/components/Layout.tsx
+++ b/packages/dotcom-ui-layout/src/components/Layout.tsx
@@ -80,9 +80,7 @@ export function Layout({
   }
 
   return (
-    <div
-      className={`n-layout ${fontLoadingClassNames.join(' ')}`}
-      data-o-component="o-typography">
+    <div className={`n-layout ${fontLoadingClassNames.join(' ')}`} data-o-component="o-typography">
       <EnhanceFonts />
       <a
         data-trackable="a11y-skip-to-help"

--- a/scripts/generate-storybook-config.js
+++ b/scripts/generate-storybook-config.js
@@ -27,8 +27,5 @@ function getPaths() {
 function prepareConfigFileContents(paths) {
   const storiesContents = paths.map((p) => `require('${p}')`).join('\n\t')
 
-  return fs
-    .readFileSync(TEMPLATE_FILE, { encoding: 'utf8' })
-    .replace('/* PLACEHOLDER */', storiesContents)
+  return fs.readFileSync(TEMPLATE_FILE, { encoding: 'utf8' }).replace('/* PLACEHOLDER */', storiesContents)
 }
-


### PR DESCRIPTION
I think these Prettification changes must have slipped through without the Git hook (that runs `npm run prettier`) being applied (i.e. commits made via GitHub GUI or commit made with `--no-verify`).

Each time I make a commit, `npm run prettier` gets run as the Git hook and I have to then remember to reset the changes it has applied to prevent them from being included in my next commit (where they would not be relevant to that specific commit).

So it seems to make sense to give them their own little commit here where they get applied and stop causing this problem.