### PR TITLE
Maggie/update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Page Kit is not a single part but a set of packages which provide the different 
 
 ### 1. Compiling client-side assets
 
-Page Kit provides a CLI tool built upon Webpack and Babel which is capable of [transpiling], [bundling], and [optimising] client-side JavaScript code. The CLI tool can be configured and extended to suit your requirements and several plugins are provided which enable support for Sass, code splitting, and more.
+Page Kit provides Webpack and Babel configuration which is capable of [transpiling], [bundling], and [optimising] client-side JavaScript code. The config can be configured and extended to suit your requirements and several plugins are provided which enable support for Sass, code splitting, and more.
 
 [transpiling]: https://scotch.io/tutorials/javascript-transpilers-what-they-are-why-we-need-them
 [bundling]: https://nolanlawson.com/2017/05/22/a-brief-and-incomplete-history-of-javascript-bundlers/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Page Kit includes a set of packages which provide the markup, behaviour, and sty
 To get started with Page Kit, you'll need to make sure you have the following software tools installed.
 
 1. [Git](https://git-scm.com/)
-2. [Node.js](https://nodejs.org/en/) (version 8 or higher is required)
+2. [Node.js](https://nodejs.org/en/) (version 12 or higher is required)
 3. [npm](http://npmjs.com/)
 4. [GNU Parallel](https://www.gnu.org/software/parallel/) (Optional, for running parallel `watch` scripts)
 


### PR DESCRIPTION
Two small updates to Page Kit's top-level readme:

- Removes a reference to the deleted CLI tool in favour of generic Webpack
- Updates the required node version to `12`