### PR TITLE
NOPS-71: Hide subscribe sticky nav button when screen is small

### DIFF
--- a/packages/dotcom-ui-header/bower.json
+++ b/packages/dotcom-ui-header/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "dotcom-ui-header",
   "dependencies": {
-    "o-header": "^8.0.0",
+    "o-header": "^8.2.0",
     "n-topic-search": "^2.0.0",
     "n-ui-foundations": "^4.0.0-beta.2"
   },

--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -105,7 +105,7 @@ const NavListRightAnon = ({ items, variant }: { items: TNavMenuItem[]; variant?:
           {first.label}
         </a>
       </li>
-      <li className="o-header__nav-item">
+      <li className="o-header__nav-item o-header__nav-item--hide-s">
         <a
           className="o-header__nav-button"
           // Added as the result of a DAC audit. This will be confusing for users of voice activation software


### PR DESCRIPTION
## Summary
The nav items in the masthead are inline and still showing on small screens causing elements to run into each other. The subscribe button is now hidden on smaller screens.

I've tested this locally and got the desired result but would appreciate someone else testing as well to make sure

After:
<img width="335" alt="image" src="https://user-images.githubusercontent.com/21983479/79422357-a65a5480-7fb4-11ea-8b01-91dbb0b87821.png">

Before:
<img width="351" alt="incorrect_buttons_aligned_with_masthead" src="https://user-images.githubusercontent.com/21983479/78796978-fd599b80-79ae-11ea-8e16-23e9f65ab441.png">
