### PR TITLE
Updating version of o-fonts-assets

### DIFF
--- a/packages/dotcom-ui-base-styles/src/lib/fontFaces.ts
+++ b/packages/dotcom-ui-base-styles/src/lib/fontFaces.ts
@@ -1,3 +1,5 @@
+// NOTE: please also update ./styles.css when updating the URLs defined below. They
+// need to stay in-sync to ensure our CSS output matches the resource hints we set.
 export const fontFaceURLs = [
   'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Regular.woff',
   'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Semibold.woff',

--- a/packages/dotcom-ui-base-styles/src/lib/fontFaces.ts
+++ b/packages/dotcom-ui-base-styles/src/lib/fontFaces.ts
@@ -1,6 +1,6 @@
 export const fontFaceURLs = [
-  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Regular.woff',
-  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Semibold.woff',
-  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Regular.woff',
-  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Bold.woff'
+  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Regular.woff',
+  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Semibold.woff',
+  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Regular.woff',
+  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Bold.woff'
 ]

--- a/packages/dotcom-ui-base-styles/styles.scss
+++ b/packages/dotcom-ui-base-styles/styles.scss
@@ -1,5 +1,9 @@
 $system-code: 'page-kit-base-styles' !default;
 
+// NOTE: please also update ./src/lib/fontFaces.ts when updating the URL below. They
+// need to stay in-sync to ensure our CSS output matches the resource hints we set.
+$o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/';
+
 // TODO: Migrate into this package existing usage of n-ui-foundations that
 // falls under definition of this package, with the intention of ideally
 // being able to decommission n-ui-foundations.

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -120,13 +120,6 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
       rel="preload"
       type="font/woff"
     />
-	<link
-      as="font"
-      crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Medium.woff"
-      rel="preload"
-      type="font/woff"
-    />
     <link
       as="font"
       crossOrigin="anonymous"

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -102,28 +102,35 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Regular.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Regular.woff"
       rel="preload"
       type="font/woff"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/MetricWeb-Semibold.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Semibold.woff"
       rel="preload"
       type="font/woff"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Regular.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Regular.woff"
+      rel="preload"
+      type="font/woff"
+    />
+	<link
+      as="font"
+      crossOrigin="anonymous"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Medium.woff"
       rel="preload"
       type="font/woff"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.3.2/FinancierDisplayWeb-Bold.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Bold.woff"
       rel="preload"
       type="font/woff"
     />


### PR DESCRIPTION
Origami team has recently updated fonts with a new font https://github.com/Financial-Times/o-fonts-assets/releases/tag/v1.4.0. Note that this PR isn't shipping any new fonts, only updating the o-asset-fonts links