### PR TITLE
Enable MainHeader logo link to be switched off

### DIFF
--- a/packages/dotcom-ui-header/README.md
+++ b/packages/dotcom-ui-header/README.md
@@ -83,6 +83,8 @@ All header components with the exception of `<LogoOnly />` require the following
 
 The topmost element - or masthead - contains the logo, toggle buttons for the [drawer](#drawer) and search bar, and the MyFT indicator if logged in.
 
+By default the logo serves as a home page link, which can be deactivated by providing prop `showLogoLink: false`.
+
 ![Example header top element](./screenshots/header-top-search.png)
 
 _Please note_ that the myFT unread articles indicator code lives outside this package in [`n-myft-ui`].

--- a/packages/dotcom-ui-header/src/__stories__/story.tsx
+++ b/packages/dotcom-ui-header/src/__stories__/story.tsx
@@ -32,7 +32,8 @@ storiesOf('FT / Header', module)
       showUserNavigation: toggleUserStateOptions(),
       showMegaNav: toggleShowMegaNav(),
       userIsLoggedIn: toggleLoggedIn(),
-      currentPath: toggleMobileNav()
+      currentPath: toggleMobileNav(),
+      showLogoLink: toggleShowLogoLink()
     }
     storyData.data = { ...storyData.data, currentPath: toggleMobileNav() }
 

--- a/packages/dotcom-ui-header/src/index.tsx
+++ b/packages/dotcom-ui-header/src/index.tsx
@@ -45,7 +45,7 @@ function MainHeader(props: THeaderProps) {
       {includeUserActionsNav ? <UserActionsNav {...props} /> : null}
       <TopWrapper>
         <TopColumnLeft />
-        <TopColumnCenter />
+        {props.showLogoLink ? <TopColumnCenter /> : <TopColumnCenterNoLink />}
         <TopColumnRight />
       </TopWrapper>
       <Search instance="primary" />
@@ -59,7 +59,7 @@ function MainHeader(props: THeaderProps) {
   )
 }
 
-MainHeader.defaultProps = defaultProps
+MainHeader.defaultProps = { ...defaultProps, showLogoLink: true }
 
 function StickyHeader(props: THeaderProps) {
   return props.showStickyHeader ? (


### PR DESCRIPTION
Extension of work done in this PR https://github.com/Financial-Times/dotcom-page-kit/pull/741 to enable the link for the `MainHeader` component to be switched on/off as it can for the `LogoOnly` header.