### PR TITLE
Add customClass to footerOptions

### DIFF
--- a/packages/dotcom-ui-footer/README.md
+++ b/packages/dotcom-ui-footer/README.md
@@ -67,3 +67,4 @@ All variants require a props object to be passed to the footer component. The co
 | theme      | string  | 'dark'  | Serve the specified variant of the footer - the `light` theme is a valid alternative. |
 | legal-only | boolean | false   | Serve the shorter, 'legal-only' variant of the footer                                 |
 | data       | object  |         | Navigation data for rendering the footer links fetched from the navigation API        |
+| customClass | string | | Add a custom class to the footer element 

--- a/packages/dotcom-ui-footer/src/__stories__/story-data.ts
+++ b/packages/dotcom-ui-footer/src/__stories__/story-data.ts
@@ -16,7 +16,8 @@ const fixture: TFooterProps = {
     'navbar-simple': null,
     subsections: null,
     user: null
-  }
+  },
+  customClass: ''
 }
 
 export default fixture

--- a/packages/dotcom-ui-footer/src/__test__/component.spec.tsx
+++ b/packages/dotcom-ui-footer/src/__test__/component.spec.tsx
@@ -27,6 +27,14 @@ describe('dotcom-ui-footer', () => {
     expect(legalFooter.find('.o-footer__brand-logo')).toExist()
   })
 
+  it('renders a custom class on the footer', () => {
+    dataFixture.customClass = 'foo'
+    const footer = mount(<Footer {...dataFixture} />)
+    const legalFooter = mount(<Footer {...dataFixture} />)
+    expect(footer.find('.o-footer').hasClass('foo')).toBe(true)
+    expect(legalFooter.find('.o-footer').hasClass('foo')).toBe(true)
+  })
+
   describe('standard footer', () => {
     it('renders the navigation sections', () => {
       expect(footer).not.toBeEmptyRender()

--- a/packages/dotcom-ui-footer/src/index.tsx
+++ b/packages/dotcom-ui-footer/src/index.tsx
@@ -10,6 +10,7 @@ import {
 
 export type TFooterOptions = {
   theme?: 'dark' | 'light' | string
+  customClass?: string
 }
 
 export type TFooterProps = TFooterOptions & {
@@ -20,7 +21,10 @@ export function Footer(props: TFooterProps) {
   const footerData = props.data.footer.items
   const theme = props.theme ? `${props.theme}` : 'dark'
   return (
-    <footer id="site-footer" className={`o-footer o-footer--theme-${theme}`} data-o-component="o-footer">
+    <footer
+      id="site-footer"
+      className={`o-footer o-footer--theme-${theme} ${props.customClass}`}
+      data-o-component="o-footer">
       <div className="o-footer__container">
         <FooterContents footerData={footerData} />
         <MoreFromFT />
@@ -35,7 +39,10 @@ export function LegalFooter(props: TFooterProps) {
   const footerData = props.data.footer.items
   const theme = props.theme ? props.theme : 'dark'
   return (
-    <footer id="site-footer" className={`o-footer o-footer--theme-${theme}`} data-o-component="o-footer">
+    <footer
+      id="site-footer"
+      className={`o-footer o-footer--theme-${theme} ${props.customClass}`}
+      data-o-component="o-footer">
       <div className="o-footer__container">
         <CompressedLegal footerData={footerData} />
         <CopyrightNotice withoutMarketsData={true} />


### PR DESCRIPTION
This Pull Request adds a customClass option to footerOptions so that applications can pass this through layoutProps and have a class render on their footer.

Use case: in next-product we want to remove the top margin from the footer on a single page. 