### PR TITLE
Use the latest version of o-fonts-assets and o-typography.

### DIFF
--- a/packages/dotcom-ui-base-styles/bower.json
+++ b/packages/dotcom-ui-base-styles/bower.json
@@ -2,7 +2,7 @@
   "name": "dotcom-ui-base-styles",
   "dependencies": {
     "n-ui-foundations": "^4.0.0",
-    "o-typography": "^6.1.0"
+    "o-typography": "^6.4.0"
   },
   "main": ["browser.js", "styles.scss"]
 }

--- a/packages/dotcom-ui-base-styles/src/lib/fontFaces.ts
+++ b/packages/dotcom-ui-base-styles/src/lib/fontFaces.ts
@@ -1,8 +1,8 @@
 // NOTE: please also update ./styles.css when updating the URLs defined below. They
 // need to stay in-sync to ensure our CSS output matches the resource hints we set.
 export const fontFaceURLs = [
-  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Regular.woff',
-  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Semibold.woff',
-  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Regular.woff',
-  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Bold.woff'
+  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Regular.woff2',
+  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Semibold.woff2',
+  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Regular.woff2',
+  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Bold.woff2'
 ]

--- a/packages/dotcom-ui-base-styles/styles.scss
+++ b/packages/dotcom-ui-base-styles/styles.scss
@@ -2,7 +2,7 @@ $system-code: 'page-kit-base-styles' !default;
 
 // NOTE: please also update ./src/lib/fontFaces.ts when updating the URL below. They
 // need to stay in-sync to ensure our CSS output matches the resource hints we set.
-$o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/';
+$o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/';
 
 // TODO: Migrate into this package existing usage of n-ui-foundations that
 // falls under definition of this package, with the intention of ideally

--- a/packages/dotcom-ui-layout/bower.json
+++ b/packages/dotcom-ui-layout/bower.json
@@ -2,7 +2,7 @@
   "name": "dotcom-ui-layout",
   "dependencies": {
     "n-ui-foundations": "^4.0.0-beta.2",
-    "o-typography": "^6.1.0"
+    "o-typography": "^6.4.0"
   },
   "main": ["browser.js", "styles.scss"]
 }

