### PR TITLE
add v0.8.x and v0.9.x releases to the roadmap

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -45,7 +45,15 @@
 ### v0.7.0
 
 - Webpack configuration refactor and CLI tool removed.
-- Initial changes based on RUM performance data
+- Initial changes based on RUM performance data.
+
+### v0.8.0
+
+- Refactor sharing data between the server and client into a new package.
+
+### v0.9.0
+
+- Implement uploading static assets via Page Kit.
 
 ### v1.0.0
 


### PR DESCRIPTION
Updates the roadmap with the remaining significant changes that we plan to make ahead of our first stable v1.x.x release. 