### PR TITLE
fix fonts loading

### DIFF
--- a/packages/dotcom-ui-layout/browser.js
+++ b/packages/dotcom-ui-layout/browser.js
@@ -1,6 +1,6 @@
 import * as footer from '@financial-times/dotcom-ui-footer/browser'
 import * as header from '@financial-times/dotcom-ui-header/browser'
-import * as baseStyles from '@financial-times/dotcom-ui-base-styles'
+import * as baseStyles from '@financial-times/dotcom-ui-base-styles/browser'
 // Polyfill for :focus-visible https://github.com/WICG/focus-visible
 // NOTE: v5 of this polyfill is not yet supported by o-normalise
 // https://github.com/WICG/focus-visible/pull/196/files

--- a/packages/dotcom-ui-layout/browser.js
+++ b/packages/dotcom-ui-layout/browser.js
@@ -1,6 +1,6 @@
 import * as footer from '@financial-times/dotcom-ui-footer/browser'
 import * as header from '@financial-times/dotcom-ui-header/browser'
-import oTypography from 'o-typography'
+import * as baseStyes from '@financial-times/dotcom-ui-base-styles'
 // Polyfill for :focus-visible https://github.com/WICG/focus-visible
 // NOTE: v5 of this polyfill is not yet supported by o-normalise
 // https://github.com/WICG/focus-visible/pull/196/files
@@ -8,7 +8,7 @@ import oTypography from 'o-typography'
 import 'focus-visible'
 
 export function init({ headerOptions = {}, footerOptions = {} } = {}) {
-  oTypography.init()
+  baseStyles.init()
   header.init(headerOptions)
   footer.init(footerOptions)
 }

--- a/packages/dotcom-ui-layout/browser.js
+++ b/packages/dotcom-ui-layout/browser.js
@@ -1,6 +1,6 @@
 import * as footer from '@financial-times/dotcom-ui-footer/browser'
 import * as header from '@financial-times/dotcom-ui-header/browser'
-import * as baseStyes from '@financial-times/dotcom-ui-base-styles'
+import * as baseStyles from '@financial-times/dotcom-ui-base-styles'
 // Polyfill for :focus-visible https://github.com/WICG/focus-visible
 // NOTE: v5 of this polyfill is not yet supported by o-normalise
 // https://github.com/WICG/focus-visible/pull/196/files

--- a/packages/dotcom-ui-layout/browser.js
+++ b/packages/dotcom-ui-layout/browser.js
@@ -8,8 +8,7 @@ import oTypography from 'o-typography'
 import 'focus-visible'
 
 export function init({ headerOptions = {}, footerOptions = {} } = {}) {
-  const rootElement = document.querySelector('.n-layout')
-  oTypography.init(rootElement)
+  oTypography.init()
   header.init(headerOptions)
   footer.init(footerOptions)
 }

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the enableGTM flag is on 1`] = `
 <html
   className="no-js core o-typography--loading-sans o-typography--loading-sans-bold o-typography--loading-display o-typography--loading-display-bold"
+  data-o-component="o-typography"
   lang="en-GB"
   style={
     Object {

--- a/packages/dotcom-ui-shell/src/components/Shell.tsx
+++ b/packages/dotcom-ui-shell/src/components/Shell.tsx
@@ -50,6 +50,7 @@ function Shell(props: TShellProps) {
       {...formatAttributeNames(props.htmlAttributes)}
       lang="en-GB"
       className={`no-js core ${loadCustomFontsClassNames}`}
+      data-o-component="o-typography"
       style={documentStyles}>
       <head>
         <DocumentHead {...props} />


### PR DESCRIPTION
welp. fun fact: font loading has never worked with Page Kit! "but bren," i hear you ask, "yes they have what the heck?", well:

- by default, we add font loading classes to the `<html>` element, which forces o-typography to use the fallback fonts while fonts load
- there's a separate bit of code to remove the loading classes if the fonts have already loaded; `o-typography` uses a cookie, `o-typography-fonts-loaded`, to signal this
- `dotcom-ui-layout`'s init calls `oTypography.init` on the `.n-layout` element. it's supposed to load the fonts and set the cookie, but it has no effect, because that element doesn't have `data-o-component="o-typography"` [any more](https://github.com/Financial-Times/dotcom-page-kit/pull/770/files#diff-b7d9d78266cd0478e141461d7d6f73a0L83)
- `dotcom-ui-base-style`'s init also calls `oTypography.init` on the default of `<html>`, but that doesn't have the `data-o-component` either, and also no apps actually use this `init`
- almost everybody already has the cookie! because fonts used to load just fine with, and they still have the cookie
- it's only now the cookie has started expiring for people, or in incognito, that people are seeing broken fonts
- previous attempts to fix this seemed to work because developers (me) had the cookie in their browser
- ~recent changes to font loading are a red herring, it's just a timing thing. this is why attempting to go back to a working version of an app didn't seem to do anything~

so, we fix it by calling `oTypography.init` with no args, so it defaults to `<html>`, and adding `data-o-component="o-typography"` to `<html>`

- [x] it's still a bit weird that both `dotcom-ui-layout` and `dotcom-ui-base-styles` call `oTypography.init`. should i update `dotcom-ui-layout` to call `dotcom-ui-base-styles` instead of `o-typography` directly? this would assume that every app using `dotcom-ui-layout` also uses `dotcom-ui-base-styles`