### PR TITLE
Remove tests which expect the length of a function

### DIFF
--- a/packages/dotcom-middleware-app-context/src/__test__/index.spec.ts
+++ b/packages/dotcom-middleware-app-context/src/__test__/index.spec.ts
@@ -34,7 +34,6 @@ describe('dotcom-middleware-app-context', () => {
 
   it('returns a request handler function', () => {
     expect(instance).toBeInstanceOf(Function)
-    expect(instance).toHaveLength(3)
   })
 
   describe('when handling a request', () => {

--- a/packages/dotcom-middleware-asset-loader/src/__test__/index.spec.ts
+++ b/packages/dotcom-middleware-asset-loader/src/__test__/index.spec.ts
@@ -21,7 +21,6 @@ describe('dotcom-middleware-asset-loader', () => {
 
     instanceWithStaticHost.forEach((item) => {
       expect(item).toBeInstanceOf(Function)
-      expect(item).toHaveLength(3)
     })
   })
 


### PR DESCRIPTION
Removes two test expectations which call `toHaveLength()` on Function values. 

I'm not sure what the original intention was but this usage is pretty unexpected (usually only strings and arrays have `length` properties) and it's not reflected in the examples given in the jest docs. https://jestjs.io/docs/en/expect#tohavelengthnumber

Both test conditions seem to be covered by remaining expectations so it should be safe to remove these. 