### PR TITLE
Fix middleware-navigation TypeScript errors

### DIFF
--- a/packages/dotcom-middleware-navigation/src/handleEdition.ts
+++ b/packages/dotcom-middleware-navigation/src/handleEdition.ts
@@ -11,8 +11,8 @@ export default (request: Request, response: Response): string => {
   // <https://github.com/Financial-Times/next-router/blob/master/server/middleware/editions.js>
   let currentEdition = request.get('FT-Edition') || defaultEdition
 
-  if (request.query.edition && isEdition(request.query.edition)) {
-    currentEdition = request.query.edition
+  if (request.query.edition && isEdition(request.query.edition as string)) {
+    currentEdition = request.query.edition as string
 
     response.cookie('next-edition', currentEdition, {
       domain: 'ft.com',

--- a/packages/dotcom-middleware-navigation/src/handleEdition.ts
+++ b/packages/dotcom-middleware-navigation/src/handleEdition.ts
@@ -11,8 +11,8 @@ export default (request: Request, response: Response): string => {
   // <https://github.com/Financial-Times/next-router/blob/master/server/middleware/editions.js>
   let currentEdition = request.get('FT-Edition') || defaultEdition
 
-  if (request.query.edition && isEdition(request.query.edition as string)) {
-    currentEdition = request.query.edition as string
+  if (typeof request.query.edition === 'string' && isEdition(request.query.edition)) {
+    currentEdition = request.query.edition
 
     response.cookie('next-edition', currentEdition, {
       domain: 'ft.com',


### PR DESCRIPTION
`next-control-centre`'s CircleCI build has a step that runs `make build-production`, which in turn runs TypeScript checks (`tsc`): https://github.com/Financial-Times/next-control-centre/blob/master/Makefile#L44.

These have started to fail; the reason why they have started now is unclear.

See: https://circleci.com/gh/Financial-Times/next-control-centre/4921.

```
node_modules/@financial-times/dotcom-middleware-navigation/src/handleEdition.ts:14:42 - error TS2345: Argument of type 'string | string[] | Query | Query[]' is not assignable to parameter of type 'string'.
  Type 'string[]' is not assignable to type 'string'.

14   if (request.query.edition && isEdition(request.query.edition)) {
                                            ~~~~~~~~~~~~~~~~~~~~~

node_modules/@financial-times/dotcom-middleware-navigation/src/handleEdition.ts:15:5 - error TS2322: Type 'string | string[] | Query | Query[]' is not assignable to type 'string'.
  Type 'string[]' is not assignable to type 'string'.

15     currentEdition = request.query.edition
```

These errors are also presented in the text editor:

<img width="1129" alt="Screenshot 2020-04-15 at 16 33 22" src="https://user-images.githubusercontent.com/10484515/79359144-1d063c00-7f3a-11ea-9434-27c661e64a78.png">

<img width="1131" alt="Screenshot 2020-04-15 at 16 35 25" src="https://user-images.githubusercontent.com/10484515/79359122-15469780-7f3a-11ea-9ba4-12c1f3ea1613.png">

The source of the errors are these lines:
- https://github.com/Financial-Times/dotcom-page-kit/blob/master/packages/dotcom-middleware-navigation/src/handleEdition.ts#L12-L15.
- https://github.com/Financial-Times/dotcom-page-kit/blob/master/packages/dotcom-server-navigation/src/editions.ts#L18

The [`dotcom-middleware-navigation`](https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-middleware-navigation) package uses [`@types/express`](https://github.com/types/express), specifically the [Request interface](https://github.com/types/express/blob/7670cf1cbce96b3159e3ff04a253926b34111220/lib/request.d.ts#L30), which has a nested interface of [`Request.query[queryParam: string]`](https://github.com/types/express/blob/7670cf1cbce96b3159e3ff04a253926b34111220/lib/request.d.ts#L131).

While this does not answer why `request.query.edition` is expected to be a type `string | Query | (string | Query)[]` (which I think means an array that contains strings, Query, or a mixture of the two), it does give us confidence to cast this value as a string (with `as string`), which is further reinforced by the expected type in the receiving [`isEdition` function](https://github.com/Financial-Times/dotcom-page-kit/blob/master/packages/dotcom-server-navigation/src/editions.ts#L18) to be a `string`.

I propose this gets released as a patch: 7.0.1.