### PR TITLE
Improve running examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "The aim of this project is to provide a high quality, well tested, and thoroughly documented, modern asset pipeline and application shell for Node.js applications based upon the latest industry standards.",
   "scripts": {
     "test": "jest",
-    "test:examples": "athloi run test --filter 'example-*'",
+    "test:examples": "jest --roots=examples",
+    "pretest:examples": "npm run build:examples",
     "build": "athloi run build --filter 'dotcom-*' --concurrency 10 --preserve-order",
     "build:examples": "athloi run build --filter 'example-*' --concurrency 10",
     "checktypes": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/core": "^7.8.0",
     "@babel/preset-react": "^7.8.0",
     "@babel/preset-typescript": "^7.8.0",
-    "@financial-times/athloi": "^1.0.0-beta.28",
+    "@financial-times/athloi": "^1.0.0",
     "@storybook/addon-knobs": "^5.3.12",
     "@storybook/addon-options": "^5.3.12",
     "@storybook/addon-viewport": "^5.3.12",


### PR DESCRIPTION
run jest directly from top level (overriding the `roots` option on the command line) instead of using athloi to iterate over every example and run jest in the subfolder. this makes the cli output nicer and is slightly faster (can use jest's parallel/async test running)