### PR TITLE
change lint-staged rules to only format staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "lint-staged": {
     "**/*.{ts,tsx,js,jsx}": [
       "npm run test -- --no-cache --findRelatedTests",
-      "npm run prettier",
-      "npm run lint -- --fix",
+      "prettier --write",
+      "eslint --fix",
       "git add"
     ]
   },


### PR DESCRIPTION
previously, if files had slipped through without being formatted, they could be changed in later, unrelated commits, but not written to that commit by `git add`.

this makes sure that only the files staged in the commit get formatted, preventing changes to unrelated files going uncommitted.

this works because `lint-staged` passes the list of staged files as arguments to the commands.

see #748