### PR TITLE
Fix master: Pin TypeScript dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "style-loader": "^1.0.0",
     "supertest": "^4.0.2",
     "ts-jest": "^25.0.0",
-    "typescript": "^3.8.3"
+    "typescript": "3.8.3"
   },
   "engines": {
     "node": ">= 12.0.0"


### PR DESCRIPTION
TypeScript does not follow Semantic Versioning.

This means that the caret (^) syntax used by npm installed a breaking version, as it expects minor and patch releases to be backwards compatible.

This unfortunately means we need to pin the dependency to ensure our code does not break.

> export * is Always Retained
> In previous TypeScript versions, declarations like export * from "foo" would be dropped in our JavaScript output if foo didn’t export any values. This sort of emit is problematic because it’s type-directed and can’t be emulated by Babel. TypeScript 3.9 will always emit these export * declarations. **In practice, we don’t expect this to break much existing code, but bundlers may have a harder time tree-shaking the code.**

https://devblogs.microsoft.com/typescript/announcing-typescript-3-9/#breaking-changes