### PR TITLE
Remove `role="contentinfo"` from `o-footer` markup.

### DIFF
--- a/packages/dotcom-ui-footer/src/components/partials.tsx
+++ b/packages/dotcom-ui-footer/src/components/partials.tsx
@@ -91,7 +91,7 @@ const MoreFromFT = () => (
 const CopyrightNotice = ({ withoutMarketsData = false }) => {
   const marketsData = withoutMarketsData ? '' : 'Markets data delayed by at least 15 minutes. '
   return (
-    <div className="o-footer__copyright" role="contentinfo">
+    <div className="o-footer__copyright">
       <small>
         {`${marketsData}© THE FINANCIAL TIMES LTD ${new Date().getFullYear()}. `}
         <abbr title="Financial Times" aria-label="F T">


### PR DESCRIPTION
As o-footer already uses the `footer` element, this results in
two `contentinfo` landmarks. There **should** only be one.

Relates to: https://github.com/Financial-Times/o-footer/pull/128