### PR TITLE
add missing react dependency to dotcom-server-handlebars

### DIFF
--- a/packages/dotcom-server-handlebars/package.json
+++ b/packages/dotcom-server-handlebars/package.json
@@ -22,7 +22,8 @@
     "dateformat": "^3.0.3",
     "glob": "^7.1.3",
     "handlebars": "^4.3.1",
-    "mixin-deep": "^2.0.0"
+    "mixin-deep": "^2.0.0",
+    "react": "^16.12.0"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/dotcom-server-handlebars/package.json
+++ b/packages/dotcom-server-handlebars/package.json
@@ -23,7 +23,8 @@
     "glob": "^7.1.3",
     "handlebars": "^4.3.1",
     "mixin-deep": "^2.0.0",
-    "react": "^16.12.0"
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "engines": {
     "node": ">= 12.0.0"


### PR DESCRIPTION
this is working as-is and not breaking tests because most things that depend on dotcom-server-handlebars also depend on one of the `dotcom-ui-` packages, which have `react` as a dependency, which gets flattened