### PR TITLE
Revert "Relocate LoadFontsEmbded prior to Stylesheets for minor performance optimisation"

### DIFF
--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -139,21 +139,6 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
     <script
       dangerouslySetInnerHTML={
         Object {
-          "__html": "(function loadCustomFonts() {
-    var rootElement = document.documentElement;
-    if (/(^|\\\\s)o-typography-fonts-loaded=1(;|$)/.test(document.cookie)) {
-        var fontLabels = ['sans', 'sans-bold', 'display', 'display-bold'];
-        for (var i = 0; i < fontLabels.length; i++) {
-            rootElement.className = rootElement.className.replace('o-typography--loading-' + fontLabels[i], '');
-        }
-    }
-}());",
-        }
-      }
-    />
-    <script
-      dangerouslySetInnerHTML={
-        Object {
           "__html": "{\\"trackErrors\\":true,\\"core\\":[\\"https://polyfill.io/v3/polyfill.min.js?features=HTMLPictureElement&source=next\\"],\\"enhanced\\":[\\"https://polyfill.io/v3/polyfill.min.js?features=default%2Ces5%2Ces2015%2Ces2016%2Ces2017%2CEventSource%2Cfetch%2CHTMLPictureElement%2CIntersectionObserver%2CNodeList.prototype.forEach&source=next\\"]}",
         }
       }
@@ -266,6 +251,21 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-NWQJW68');",
+        }
+      }
+    />
+    <script
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "(function loadCustomFonts() {
+    var rootElement = document.documentElement;
+    if (/(^|\\\\s)o-typography-fonts-loaded=1(;|$)/.test(document.cookie)) {
+        var fontLabels = ['sans', 'sans-bold', 'display', 'display-bold'];
+        for (var i = 0; i < fontLabels.length; i++) {
+            rootElement.className = rootElement.className.replace('o-typography--loading-' + fontLabels[i], '');
+        }
+    }
+}());",
         }
       }
     />

--- a/packages/dotcom-ui-shell/src/components/Shell.tsx
+++ b/packages/dotcom-ui-shell/src/components/Shell.tsx
@@ -60,7 +60,6 @@ function Shell(props: TShellProps) {
           type="application/json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(props.initialProps) }}
         />
-        <LoadFontsEmbed />
         <StyleSheets
           criticalStyles={props.criticalStyles}
           stylesheets={props.stylesheets}
@@ -68,6 +67,7 @@ function Shell(props: TShellProps) {
         />
         <Bootstrap {...bootstrapProps} />
         <GTMHead flags={props.flags} />
+        <LoadFontsEmbed />
       </head>
       <body {...formatAttributeNames(props.bodyAttributes)}>
         <GTMBody flags={props.flags} />


### PR DESCRIPTION
This causes a font loading race condition in Chrome that means sometimes,
although fonts have loaded, we don't remove the classes from the body,
so the fallback fonts are displayed.

This reverts commit 721eb24363a2a26d3809f993e2afd9c01c0bf63b.

https://financialtimes.atlassian.net/browse/NOPS-120