### PR TITLE
Add `dotcom-ui-data-embed`

### DIFF
--- a/examples/kitchen-sink/__test__/integration.test.js
+++ b/examples/kitchen-sink/__test__/integration.test.js
@@ -54,4 +54,8 @@ describe('examples/kitchen-sink/integration', () => {
   it('renders app context data as embedded JSON', () => {
     expect(response.text).toContain('<script type="application/json" id="page-kit-app-context">')
   })
+
+  it('renders data embed data as embedded JSON', () => {
+    expect(response.text).toContain('<script type="application/json" id="data-embed">')
+  })
 })

--- a/examples/kitchen-sink/client/main.js
+++ b/examples/kitchen-sink/client/main.js
@@ -2,12 +2,18 @@ import readyState from 'ready-state'
 import * as flags from '@financial-times/dotcom-ui-flags'
 import * as layout from '@financial-times/dotcom-ui-layout'
 import * as appContext from '@financial-times/dotcom-ui-app-context'
+import * as dataEmbed from '@financial-times/dotcom-ui-data-embed'
 import * as tracking from '@financial-times/n-tracking'
 import * as ads from '@financial-times/n-ads'
+
+import { DATA_EMBED_ID } from '../constants.js'
 
 readyState.domready.then(() => {
   const flagsClient = flags.init()
   const appContextClient = appContext.init()
+  const dataEmbedClient = dataEmbed.init({ id: DATA_EMBED_ID })
+
+  console.log('Shared data', dataEmbedClient.getAll()) // eslint-disable-line no-console
 
   layout.init()
 

--- a/examples/kitchen-sink/constants.js
+++ b/examples/kitchen-sink/constants.js
@@ -1,0 +1,1 @@
+export const DATA_EMBED_ID = 'data-embed'

--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -15,6 +15,7 @@
     "@financial-times/dotcom-middleware-asset-loader": "file:../../packages/dotcom-middleware-asset-loader",
     "@financial-times/dotcom-middleware-navigation": "file:../../packages/dotcom-middleware-navigation",
     "@financial-times/dotcom-ui-app-context": "file:../../packages/dotcom-ui-app-context",
+    "@financial-times/dotcom-ui-data-embed": "file:../../packages/dotcom-ui-data-embed",
     "@financial-times/dotcom-ui-flags": "file:../../packages/dotcom-ui-flags",
     "@financial-times/dotcom-ui-layout": "file:../../packages/dotcom-ui-layout",
     "@financial-times/dotcom-ui-shell": "file:../../packages/dotcom-ui-shell",

--- a/examples/kitchen-sink/server/app.js
+++ b/examples/kitchen-sink/server/app.js
@@ -11,6 +11,12 @@ app.use(
   appContext.init({ appContext: { appName: 'kitchen-sink' } })
 )
 
+// Embed custom data into every view
+app.use((request, response, next) => {
+  response.locals.embeddedData = { foo: true, bar: 'qux' }
+  next()
+})
+
 app.get('/', require('./controllers/home'))
 
 module.exports = app

--- a/examples/kitchen-sink/server/controllers/home.js
+++ b/examples/kitchen-sink/server/controllers/home.js
@@ -1,13 +1,16 @@
 const React = require('react')
 const ReactDOM = require('react-dom/server')
+const { DataEmbed } = require('@financial-times/dotcom-ui-data-embed')
 const { Shell } = require('@financial-times/dotcom-ui-shell')
 const { Layout } = require('@financial-times/dotcom-ui-layout')
 const { Slot, AdsOptionsEmbed } = require('@financial-times/n-ads')
 
+const { DATA_EMBED_ID } = require('../../constants.js')
+
 module.exports = (_, response, next) => {
   try {
     const flags = { ads: true, tracking: true }
-    const { appContext, assetLoader } = response.locals
+    const { appContext, assetLoader, embeddedData } = response.locals
     const styleBundles = [
       ...assetLoader.getStylesheetURLsFor('page-kit-layout-styles'),
       ...assetLoader.getStylesheetURLsFor('styles')
@@ -64,6 +67,7 @@ module.exports = (_, response, next) => {
             </section>
           </div>
         </Layout>
+        <DataEmbed id={DATA_EMBED_ID} data={embeddedData} />
       </Shell>
     )
 

--- a/packages/dotcom-server-app-context/README.md
+++ b/packages/dotcom-server-app-context/README.md
@@ -4,7 +4,7 @@ This package provides tools to define FT app context data and a [JSON schema] de
 
 To learn more about why this feature exists please review the [design document]. To find out which properties can be defined please refer to the [app context schema].
 
-_Please note_ that all app context properties will be appended to every tracking event sent to Spoor. For this reason it is very important not to pollute the schema.
+If you want to share application specific data with the client, consider using [@financial-times/dotcom-ui-data-embed](../dotcom-ui-data-embed).
 
 [JSON schema]: https://json-schema.org/
 [design document]: ../../docs/design-decisions/app-context.md

--- a/packages/dotcom-server-app-context/src/__test__/validate.spec.ts
+++ b/packages/dotcom-server-app-context/src/__test__/validate.spec.ts
@@ -13,7 +13,8 @@ describe('dotcom-server-app-context/src/validate', () => {
 
   it('throws an error when given an unknown property/value', () => {
     expect(() => subject('thisProperty', 'isNotInTheSchema')).toThrow(
-      'Validation error: data should NOT have additional properties, received "isNotInTheSchema"'
+      'Validation error: data should NOT have additional properties, received "isNotInTheSchema"' +
+        '\nIf you want to share application specific data with the client, consider using @financial-times/dotcom-ui-data-embed.'
     )
   })
 })

--- a/packages/dotcom-server-app-context/src/validate.ts
+++ b/packages/dotcom-server-app-context/src/validate.ts
@@ -11,6 +11,14 @@ export default function validate(field: string, value): boolean {
   if (isValid(data)) {
     return true
   } else {
-    throw Error(`Validation error: ${ajv.errorsText(isValid.errors)}, received "${value}"`)
+    let errorMessage = `Validation error: ${ajv.errorsText(isValid.errors)}, received "${value}"`
+    const hasErrorsForAdditionProperties = isValid.errors.some(
+      (error) => error.keyword === 'additionalProperties'
+    )
+    if (hasErrorsForAdditionProperties) {
+      errorMessage +=
+        '\nIf you want to share application specific data with the client, consider using @financial-times/dotcom-ui-data-embed.'
+    }
+    throw Error(errorMessage)
   }
 }

--- a/packages/dotcom-ui-app-context/README.md
+++ b/packages/dotcom-ui-app-context/README.md
@@ -4,6 +4,7 @@ This package provides methods for embedding [app context data] into your server-
 
 [app context data]: ../dotcom-server-app-context/schema.md
 
+If you want to share application specific data with the client, consider using [@financial-times/dotcom-ui-data-embed](../dotcom-ui-data-embed).
 
 ## Getting started
 

--- a/packages/dotcom-ui-app-context/package.json
+++ b/packages/dotcom-ui-app-context/package.json
@@ -29,5 +29,7 @@
     "directory": "packages/dotcom-ui-app-context"
   },
   "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-ui-app-context",
-  "dependencies": {}
+  "dependencies": {
+    "@financial-times/dotcom-ui-data-embed": "file:../dotcom-ui-data-embed"
+  }
 }

--- a/packages/dotcom-ui-app-context/src/client/loadAppContext.ts
+++ b/packages/dotcom-ui-app-context/src/client/loadAppContext.ts
@@ -1,18 +1,7 @@
+import { loadDataEmbed } from '@financial-times/dotcom-ui-data-embed'
 import { TAppContext } from '../types'
 import { APP_CONTEXT_ELEMENT_ID } from '../constants'
 
 export default function loadEmbeddedAppContext(): TAppContext {
-  const elem = document.getElementById(APP_CONTEXT_ELEMENT_ID)
-
-  let data = {}
-
-  if (elem) {
-    try {
-      data = JSON.parse(elem.innerHTML)
-    } catch (error) {
-      console.error('Embedded app context could not be loaded:', error) // eslint-disable-line no-console
-    }
-  }
-
-  return Object.freeze(data) as TAppContext
+  return loadDataEmbed(APP_CONTEXT_ELEMENT_ID) as TAppContext
 }

--- a/packages/dotcom-ui-app-context/src/components/AppContextEmbed.ts
+++ b/packages/dotcom-ui-app-context/src/components/AppContextEmbed.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import { DataEmbed } from '@financial-times/dotcom-ui-data-embed'
 import { TAppContext } from '../types'
 import { APP_CONTEXT_ELEMENT_ID } from '../constants'
 
@@ -7,11 +7,5 @@ export type TAppContextProps = {
 }
 
 export function AppContextEmbed({ appContext }: TAppContextProps) {
-  return (
-    <script
-      type="application/json"
-      id={APP_CONTEXT_ELEMENT_ID}
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(appContext) }}
-    />
-  )
+  return DataEmbed({ id: APP_CONTEXT_ELEMENT_ID, data: appContext })
 }

--- a/packages/dotcom-ui-data-embed/.npmignore
+++ b/packages/dotcom-ui-data-embed/.npmignore
@@ -1,0 +1,6 @@
+**/__fixtures__/**
+**/__stories__/**
+**/__test__/**
+**/__tests__/**
+tsconfig.json
+*.tsbuildinfo

--- a/packages/dotcom-ui-data-embed/.npmrc
+++ b/packages/dotcom-ui-data-embed/.npmrc
@@ -1,0 +1,2 @@
+package-lock=false
+shrinkwrap=false

--- a/packages/dotcom-ui-data-embed/README.md
+++ b/packages/dotcom-ui-data-embed/README.md
@@ -1,0 +1,3 @@
+# @financial-times/dotcom-ui-data-embed
+
+This package provides methods for putting data into your server-side rendered pages and safely retrieving it again in the browser.

--- a/packages/dotcom-ui-data-embed/README.md
+++ b/packages/dotcom-ui-data-embed/README.md
@@ -1,3 +1,89 @@
 # @financial-times/dotcom-ui-data-embed
 
 This package provides methods for putting data into your server-side rendered pages and safely retrieving it again in the browser.
+
+## Getting started
+
+This package is compatible with Node 12+ and is distributed on npm.
+
+```sh
+npm install --save @financial-times/dotcom-ui-data-embed
+```
+
+After installing the package you can use it to embed data into your pages on the server-side. This data can then be retrieved and used in your client-side code.
+
+### Server-side integration
+
+If you are using React to render your app you can use the `DataEmbed` component to integrate the data embed data with your pages:
+
+```jsx
+import { DataEmbed } from '@financial-times/dotcom-ui-data-embed'
+const DATA_EMBED_ID = 'data-embed'
+const data = { property: 'value', secondProperty: 'second-value' }
+
+export default (props) => (
+  <html>
+    <head>
+      <meta charSet="utf-8" />
+      <title>My Amazing Website</title>
+      <DataEmbed id={DATA_EMBED_ID} data={data} />
+    </head>
+    <body>
+      ...
+    </body>
+  </html>
+)
+```
+
+Otherwise you can insert a JSON formatted string into a `<script>` element with an ID of `data-embed`.
+
+```html
+<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <title>My Amazing Website</title>
+        <script type="application/json" id="data-embed">
+        {"property":"value","secondProperty":"second-value"}
+        </script>
+    </head>
+    <body>
+        ...
+    </body>
+</html>
+```
+
+### Client-side integration
+
+Once you have data embedded in your page you can use the [data embed client](#client-side-api) in your client-side code. The client provides methods for safely retrieving data.
+
+```js
+import * as dataEmbed from '@financial-times/dotcom-ui-data-embed'
+
+const dataEmbedClient = dataEmbed.init({ id: 'data-embed' })
+
+if (dataEmbedClient.get('property')) {
+  ...
+}
+```
+
+## Client-side API
+
+### `init({ id }:{ id: string })`
+
+Initialises and returns a new [data embed client](#data-embed-client-api) which can be used to safely access the status of individual contexts.
+
+This method requires an `id` parameter within an options object.
+This `id` should match the `id` attribute on the embed element within the page.
+
+## Data Embed Client API
+
+### `get(property: string)`
+
+Returns the value of the requested property. If the property is not found this will return `undefined`.
+
+### `getAll()`
+
+Returns all data embed data.
+
+_Please note_ that the data returned is frozen so it cannot be modified.

--- a/packages/dotcom-ui-data-embed/README.md
+++ b/packages/dotcom-ui-data-embed/README.md
@@ -71,7 +71,7 @@ if (dataEmbedClient.get('property')) {
 
 ### `init({ id }:{ id: string })`
 
-Initialises and returns a new [data embed client](#data-embed-client-api) which can be used to safely access the status of individual contexts.
+Initialises and returns a new [data embed client](#data-embed-client-api) which can be used to safely access the data.
 
 This method requires an `id` parameter within an options object.
 This `id` should match the `id` attribute on the embed element within the page.

--- a/packages/dotcom-ui-data-embed/browser.js
+++ b/packages/dotcom-ui-data-embed/browser.js
@@ -1,0 +1,1 @@
+export * from './dist/browser/client/index'

--- a/packages/dotcom-ui-data-embed/component.js
+++ b/packages/dotcom-ui-data-embed/component.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/node/index')

--- a/packages/dotcom-ui-data-embed/package.json
+++ b/packages/dotcom-ui-data-embed/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@financial-times/dotcom-ui-data-embed",
+  "version": "0.0.0",
+  "description": "",
+  "main": "component.js",
+  "browser": "browser.js",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "tsc": "../../node_modules/.bin/tsc --incremental",
+    "clean": "npm run clean:dist && npm run clean:node_modules",
+    "clean:dist": "rm -rf dist",
+    "clean:node_modules": "rm -rf node_modules",
+    "clean:install": "npm run clean && npm i",
+    "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
+    "build:browser": "npm run tsc -- --module es2015 --outDir ./dist/browser",
+    "build": "npm run build:node && npm run build:browser",
+    "dev": "echo -n node browser | parallel -u -d ' ' npm run build:{} -- --watch"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 12.0.0"
+  },
+  "peerDependencies": {
+    "react": "^16.8.6"
+  },
+  "repository": {
+    "type": "git",
+    "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
+    "directory": "packages/dotcom-ui-data-embed"
+  },
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-ui-data-embed",
+  "devDependencies": {}
+}

--- a/packages/dotcom-ui-data-embed/src/__test__/client/DataEmbedStore.spec.ts
+++ b/packages/dotcom-ui-data-embed/src/__test__/client/DataEmbedStore.spec.ts
@@ -20,7 +20,7 @@ describe('dotcom-ui-data-embed/src/client/DataEmbedStore', () => {
       expect(instance.get('baz')).toBe('qux')
     })
 
-    it('returns undefined for contexts which do not exist', () => {
+    it('returns undefined for properties that do not exist', () => {
       expect(instance.get('buzz')).toBeUndefined()
     })
   })

--- a/packages/dotcom-ui-data-embed/src/__test__/client/DataEmbedStore.spec.ts
+++ b/packages/dotcom-ui-data-embed/src/__test__/client/DataEmbedStore.spec.ts
@@ -1,0 +1,37 @@
+import subject from '../../client/DataEmbedStore'
+
+const fakeData = {
+  foo: 1,
+  bar: true,
+  baz: 'qux'
+}
+
+describe('dotcom-ui-data-embed/src/client/DataEmbedStore', () => {
+  let instance
+
+  beforeEach(() => {
+    instance = new subject(fakeData)
+  })
+
+  describe('.get()', () => {
+    it('returns the value of an existing data', () => {
+      expect(instance.get('foo')).toBe(1)
+      expect(instance.get('bar')).toBe(true)
+      expect(instance.get('baz')).toBe('qux')
+    })
+
+    it('returns undefined for contexts which do not exist', () => {
+      expect(instance.get('buzz')).toBeUndefined()
+    })
+  })
+
+  describe('.getAll()', () => {
+    it('returns all data', () => {
+      expect(instance.getAll()).toEqual(fakeData)
+    })
+
+    it('freezes the data', () => {
+      expect(Object.isFrozen(instance.getAll())).toBe(true)
+    })
+  })
+})

--- a/packages/dotcom-ui-data-embed/src/__test__/client/index.spec.ts
+++ b/packages/dotcom-ui-data-embed/src/__test__/client/index.spec.ts
@@ -1,0 +1,16 @@
+import { init as subject } from '../../client'
+import loadDataEmbed from '../../client/loadDataEmbed'
+import DataEmbedStore from '../../client/DataEmbedStore'
+jest.mock('../../client/loadDataEmbed.ts')
+jest.mock('../../client/DataEmbedStore.ts')
+
+describe('dotcom-ui-data-embed/src/client/index', () => {
+  describe('.init()', () => {
+    it('returns the value of an existing data embed store', () => {
+      const result = subject({ id: 'data-embed' })
+      expect(result).toBeInstanceOf(DataEmbedStore)
+      expect(loadDataEmbed).toBeCalledWith('data-embed')
+      expect(DataEmbedStore).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/dotcom-ui-data-embed/src/__test__/client/loadDataEmbed.spec.ts
+++ b/packages/dotcom-ui-data-embed/src/__test__/client/loadDataEmbed.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import subject from '../../client/loadDataEmbed'
+const SCRIPT_ELEMENT_ID = 'data-embed'
+
+describe('dotcom-ui-data-embed/src/client/loadDataEmbed', () => {
+  describe('when there is a configuration object', () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <script id="${SCRIPT_ELEMENT_ID}">{"foo":1,"bar":true,"baz":"qux"}</script>
+      `
+    })
+
+    it('returns a frozen object', () => {
+      const result = subject(SCRIPT_ELEMENT_ID)
+
+      expect(result).toEqual({ foo: 1, bar: true, baz: 'qux' })
+      expect(Object.isFrozen(result)).toBe(true)
+    })
+  })
+
+  describe('when there is no a configuration object', () => {
+    beforeEach(() => {
+      document.body.innerHTML = ''
+    })
+
+    it('returns a frozen empty object', () => {
+      const result = subject(SCRIPT_ELEMENT_ID)
+
+      expect(result).toEqual({})
+      expect(Object.isFrozen(result)).toBe(true)
+    })
+  })
+})

--- a/packages/dotcom-ui-data-embed/src/__test__/components/DataEmbed.spec.ts
+++ b/packages/dotcom-ui-data-embed/src/__test__/components/DataEmbed.spec.ts
@@ -1,0 +1,18 @@
+import renderer from 'react-test-renderer'
+import { DataEmbed as subject } from '../../components/DataEmbed'
+
+const data = {
+  id: 'data-embed',
+  data: {
+    foo: 1,
+    bar: true,
+    baz: 'qux'
+  }
+}
+
+describe('dotcom-ui-data-embed/src/components/dataEmbed', () => {
+  it('renders a script element containing data', () => {
+    const tree = renderer.create(subject(data))
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/packages/dotcom-ui-data-embed/src/__test__/components/__snapshots__/DataEmbed.spec.ts.snap
+++ b/packages/dotcom-ui-data-embed/src/__test__/components/__snapshots__/DataEmbed.spec.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dotcom-ui-data-embed/src/components/dataEmbed renders a script element containing data 1`] = `
+<script
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "{\\"foo\\":1,\\"bar\\":true,\\"baz\\":\\"qux\\"}",
+    }
+  }
+  id="data-embed"
+  type="application/json"
+/>
+`;

--- a/packages/dotcom-ui-data-embed/src/client/DataEmbedStore.ts
+++ b/packages/dotcom-ui-data-embed/src/client/DataEmbedStore.ts
@@ -1,0 +1,15 @@
+export default class DataEmbedStore {
+  private data
+
+  constructor(data) {
+    this.data = Object.freeze(data)
+  }
+
+  get(key: string) {
+    return this.data.hasOwnProperty(key) ? this.data[key] : undefined
+  }
+
+  getAll() {
+    return this.data
+  }
+}

--- a/packages/dotcom-ui-data-embed/src/client/index.ts
+++ b/packages/dotcom-ui-data-embed/src/client/index.ts
@@ -1,3 +1,9 @@
 import loadDataEmbed from './loadDataEmbed'
+import DataEmbedStore from './DataEmbedStore'
 
-export { loadDataEmbed }
+const init = ({ id }: { id: string }) => {
+  const data = loadDataEmbed(id)
+  return new DataEmbedStore(data)
+}
+
+export { loadDataEmbed, init }

--- a/packages/dotcom-ui-data-embed/src/client/index.ts
+++ b/packages/dotcom-ui-data-embed/src/client/index.ts
@@ -1,2 +1,3 @@
-const noop = () => {}
-export { noop }
+import loadDataEmbed from './loadDataEmbed'
+
+export { loadDataEmbed }

--- a/packages/dotcom-ui-data-embed/src/client/index.ts
+++ b/packages/dotcom-ui-data-embed/src/client/index.ts
@@ -1,0 +1,2 @@
+const noop = () => {}
+export { noop }

--- a/packages/dotcom-ui-data-embed/src/client/loadDataEmbed.ts
+++ b/packages/dotcom-ui-data-embed/src/client/loadDataEmbed.ts
@@ -1,0 +1,15 @@
+export default function loadDataEmbed(id: string) {
+  const dataEmbedElement = document.getElementById(id)
+
+  let data = {}
+
+  if (dataEmbedElement) {
+    try {
+      data = JSON.parse(dataEmbedElement.innerHTML)
+    } catch (error) {
+      console.error('Data embed error', error) // eslint-disable-line no-console
+    }
+  }
+
+  return Object.freeze(data)
+}

--- a/packages/dotcom-ui-data-embed/src/components/DataEmbed.tsx
+++ b/packages/dotcom-ui-data-embed/src/components/DataEmbed.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function DataEmbed({ id, data }: { id: string; data: object }) {
+  return <script type="application/json" id={id} dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
+}

--- a/packages/dotcom-ui-data-embed/src/index.ts
+++ b/packages/dotcom-ui-data-embed/src/index.ts
@@ -1,0 +1,1 @@
+export * from './client'

--- a/packages/dotcom-ui-data-embed/src/index.ts
+++ b/packages/dotcom-ui-data-embed/src/index.ts
@@ -1,1 +1,2 @@
+export * from './components/DataEmbed'
 export * from './client'

--- a/packages/dotcom-ui-data-embed/tsconfig.json
+++ b/packages/dotcom-ui-data-embed/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "rootDir": "./src/",
+  "extends": "../../tsconfig.json"
+}

--- a/packages/dotcom-ui-flags/package.json
+++ b/packages/dotcom-ui-flags/package.json
@@ -23,6 +23,9 @@
   "engines": {
     "node": ">= 12.0.0"
   },
+  "dependencies": {
+    "@financial-times/dotcom-ui-data-embed": "file:../dotcom-ui-data-embed"
+  },
   "peerDependencies": {
     "react": "^16.8.6"
   },

--- a/packages/dotcom-ui-flags/src/__test__/components/FlagsEmbed.spec.ts
+++ b/packages/dotcom-ui-flags/src/__test__/components/FlagsEmbed.spec.ts
@@ -1,0 +1,14 @@
+import renderer from 'react-test-renderer'
+import { FlagsEmbed as subject } from '../../components/FlagsEmbed'
+
+const flags = {
+  foo: 1,
+  baz: 'qux'
+}
+
+describe('dotcom-ui-flags/src/components/FlagsEmbed', () => {
+  it('renders a script element containing flags', () => {
+    const tree = renderer.create(subject({ flags }))
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/packages/dotcom-ui-flags/src/__test__/components/__snapshots__/FlagsEmbed.spec.ts.snap
+++ b/packages/dotcom-ui-flags/src/__test__/components/__snapshots__/FlagsEmbed.spec.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dotcom-ui-flags/src/components/FlagsEmbed renders a script element containing flags 1`] = `
+<script
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "{\\"foo\\":1,\\"baz\\":\\"qux\\"}",
+    }
+  }
+  id="page-kit-flags-embed"
+  type="application/json"
+/>
+`;

--- a/packages/dotcom-ui-flags/src/__test__/server/formatFlagsJSON.spec.ts
+++ b/packages/dotcom-ui-flags/src/__test__/server/formatFlagsJSON.spec.ts
@@ -3,14 +3,8 @@ import subject from '../../server/formatFlagsJSON'
 const fixture = Object.freeze({ foo: 1, bar: false, baz: 'qux' })
 
 describe('dotcom-ui-flags/src/server/formatFlagsJSON', () => {
-  it('returns a stringified object', () => {
-    const result = subject(fixture)
-    // NOTE: '' !== String('')
-    expect(typeof result === 'string').toBe(true)
-  })
-
   it('filters out properties with falsey values', () => {
     const result = subject(fixture)
-    expect(result).toBe('{"foo":1,"baz":"qux"}')
+    expect(result).toStrictEqual({ foo: 1, baz: 'qux' })
   })
 })

--- a/packages/dotcom-ui-flags/src/client/Flags.ts
+++ b/packages/dotcom-ui-flags/src/client/Flags.ts
@@ -2,7 +2,6 @@ import { TFlagsData, TFlag } from '../types'
 
 export default class Flags {
   private flags: TFlagsData
-
   constructor(flags: TFlagsData) {
     this.flags = Object.freeze(flags)
   }

--- a/packages/dotcom-ui-flags/src/client/loadFlags.ts
+++ b/packages/dotcom-ui-flags/src/client/loadFlags.ts
@@ -1,18 +1,7 @@
+import { loadDataEmbed } from '@financial-times/dotcom-ui-data-embed'
 import { TFlagsData } from '../types'
 import { SCRIPT_ELEMENT_ID } from '../constants'
 
 export default function loadFlags(): TFlagsData {
-  const flagsConfigEl = document.getElementById(SCRIPT_ELEMENT_ID)
-
-  let data = {}
-
-  if (flagsConfigEl) {
-    try {
-      data = JSON.parse(flagsConfigEl.innerHTML)
-    } catch (error) {
-      console.error('Flags configuration error', error) // eslint-disable-line no-console
-    }
-  }
-
-  return Object.freeze(data)
+  return loadDataEmbed(SCRIPT_ELEMENT_ID)
 }

--- a/packages/dotcom-ui-flags/src/components/FlagsEmbed.ts
+++ b/packages/dotcom-ui-flags/src/components/FlagsEmbed.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import { DataEmbed } from '@financial-times/dotcom-ui-data-embed'
 import { formatFlagsJSON } from '../server'
 import { TFlagsData } from '../types'
 import { SCRIPT_ELEMENT_ID } from '../constants'
@@ -8,13 +8,7 @@ type TFlagsEmbedProps = {
 }
 
 function FlagsEmbed({ flags }: TFlagsEmbedProps) {
-  return (
-    <script
-      type="application/json"
-      id={SCRIPT_ELEMENT_ID}
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(formatFlagsJSON(flags)) }}
-    />
-  )
+  return DataEmbed({ id: SCRIPT_ELEMENT_ID, data: formatFlagsJSON(flags) })
 }
 
 FlagsEmbed.defaultProps = {

--- a/packages/dotcom-ui-flags/src/components/FlagsEmbed.tsx
+++ b/packages/dotcom-ui-flags/src/components/FlagsEmbed.tsx
@@ -12,7 +12,7 @@ function FlagsEmbed({ flags }: TFlagsEmbedProps) {
     <script
       type="application/json"
       id={SCRIPT_ELEMENT_ID}
-      dangerouslySetInnerHTML={{ __html: formatFlagsJSON(flags) }}
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(formatFlagsJSON(flags)) }}
     />
   )
 }

--- a/packages/dotcom-ui-flags/src/server/formatFlagsJSON.ts
+++ b/packages/dotcom-ui-flags/src/server/formatFlagsJSON.ts
@@ -1,6 +1,6 @@
 import { TFlagsData } from '../types'
 
-export default function formatFlagsJSON(flags: TFlagsData = {}): string {
+export default function formatFlagsJSON(flags: TFlagsData = {}): TFlagsData {
   const output = {}
 
   Object.keys(flags).forEach((key) => {
@@ -11,5 +11,5 @@ export default function formatFlagsJSON(flags: TFlagsData = {}): string {
     }
   })
 
-  return JSON.stringify(output)
+  return output
 }


### PR DESCRIPTION
In order to allow users to share data between the server and client introduce a new `dotcom-ui-data-embed` package.

Some parts of this package can be reused and consumed by the `dotcom-ui-flags` and `dotcom-ui-app-context` packages.

I have [spiked this feature in the `next-video-page` application that was blocked without this feature](https://github.com/Financial-Times/next-video-page/compare/spike-data-embed-2?expand=1).

## Screenshot of kitchen sink example output
<img width="980" alt="Screenshot of kitchen sink example output" src="https://user-images.githubusercontent.com/2445413/81720035-c37c2900-9475-11ea-9782-a9fe87583b34.png">


Closes https://github.com/Financial-Times/dotcom-page-kit/issues/799
Closes https://github.com/Financial-Times/dotcom-page-kit/pull/761