### PR TITLE
Custom contexts

### DIFF
--- a/packages/dotcom-ui-app-context/src/__test__/AppContext.spec.ts
+++ b/packages/dotcom-ui-app-context/src/__test__/AppContext.spec.ts
@@ -8,7 +8,10 @@ const fakeContext = {
     product: 'next',
     abTestState: 'someCohort:on',
     isProduction: true
-  }
+  },
+  customContext1: undefined,
+  customContext2: null,
+  customContext3: {}
 }
 
 describe('dotcom-ui-app-context/src/client/AppContext', () => {

--- a/packages/dotcom-ui-app-context/src/__test__/loadAppContext.spec.ts
+++ b/packages/dotcom-ui-app-context/src/__test__/loadAppContext.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import subject from '../client/loadAppContext'
+import loadAppContext from '../client/loadAppContext'
 import AppContext from '../client/AppContext'
 
 describe('dotcom-ui-app-context/src/client/loadAppContext', () => {
@@ -26,7 +26,7 @@ describe('dotcom-ui-app-context/src/client/loadAppContext', () => {
     })
 
     it('processes multiple contexts', () => {
-      const allContexts = subject()
+      const allContexts = loadAppContext()
       const client = new AppContext(allContexts)
 
       expect(client.getAll()).toEqual({
@@ -40,7 +40,7 @@ describe('dotcom-ui-app-context/src/client/loadAppContext', () => {
     })
 
     it('returns a frozen object', () => {
-      const result = subject()
+      const result = loadAppContext()
 
       expect(result).toEqual({
         appContext: { appName: 'app-name', appVersion: '123' },
@@ -58,7 +58,7 @@ describe('dotcom-ui-app-context/src/client/loadAppContext', () => {
     })
 
     it('returns a frozen empty object', () => {
-      const result = subject()
+      const result = loadAppContext()
 
       expect(result).toEqual({})
       expect(Object.isFrozen(result)).toBe(true)

--- a/packages/dotcom-ui-app-context/src/__test__/loadAppContext.spec.ts
+++ b/packages/dotcom-ui-app-context/src/__test__/loadAppContext.spec.ts
@@ -3,19 +3,51 @@
  */
 
 import subject from '../client/loadAppContext'
+import AppContext from '../client/AppContext'
 
 describe('dotcom-ui-app-context/src/client/loadAppContext', () => {
   describe('when there is a configuration object', () => {
     beforeEach(() => {
       document.body.innerHTML = `
-        <script type="application/json" id="page-kit-app-context">{"appName":"app-name","appVersion":"123"}</script>
+        <script type="application/json" data-page-kit-context="appContext">
+          {"appName":"app-name","appVersion":"123"}
+        </script>
+        <script type="application/json" data-page-kit-context>
+        </script>
+        <script type="application/json" data-page-kit-context="custom1">
+          {"customValue":"custom-value-1","customData":["a", "b", "c"]}
+        </script>
+        <script type="application/json" data-page-kit-context="custom2">
+        </script>
+        <script type="application/json" data-page-kit-context="custom3">
+          {"customValue":"custom-value-3","customData":["d", "e", "f"]}
+        </script>
       `
+    })
+
+    it('processes multiple contexts', () => {
+      const allContexts = subject()
+      const client = new AppContext(allContexts)
+
+      expect(client.getAll()).toEqual({
+        appName: 'app-name',
+        appVersion: '123'
+      })
+      expect(allContexts.custom1).toEqual({
+        customData: ['a', 'b', 'c'],
+        customValue: 'custom-value-1'
+      })
     })
 
     it('returns a frozen object', () => {
       const result = subject()
 
-      expect(result).toEqual({ appName: 'app-name', appVersion: '123' })
+      expect(result).toEqual({
+        appContext: { appName: 'app-name', appVersion: '123' },
+        custom1: { customValue: 'custom-value-1', customData: ['a', 'b', 'c'] },
+        custom2: {},
+        custom3: { customValue: 'custom-value-3', customData: ['d', 'e', 'f'] }
+      })
       expect(Object.isFrozen(result)).toBe(true)
     })
   })

--- a/packages/dotcom-ui-app-context/src/__test__/loadAppContext.spec.ts
+++ b/packages/dotcom-ui-app-context/src/__test__/loadAppContext.spec.ts
@@ -12,7 +12,9 @@ describe('dotcom-ui-app-context/src/client/loadAppContext', () => {
         <script type="application/json" data-page-kit-context="appContext">
           {"appName":"app-name","appVersion":"123"}
         </script>
-        <script type="application/json" data-page-kit-context>
+        <script type="application/json" data-page-kit-context></script>
+        <script type="application/json" data-page-kit-context="empty"></script>
+        <script type="application/json" data-page-kit-context="whitespace">
         </script>
         <script type="application/json" data-page-kit-context="custom1">
           {"customValue":"custom-value-1","customData":["a", "b", "c"]}
@@ -44,6 +46,8 @@ describe('dotcom-ui-app-context/src/client/loadAppContext', () => {
 
       expect(result).toEqual({
         appContext: { appName: 'app-name', appVersion: '123' },
+        empty: {},
+        whitespace: {},
         custom1: { customValue: 'custom-value-1', customData: ['a', 'b', 'c'] },
         custom2: {},
         custom3: { customValue: 'custom-value-3', customData: ['d', 'e', 'f'] }

--- a/packages/dotcom-ui-app-context/src/client/browser.ts
+++ b/packages/dotcom-ui-app-context/src/client/browser.ts
@@ -2,10 +2,11 @@ import AppContext from './AppContext'
 import loadEmbeddedAppContext from './loadAppContext'
 
 export function init() {
-  const appContext = loadEmbeddedAppContext()
+  const { appContext, ...customContext } = loadEmbeddedAppContext()
   const client = new AppContext({ appContext })
 
   console.log('Page Kit app context:', client.getAll()) // eslint-disable-line no-console
+  console.log('Custom context:', Object.keys(customContext)) // eslint-disable-line no-console
 
   return client
 }

--- a/packages/dotcom-ui-app-context/src/client/loadAppContext.ts
+++ b/packages/dotcom-ui-app-context/src/client/loadAppContext.ts
@@ -1,18 +1,35 @@
+/*eslint no-console: ["error", { allow: ["error"] }] */
+
 import { TAppContext } from '../types'
-import { APP_CONTEXT_ELEMENT_ID } from '../constants'
 
-export default function loadEmbeddedAppContext(): TAppContext {
-  const elem = document.getElementById(APP_CONTEXT_ELEMENT_ID)
+function parseContent(el: HTMLElement) {
+  const id = el.dataset.pageKitContext
 
-  let data = {}
-
-  if (elem) {
-    try {
-      data = JSON.parse(elem.innerHTML)
-    } catch (error) {
-      console.error('Embedded app context could not be loaded:', error) // eslint-disable-line no-console
-    }
+  try {
+    const content = el.innerHTML.trim()
+    const json = content.length ? JSON.parse(content) : {}
+    return { id, json }
+  } catch (err) {
+    console.error(`Embedded context ${id} could not be loaded`, err)
+    return {}
   }
+}
 
-  return Object.freeze(data) as TAppContext
+type Context = {
+  appContext: TAppContext
+  [key: string]: {}
+}
+export default function loadEmbeddedAppContext(): Context {
+  const data: Context = { appContext: undefined }
+  const contextNodes = document.querySelectorAll('[data-page-kit-context]')
+
+  contextNodes.forEach((el: HTMLElement) => {
+    const { id, json } = parseContent(el)
+
+    if (id && json) {
+      data[id] = json
+    }
+  })
+
+  return Object.freeze(data)
 }


### PR DESCRIPTION
## What

This is a speculative PR to allow consuming apps to take advantage of PageKit's `AppContext` infrastructure.

## Why

Some apps (e.g. Globetrotter) are overloading `appContext` with their own properties in order to pass config options from server to client.

## How

The proposal is to expose AppContext's JSON embedding and retrieving features to additional custom slots.

**Criteria:**
- Minimal and non-invasive
- Backwards-compatibility