### PR TITLE
Update unread-articles-indicator link

### DIFF
--- a/packages/dotcom-ui-header/README.md
+++ b/packages/dotcom-ui-header/README.md
@@ -89,7 +89,7 @@ By default the logo serves as a home page link, which can be deactivated by prov
 
 _Please note_ that the myFT unread articles indicator code lives outside this package in [`n-myft-ui`].
 
-[`n-myft-ui`]: https://github.com/Financial-Times/n-myft-ui/blob/master/components/unread-articles-indicator/index.js#L55
+[`n-myft-ui`]: https://github.com/Financial-Times/n-myft-ui/blob/master/components/unread-articles-indicator
 
 ### Navigation
 


### PR DESCRIPTION
We wrote a nice Readme for unread-articles-indicator so maybe it is better to link to the readme instead of a particular line?