--- a/packages/dotcom-ui-shell/src/__test__/components/ResourceHints.test.tsx
+++ b/packages/dotcom-ui-shell/src/__test__/components/ResourceHints.test.tsx
@@ -9,7 +9,7 @@ describe('dotcom-ui-shell/src/components/ResourceHints', () => {
       'www.example.com/images/graphic.svg#icon',
       'http://polyfill.io/v3/bundle.min.js?features=es5,es6',
       '/assets/public/style.as83hd99.css',
-      '/__origami/service/build/v2/files/o-fonts-assets/FontFace.woff'
+      '/__origami/service/build/v2/files/o-fonts-assets/FontFace.woff2'
     ]
 
     const tree = renderer.create(<Subject resourceHints={fixture} />).toJSON()

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/ResourceHints.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/ResourceHints.test.tsx.snap
@@ -46,7 +46,7 @@ Array [
   <link
     as="font"
     crossOrigin="anonymous"
-    href="/__origami/service/build/v2/files/o-fonts-assets/FontFace.woff"
+    href="/__origami/service/build/v2/files/o-fonts-assets/FontFace.woff2"
     rel="preload"
     type="font/woff"
   />,

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/ResourceHints.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/ResourceHints.test.tsx.snap
@@ -48,7 +48,7 @@ Array [
     crossOrigin="anonymous"
     href="/__origami/service/build/v2/files/o-fonts-assets/FontFace.woff2"
     rel="preload"
-    type="font/woff"
+    type="font/woff2"
   />,
 ]
 `;

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -105,28 +105,28 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
       crossOrigin="anonymous"
       href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Regular.woff2"
       rel="preload"
-      type="font/woff"
+      type="font/woff2"
     />
     <link
       as="font"
       crossOrigin="anonymous"
       href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Semibold.woff2"
       rel="preload"
-      type="font/woff"
+      type="font/woff2"
     />
     <link
       as="font"
       crossOrigin="anonymous"
       href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Regular.woff2"
       rel="preload"
-      type="font/woff"
+      type="font/woff2"
     />
     <link
       as="font"
       crossOrigin="anonymous"
       href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Bold.woff2"
       rel="preload"
-      type="font/woff"
+      type="font/woff2"
     />
     <script
       dangerouslySetInnerHTML={

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -103,28 +103,28 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Regular.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Regular.woff2"
       rel="preload"
       type="font/woff"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Semibold.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Semibold.woff2"
       rel="preload"
       type="font/woff"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Regular.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Regular.woff2"
       rel="preload"
       type="font/woff"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Bold.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Bold.woff2"
       rel="preload"
       type="font/woff"
     />

--- a/packages/dotcom-ui-shell/src/__test__/lib/getResourceType.spec.ts
+++ b/packages/dotcom-ui-shell/src/__test__/lib/getResourceType.spec.ts
@@ -5,7 +5,7 @@ describe('dotcom-ui-shell/src/lib/getResourceType', () => {
     expect(subject('style.css')).toEqual('style')
     expect(subject('script.js')).toEqual('script')
     expect(subject('image.png')).toEqual('image')
-    expect(subject('font.woff')).toEqual('font')
+    expect(subject('font.woff2')).toEqual('font')
   })
 
   it('throws if the file extension cannot be matched', () => {

--- a/packages/dotcom-ui-shell/src/__test__/lib/getResourceType.spec.ts
+++ b/packages/dotcom-ui-shell/src/__test__/lib/getResourceType.spec.ts
@@ -5,6 +5,7 @@ describe('dotcom-ui-shell/src/lib/getResourceType', () => {
     expect(subject('style.css')).toEqual('style')
     expect(subject('script.js')).toEqual('script')
     expect(subject('image.png')).toEqual('image')
+    expect(subject('font.woff')).toEqual('font')
     expect(subject('font.woff2')).toEqual('font')
   })
 

--- a/packages/dotcom-ui-shell/src/lib/getResourceType.ts
+++ b/packages/dotcom-ui-shell/src/lib/getResourceType.ts
@@ -7,7 +7,7 @@ const ScriptFiles = new Set(['.js', '.mjs'])
 
 const ImageFiles = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp'])
 
-const FontFiles = new Set(['.woff2', '.woff22', '.otf', '.ttf', '.eot'])
+const FontFiles = new Set(['.woff', '.woff2', '.otf', '.ttf', '.eot'])
 
 export default (file: string): string => {
   // Always parse the file so that we can ignore any domain names, query strings etc.

--- a/packages/dotcom-ui-shell/src/lib/getResourceType.ts
+++ b/packages/dotcom-ui-shell/src/lib/getResourceType.ts
@@ -7,7 +7,7 @@ const ScriptFiles = new Set(['.js', '.mjs'])
 
 const ImageFiles = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp'])
 
-const FontFiles = new Set(['.woff', '.woff2', '.otf', '.ttf', '.eot'])
+const FontFiles = new Set(['.woff2', '.woff22', '.otf', '.ttf', '.eot'])
 
 export default (file: string): string => {
   // Always parse the file so that we can ignore any domain names, query strings etc.


### PR DESCRIPTION
The latest version of o-fonts-assets includes woff2 formats
for a significant reduction in filesize:
https://github.com/Financial-Times/o-fonts-assets/pull/19

 It looks like more browsers support woff2 than
`<link rel="preload">`, so it is safe to update the preloads
to the woff2 format.
https://caniuse.com/#search=woff2
https://caniuse.com/#search=preload

Bonus: When projects which depend on page kit are re-deployed
the double font download issue caused by the preload
o-fonts-assets version being different will be resolved
(for now, unless they diverge again):
https://financialtimes.slack.com/archives/C3TJ6KXEU/p1590161366213400