### PR TITLE
Use Dart Sass for Sass implementation

### DIFF
--- a/packages/dotcom-build-sass/README.md
+++ b/packages/dotcom-build-sass/README.md
@@ -68,7 +68,7 @@ Several [hooks](#hooks) are provided in order to access and modify the configura
 | Option            | Type     | Default | Description                                                        |
 |-------------------|----------|---------|--------------------------------------------------------------------|
 | `webpackImporter` | Boolean  | `false` | See https://github.com/webpack-contrib/sass-loader#webpackimporter |
-| `includePaths`    | String[] | `[]`    | See https://github.com/sass/node-sass/#includepaths                |
+| `includePaths`    | String[] | `[]`    | See https://sass-lang.com/documentation/js-api#includepaths        |
 
 
 ## Hooks

--- a/packages/dotcom-build-sass/package.json
+++ b/packages/dotcom-build-sass/package.json
@@ -25,9 +25,10 @@
     "css-loader": "^3.0.0",
     "cssnano": "^4.1.10",
     "dlv": "^1.1.3",
+    "fibers": "^4.0.2",
     "mini-css-extract-plugin": "^0.9.0",
-    "node-sass": "^4.12.0",
     "postcss-loader": "^3.0.0",
+    "sass": "^1.25.0",
     "sass-loader": "^8.0.0",
     "webpack-fix-style-only-entries": "^0.4.0"
   },

--- a/packages/dotcom-build-sass/package.json
+++ b/packages/dotcom-build-sass/package.json
@@ -25,7 +25,6 @@
     "css-loader": "^3.0.0",
     "cssnano": "^4.1.10",
     "dlv": "^1.1.3",
-    "fibers": "^4.0.2",
     "mini-css-extract-plugin": "^0.9.0",
     "postcss-loader": "^3.0.0",
     "sass": "^1.25.0",

--- a/packages/dotcom-build-sass/src/plugin.ts
+++ b/packages/dotcom-build-sass/src/plugin.ts
@@ -76,11 +76,14 @@ export function plugin(options: TPluginOptions = {}) {
       // This enables the use of enhanced-resolve for @import statements prefixed with ~
       // but we don't usually use this and disabling it can speed up builds by up to 20%.
       webpackImporter,
+      // Prefer `dart-sass`.
+      implementation: require('sass'),
       sassOptions: {
         // Disable formatting so that we don't spend time pretty printing
         outputStyle: 'compressed',
         // Enable Sass to @import source files from installed dependencies
-        includePaths: ['bower_components', 'node_modules', ...includePaths]
+        includePaths: ['bower_components', 'node_modules', ...includePaths],
+        fiber: require('fibers')
       }
     }
   }

--- a/packages/dotcom-build-sass/src/plugin.ts
+++ b/packages/dotcom-build-sass/src/plugin.ts
@@ -82,8 +82,7 @@ export function plugin(options: TPluginOptions = {}) {
         // Disable formatting so that we don't spend time pretty printing
         outputStyle: 'compressed',
         // Enable Sass to @import source files from installed dependencies
-        includePaths: ['bower_components', 'node_modules', ...includePaths],
-        fiber: require('fibers')
+        includePaths: ['bower_components', 'node_modules', ...includePaths]
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/Financial-Times/dotcom-page-kit/issues/678.

Switches from using LibSass to Dart Sass for Sass implementation.

Work was validated by running `npm run build` in `./examples/ft-ui` having added the below lines to its `/client/main.scss` file.

```scss
@if true {
  $not-already-defined: true !global;
}
```

Dart Sass throws a warning if a global variable is defined outside of global scope, which LibSass doesn't.

To ensure warnings are enabled you can add to the `main.scss` file the below line which outputs a warning.

```scss
@warn 'warning text';
```

#### Before (i.e. LibSass)
![before](https://user-images.githubusercontent.com/10484515/74751164-c5fb2800-5264-11ea-8642-826a1abb3e27.png)

---

#### Before (i.e. Dart Sass)
![after](https://user-images.githubusercontent.com/10484515/74751144-c1367400-5264-11ea-8ca2-248c149ff396.png)

#### TODO:
- Testing of this Page Kit branch with consuming apps to ensure that `n-` components are spec compliant.

- [x] `next-static`: https://github.com/Financial-Times/next-static/pull/134. 
- [x] `next-search-page`: no changes required.
- [x] `next-video-page`: no changes required.
- [x] `next-errors`: no changes required.
- [x] `next-epaper`: no changes required.
- [x] `next-tour-page`: https://github.com/Financial-Times/next-tour-page/pull/261.
- [x] `next-graphics-page`: https://github.com/Financial-Times/next-graphics-page/pull/249.
- [x] `next-profile`: https://github.com/Financial-Times/next-profile/pull/292.
- [x] `next-syn-list`: no changes required.
- [x] `next-product`: https://github.com/Financial-Times/next-product/pull/867.
- [x] `next-b2b-prospect`: no changes required.
- [x] `next-retention`: no changes required.
- [x] `next-subscribe`: no changes required.
- [x] `next-stream-page`: no changes required.
- [x] `next-front-page`: no changes required.
- [x] `next-myft-page`: no changes required.
- [x] `next-article`: https://github.com/Financial-Times/next-article/pull/3691.
- [x] `next-control-centre`: no changes required.

#### References:
- [Sass: Dart Sass](https://sass-lang.com/dart-sass).
- [GitHub: webpack-contrib/sass-loader - Options](https://github.com/webpack-contrib/sass-loader#user-content-options).