### PR TITLE
Correct background-color for combined-hbs-jsx example

### DIFF
--- a/examples/combined-hbs-jsx/views/Home.jsx
+++ b/examples/combined-hbs-jsx/views/Home.jsx
@@ -21,7 +21,7 @@ export default function Home({ pageTitle }) {
   const myAssignedOutput = <Component title="This is JSX output" />
 
   return (
-    <div style={{ backgroundColor: '#FFF1EF', padding: '20px' }}>
+    <div style={{ backgroundColor: '#FFF1E5', padding: '20px' }}>
       <h1>{pageTitle}</h1>
       <p>This page has been rendered using JSX as the view engine</p>
 

--- a/examples/combined-hbs-jsx/views/home.hbs
+++ b/examples/combined-hbs-jsx/views/home.hbs
@@ -1,4 +1,4 @@
-<div style="background-color:#FFF1EF; padding:20px">
+<div style="background-color:#FFF1E5; padding:20px">
   <h1>{{pageTitle}}</h1>
   <p>This page has been rendered using Handlebars as the view engine</p>
 


### PR DESCRIPTION
#### Before (`jsx-to-hbs` example):
![before_3456_jsx-to-hbs](https://user-images.githubusercontent.com/10484515/74026535-4df84c80-499e-11ea-91e6-bc72cdc24cfa.png)

#### After (`jsx-to-hbs` example):
![after_jsx-to-hbs](https://user-images.githubusercontent.com/10484515/74026540-505aa680-499e-11ea-87a3-a6a9c1c19c36.png)

---

#### Before (`hbs-to-jsx` example):
![before_hbs-to-jsx](https://user-images.githubusercontent.com/10484515/74026536-4f297980-499e-11ea-88f1-6654ec131d5d.png)

#### After (`hbs-to-jsx` example):
![after_hbs-to-jsx](https://user-images.githubusercontent.com/10484515/74026538-4fc21000-499e-11ea-9a88-1d3b77a88bc4.png)

---

### Correct hexcode acquired from FT.com:
![Screenshot 2020-02-07 at 11 35 29](https://user-images.githubusercontent.com/10484515/74026596-708a6580-499e-11ea-94b9-68524d328b5f.png)