### PR TITLE
add server/templates to the list of directories to search for partials

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.2
+
+Add `server/templates` to the default list of Handlebar partial directories to search. The upcoming n-messaging-client release uses `server/templates` not `templates`.
+
 ## 0.6.1
 
 - Code splitting plugin: Tweaks code splitting to rules to ensure CSS modules are not included in output chunks

--- a/packages/dotcom-server-handlebars/src/PageKitHandlebars.ts
+++ b/packages/dotcom-server-handlebars/src/PageKitHandlebars.ts
@@ -55,8 +55,9 @@ const defaultOptions: TPageKitHandlebarsOptions = {
   partials: {},
   partialPaths: {
     './views/partials': '**/*.{hbs,html}',
-    './bower_components': '*/{templates,components,partials,views}/**/*.{hbs,html}',
-    './node_modules/@financial-times': '*/{templates,components,partials,views}/**/*.{hbs,html}'
+    './bower_components': '*/{templates,server/templates,components,partials,views}/**/*.{hbs,html}',
+    './node_modules/@financial-times':
+      '*/{templates,server/templates,components,partials,views}/**/*.{hbs,html}'
   }
 }
 


### PR DESCRIPTION
The upcoming n-messaging-client release uses `server/templates` not `templates`.