### PR TITLE
feat: add new header variant aimed at app users (ACC-396)

### DIFF
--- a/packages/dotcom-ui-header/README.md
+++ b/packages/dotcom-ui-header/README.md
@@ -27,6 +27,7 @@ This package provides several UI components to render different parts and styles
 - `<Header />` the full header with navigation with lots of options. See [header elements](#header-elements) for a breakdown of its parts.
 - `<Drawer />` the navigation drawer which should be rendered separately from the header, preferably near the bottom of the document.
 - `<LogoOnly />` a simple masthead displaying the logo image which doesn't require any configuration. Doesn't link to the homepage by default, pass in a `showLogoLink={true}` prop to make it link through.
+- `<NoOutboundLinksHeader />` a stripped back masthead displaying the logo image, user actions and optional sub-navigation. Aimed at reducing the possibility of a user clicking through to content related pages.
 
 
 ```jsx

--- a/packages/dotcom-ui-header/src/__stories__/story.tsx
+++ b/packages/dotcom-ui-header/src/__stories__/story.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react'
 import { withKnobs, radios, boolean } from '@storybook/addon-knobs'
 import * as header from '../../browser.js'
 import { OnReady } from '../../../../.storybook/components/OnReady'
-import { Header as HeaderSimple, Header as HeaderLarge, Drawer, StickyHeader, LogoOnly } from '../../src'
+import { Header as HeaderSimple, Header as HeaderLarge, Drawer, StickyHeader, LogoOnly, NoOutboundLinksHeader } from '../../src'
 import storyData from './story-data'
 import '../../styles.scss'
 import './demos.scss'
@@ -79,4 +79,14 @@ storiesOf('FT / Header', module)
   .add('Logo only', () => {
     const knobs = { variant: toggleVariantOptions(), showLogoLink: toggleShowLogoLink() }
     return <LogoOnly {...knobs} />
+  })
+  .add('No Outbound links', () => {
+    const knobs = {
+      userIsLoggedIn: toggleLoggedIn(),
+      showLogoLink: toggleShowLogoLink(),
+      showUserNavigation: toggleUserStateOptions(),
+      showSubNavigation: toggleShowSubNav(),
+    }
+
+    return <NoOutboundLinksHeader {...storyData} {...knobs} />
   })

--- a/packages/dotcom-ui-header/src/__test__/components/NoOutboundLinks.spec.tsx
+++ b/packages/dotcom-ui-header/src/__test__/components/NoOutboundLinks.spec.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import fixture from '../../__stories__/story-data/index'
+import { NoOutboundLinksHeader as Subject } from '../../index'
+
+const propsAnonymous = { ...fixture, userIsAnonymous: true, userIsLoggedIn: false }
+const propsLoggedIn = { ...fixture, userIsAnonymous: false, userIsLoggedIn: true }
+
+describe('dotcom-ui-header/src/components/NoOutboundLinksHeader', () => {
+  it('renders as an anonymous user', () => {
+    const tree = renderer.create(<Subject {...propsAnonymous} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders as a logged in user', () => {
+    const tree = renderer.create(<Subject {...propsLoggedIn} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/NoOutboundLinks.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/NoOutboundLinks.spec.tsx.snap
@@ -1,0 +1,337 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dotcom-ui-header/src/components/NoOutboundLinksHeader renders as a logged in user 1`] = `
+<header
+  className="o-header o-header--simple"
+  data-o-component="o-header"
+  data-o-header--no-js={true}
+  id="site-navigation"
+  tabIndex={-1}
+>
+  <div
+    className="o-header__row o-header__top"
+    data-trackable="header-top"
+  >
+    <div
+      className="o-header__container"
+    >
+      <div
+        className="o-header__top-wrapper"
+      >
+        <div
+          className="o-header__top-column o-header__top-column--center"
+        >
+          <div
+            className="o-header__top-logo"
+            style={
+              Object {
+                "backgroundImage": "none",
+              }
+            }
+          >
+            <svg
+              viewBox="0 0 1054 86"
+            >
+              <title>
+                Financial Times
+              </title>
+              <path
+                d="M26.177 72.609c0 5.938 1.697 7.295 12.554 7.295v3.732H.9v-3.732c7.464 0 10.01-.679 10.01-7.125V12.215c0-6.447-2.546-7.126-10.01-7.126V1.357h63.448l.34 22.563h-3.054C59.937 6.956 55.696 5.43 39.919 5.43H26.008v33.59h11.196c10.688 0 11.367-1.697 12.215-10.179h3.054v24.599h-3.054c-.848-8.482-1.527-10.01-12.215-10.01H26.008v29.18h.17zm46.314 11.027v-3.732c7.465 0 10.01-.679 10.01-7.125V12.215c0-6.447-2.545-7.126-10.01-7.126V1.357h35.287V5.09c-7.465 0-10.01.679-10.01 7.126v60.564c0 6.446 2.545 7.125 10.01 7.125v3.732H72.49zm115.36 1.357l-56.323-69.725V72.44c0 6.617 4.58 7.634 12.385 7.634v3.733h-29.858v-3.733c7.803 0 12.045-1.017 12.045-7.634V8.991c-3.563-3.732-6.108-3.902-12.045-3.902V1.357h26.465l43.09 55.475V12.554c0-6.616-4.58-7.634-12.384-7.634V1.357h30.027V5.09c-7.803 0-12.045 1.018-12.045 7.635v72.27h-1.357zm40.207-1.357h-29.689v-3.732c7.804 0 11.367-1.018 13.911-7.804L239.085.509h7.464l28.84 72.1c2.545 6.447 3.732 7.125 9.67 7.125v3.732h-34.438v-3.732c10.518 0 11.536-.848 8.99-7.125l-8.481-21.884h-25.787L217.71 71.93c-2.375 6.447 1.357 7.804 10.518 7.804v3.902h-.17zm-1.188-37.153h22.393l-11.705-29.518-10.688 29.518zm135.548 38.51l-56.153-69.725V72.44c0 6.617 4.58 7.634 12.384 7.634v3.733h-29.18v-3.733c7.126 0 11.367-1.017 11.367-7.634V9.161c-4.071-3.732-7.125-4.072-13.91-4.072V1.357h28.16l43.09 55.475V12.554c0-6.616-4.58-7.634-12.383-7.634V1.357h29.858V5.09c-7.804 0-12.045 1.018-12.045 7.635v72.27h-1.188zm83.297-83.805h2.036l1.187 24.598-3.053.17c-2.036-14.08-9.5-21.545-23.242-21.545-15.268 0-26.804 13.063-26.804 33.081 0 25.617 16.116 40.206 33.08 40.206 7.296 0 13.912-2.035 20.358-8.99l2.376 2.374c-5.26 7.465-15.608 13.742-29.52 13.742-20.696 0-41.732-15.608-41.732-41.734C380.4 17.813 399.57 0 422.813 0c11.027 0 16.795 4.75 19.848 4.75 1.357 0 2.375-1.187 3.054-3.562zm12.723 82.448v-3.732c7.465 0 10.01-.679 10.01-7.125V12.215c0-6.447-2.545-7.126-10.01-7.126V1.357h35.287V5.09c-7.464 0-10.01.679-10.01 7.126v60.564c0 6.446 2.546 7.125 10.01 7.125v3.732h-35.287zm68.538 0h-27.653v-3.732c6.108 0 9.331-1.018 11.876-7.804L538.003.509h7.464l28.84 72.1c2.545 6.447 3.733 7.125 9.67 7.125v3.732H549.54v-3.732c10.518 0 11.536-.848 8.991-7.125l-8.482-21.884h-25.786l-7.635 21.205c-2.375 6.447 1.358 7.804 10.519 7.804v3.902h-.17zm-1.188-37.153h22.394l-11.536-29.518-10.858 29.518zm63.957 37.153v-3.732c7.465 0 10.01-.679 10.01-7.125V12.215c0-6.447-2.545-7.126-10.01-7.126V1.357h35.117V5.09c-7.464 0-9.84.679-9.84 7.126v61.073c0 5.428 2.715 6.107 7.126 6.107h4.241c15.947 0 21.036-2.375 25.447-20.527l3.054.339-2.545 24.26h-62.6v.17zM760.75 1.357l.339 23.92h-3.054C756.34 7.634 752.098 5.43 736.32 5.43h-5.089v67.18c0 6.447 2.375 7.295 12.554 7.295v3.732h-40.376v-3.732c10.179 0 12.723-1.018 12.723-7.295V5.429h-5.089c-15.777 0-20.018 2.205-21.715 19.848h-3.053l.339-23.92h74.136zm7.973 82.28v-3.733c7.465 0 10.01-.679 10.01-7.125V12.215c0-6.447-2.545-7.126-10.01-7.126V1.357h35.287V5.09c-7.465 0-10.01.679-10.01 7.126v60.564c0 6.446 2.545 7.125 10.01 7.125v3.732h-35.287zM910.21 1.356V5.09c-7.465 0-10.688.34-10.01 6.956l6.447 61.073c.679 6.277 3.054 6.955 10.518 6.955v3.733h-35.117v-3.733c7.295 0 9.84-.678 9.331-6.955L884.762 8.99l-25.956 76.172h-1.018L832.34 8.822l-6.108 64.126c-.678 6.447 3.733 7.125 11.197 7.125v3.733h-27.483v-3.733c7.465 0 10.01-1.187 10.518-7.125l6.447-61.073c.679-6.446-2.545-6.955-10.01-6.955V1.357h28.84l17.305 56.153 18.661-56.153h28.5zm65.653 52.082h-3.053c-.849-8.482-1.527-10.01-12.215-10.01H948.04v29.859c0 5.428 2.715 6.107 7.125 6.107h6.786c15.947 0 21.036-2.375 25.447-20.527l3.054.339-2.884 24.26h-64.805v-3.733c7.464 0 10.009-.678 10.009-7.125V12.215c0-6.447-2.545-7.126-10.01-7.126V1.357h62.261l.34 20.527h-3.054c-1.866-14.59-5.598-16.286-21.885-16.286H948.21v33.42h12.554c10.687 0 11.366-1.696 12.214-10.178h3.054v24.599h-.17zm65.484 13.232c0-7.464-4.75-11.196-12.893-15.777l-13.063-6.786c-9.84-5.259-15.607-11.027-15.607-21.375C999.783 9.84 1010.81 0 1025.23 0c9.84 0 14.929 4.75 17.813 4.75 1.866 0 2.714-1.187 3.562-3.562h2.375l1.188 23.072-3.054.17c-1.696-11.198-9.67-19.85-20.866-19.85-8.483 0-14.081 5.09-14.081 12.215 0 7.804 5.937 11.027 12.554 14.59l11.196 5.937c10.519 5.768 17.983 11.536 17.983 22.563 0 14.59-12.554 24.939-28.161 24.939-11.028 0-16.456-5.26-19.34-5.26-1.866 0-2.884 1.697-3.732 4.242h-2.376l-1.696-24.43 3.054-.339c2.375 15.268 12.893 21.545 23.411 21.545 8.822-.17 16.286-4.071 16.286-13.91z"
+                fill="#231F20"
+                fillRule="evenodd"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <nav
+    aria-label="Primary navigation"
+    className="o-header__row o-header__nav o-header__nav--desktop"
+    data-trackable="header-nav:desktop"
+    id="o-header-nav-desktop"
+    role="navigation"
+  >
+    <div
+      className="o-header__container"
+    />
+  </nav>
+  <div
+    aria-label="Sub navigation"
+    className="o-header__subnav"
+    data-o-header-subnav={true}
+    data-trackable="header-subnav"
+    role="navigation"
+  >
+    <div
+      className="o-header__container"
+    >
+      <div
+        className="o-header__subnav-wrap-outside"
+      >
+        <div
+          className="o-header__subnav-wrap-inside"
+          data-o-header-subnav-wrapper={true}
+        >
+          <div
+            className="o-header__subnav-content"
+          >
+            <ol
+              aria-label="Breadcrumb"
+              className="o-header__subnav-list o-header__subnav-list--breadcrumb"
+              data-trackable="breadcrumb"
+            >
+              <li
+                className="o-header__subnav-item"
+              >
+                <a
+                  className="o-header__subnav-link "
+                  data-trackable="World"
+                  href="/world"
+                >
+                  World
+                </a>
+              </li>
+              <li
+                className="o-header__subnav-item"
+              >
+                <a
+                  aria-current="page"
+                  aria-label="UK, current page"
+                  className="o-header__subnav-link o-header__subnav-link--highlight"
+                  data-trackable="UK"
+                  href="/world/uk"
+                >
+                  UK
+                </a>
+              </li>
+            </ol>
+            <ul
+              aria-label="Subsections"
+              className="o-header__subnav-list o-header__subnav-list--subsections"
+              data-trackable="subsections"
+            >
+              <li
+                className="o-header__subnav-item"
+              >
+                <a
+                  className="o-header__subnav-link "
+                  data-trackable="UK Business & Economy"
+                  href="/uk-business-economy"
+                >
+                  UK Business & Economy
+                </a>
+              </li>
+              <li
+                className="o-header__subnav-item"
+              >
+                <a
+                  className="o-header__subnav-link "
+                  data-trackable="UK Politics & Policy"
+                  href="/world/uk/politics"
+                >
+                  UK Politics & Policy
+                </a>
+              </li>
+              <li
+                className="o-header__subnav-item"
+              >
+                <a
+                  className="o-header__subnav-link "
+                  data-trackable="UK Companies"
+                  href="/companies/uk"
+                >
+                  UK Companies
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <button
+          aria-hidden="true"
+          aria-label="scroll left"
+          className="o-header__subnav-button o-header__subnav-button--left"
+          disabled={true}
+          title="scroll left"
+        />
+        <button
+          aria-hidden="true"
+          aria-label="scroll right"
+          className="o-header__subnav-button o-header__subnav-button--right"
+          disabled={true}
+          title="scroll right"
+        />
+      </div>
+    </div>
+  </div>
+</header>
+`;
+
+exports[`dotcom-ui-header/src/components/NoOutboundLinksHeader renders as an anonymous user 1`] = `
+<header
+  className="o-header o-header--simple"
+  data-o-component="o-header"
+  data-o-header--no-js={true}
+  id="site-navigation"
+  tabIndex={-1}
+>
+  <div
+    className="o-header__row o-header__top"
+    data-trackable="header-top"
+  >
+    <div
+      className="o-header__container"
+    >
+      <div
+        className="o-header__top-wrapper"
+      >
+        <div
+          className="o-header__top-column o-header__top-column--center"
+        >
+          <div
+            className="o-header__top-logo"
+            style={
+              Object {
+                "backgroundImage": "none",
+              }
+            }
+          >
+            <svg
+              viewBox="0 0 1054 86"
+            >
+              <title>
+                Financial Times
+              </title>
+              <path
+                d="M26.177 72.609c0 5.938 1.697 7.295 12.554 7.295v3.732H.9v-3.732c7.464 0 10.01-.679 10.01-7.125V12.215c0-6.447-2.546-7.126-10.01-7.126V1.357h63.448l.34 22.563h-3.054C59.937 6.956 55.696 5.43 39.919 5.43H26.008v33.59h11.196c10.688 0 11.367-1.697 12.215-10.179h3.054v24.599h-3.054c-.848-8.482-1.527-10.01-12.215-10.01H26.008v29.18h.17zm46.314 11.027v-3.732c7.465 0 10.01-.679 10.01-7.125V12.215c0-6.447-2.545-7.126-10.01-7.126V1.357h35.287V5.09c-7.465 0-10.01.679-10.01 7.126v60.564c0 6.446 2.545 7.125 10.01 7.125v3.732H72.49zm115.36 1.357l-56.323-69.725V72.44c0 6.617 4.58 7.634 12.385 7.634v3.733h-29.858v-3.733c7.803 0 12.045-1.017 12.045-7.634V8.991c-3.563-3.732-6.108-3.902-12.045-3.902V1.357h26.465l43.09 55.475V12.554c0-6.616-4.58-7.634-12.384-7.634V1.357h30.027V5.09c-7.803 0-12.045 1.018-12.045 7.635v72.27h-1.357zm40.207-1.357h-29.689v-3.732c7.804 0 11.367-1.018 13.911-7.804L239.085.509h7.464l28.84 72.1c2.545 6.447 3.732 7.125 9.67 7.125v3.732h-34.438v-3.732c10.518 0 11.536-.848 8.99-7.125l-8.481-21.884h-25.787L217.71 71.93c-2.375 6.447 1.357 7.804 10.518 7.804v3.902h-.17zm-1.188-37.153h22.393l-11.705-29.518-10.688 29.518zm135.548 38.51l-56.153-69.725V72.44c0 6.617 4.58 7.634 12.384 7.634v3.733h-29.18v-3.733c7.126 0 11.367-1.017 11.367-7.634V9.161c-4.071-3.732-7.125-4.072-13.91-4.072V1.357h28.16l43.09 55.475V12.554c0-6.616-4.58-7.634-12.383-7.634V1.357h29.858V5.09c-7.804 0-12.045 1.018-12.045 7.635v72.27h-1.188zm83.297-83.805h2.036l1.187 24.598-3.053.17c-2.036-14.08-9.5-21.545-23.242-21.545-15.268 0-26.804 13.063-26.804 33.081 0 25.617 16.116 40.206 33.08 40.206 7.296 0 13.912-2.035 20.358-8.99l2.376 2.374c-5.26 7.465-15.608 13.742-29.52 13.742-20.696 0-41.732-15.608-41.732-41.734C380.4 17.813 399.57 0 422.813 0c11.027 0 16.795 4.75 19.848 4.75 1.357 0 2.375-1.187 3.054-3.562zm12.723 82.448v-3.732c7.465 0 10.01-.679 10.01-7.125V12.215c0-6.447-2.545-7.126-10.01-7.126V1.357h35.287V5.09c-7.464 0-10.01.679-10.01 7.126v60.564c0 6.446 2.546 7.125 10.01 7.125v3.732h-35.287zm68.538 0h-27.653v-3.732c6.108 0 9.331-1.018 11.876-7.804L538.003.509h7.464l28.84 72.1c2.545 6.447 3.733 7.125 9.67 7.125v3.732H549.54v-3.732c10.518 0 11.536-.848 8.991-7.125l-8.482-21.884h-25.786l-7.635 21.205c-2.375 6.447 1.358 7.804 10.519 7.804v3.902h-.17zm-1.188-37.153h22.394l-11.536-29.518-10.858 29.518zm63.957 37.153v-3.732c7.465 0 10.01-.679 10.01-7.125V12.215c0-6.447-2.545-7.126-10.01-7.126V1.357h35.117V5.09c-7.464 0-9.84.679-9.84 7.126v61.073c0 5.428 2.715 6.107 7.126 6.107h4.241c15.947 0 21.036-2.375 25.447-20.527l3.054.339-2.545 24.26h-62.6v.17zM760.75 1.357l.339 23.92h-3.054C756.34 7.634 752.098 5.43 736.32 5.43h-5.089v67.18c0 6.447 2.375 7.295 12.554 7.295v3.732h-40.376v-3.732c10.179 0 12.723-1.018 12.723-7.295V5.429h-5.089c-15.777 0-20.018 2.205-21.715 19.848h-3.053l.339-23.92h74.136zm7.973 82.28v-3.733c7.465 0 10.01-.679 10.01-7.125V12.215c0-6.447-2.545-7.126-10.01-7.126V1.357h35.287V5.09c-7.465 0-10.01.679-10.01 7.126v60.564c0 6.446 2.545 7.125 10.01 7.125v3.732h-35.287zM910.21 1.356V5.09c-7.465 0-10.688.34-10.01 6.956l6.447 61.073c.679 6.277 3.054 6.955 10.518 6.955v3.733h-35.117v-3.733c7.295 0 9.84-.678 9.331-6.955L884.762 8.99l-25.956 76.172h-1.018L832.34 8.822l-6.108 64.126c-.678 6.447 3.733 7.125 11.197 7.125v3.733h-27.483v-3.733c7.465 0 10.01-1.187 10.518-7.125l6.447-61.073c.679-6.446-2.545-6.955-10.01-6.955V1.357h28.84l17.305 56.153 18.661-56.153h28.5zm65.653 52.082h-3.053c-.849-8.482-1.527-10.01-12.215-10.01H948.04v29.859c0 5.428 2.715 6.107 7.125 6.107h6.786c15.947 0 21.036-2.375 25.447-20.527l3.054.339-2.884 24.26h-64.805v-3.733c7.464 0 10.009-.678 10.009-7.125V12.215c0-6.447-2.545-7.126-10.01-7.126V1.357h62.261l.34 20.527h-3.054c-1.866-14.59-5.598-16.286-21.885-16.286H948.21v33.42h12.554c10.687 0 11.366-1.696 12.214-10.178h3.054v24.599h-.17zm65.484 13.232c0-7.464-4.75-11.196-12.893-15.777l-13.063-6.786c-9.84-5.259-15.607-11.027-15.607-21.375C999.783 9.84 1010.81 0 1025.23 0c9.84 0 14.929 4.75 17.813 4.75 1.866 0 2.714-1.187 3.562-3.562h2.375l1.188 23.072-3.054.17c-1.696-11.198-9.67-19.85-20.866-19.85-8.483 0-14.081 5.09-14.081 12.215 0 7.804 5.937 11.027 12.554 14.59l11.196 5.937c10.519 5.768 17.983 11.536 17.983 22.563 0 14.59-12.554 24.939-28.161 24.939-11.028 0-16.456-5.26-19.34-5.26-1.866 0-2.884 1.697-3.732 4.242h-2.376l-1.696-24.43 3.054-.339c2.375 15.268 12.893 21.545 23.411 21.545 8.822-.17 16.286-4.071 16.286-13.91z"
+                fill="#231F20"
+                fillRule="evenodd"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <nav
+    aria-label="Primary navigation"
+    className="o-header__row o-header__nav o-header__nav--desktop"
+    data-trackable="header-nav:desktop"
+    id="o-header-nav-desktop"
+    role="navigation"
+  >
+    <div
+      className="o-header__container"
+    />
+  </nav>
+  <div
+    aria-label="Sub navigation"
+    className="o-header__subnav"
+    data-o-header-subnav={true}
+    data-trackable="header-subnav"
+    role="navigation"
+  >
+    <div
+      className="o-header__container"
+    >
+      <div
+        className="o-header__subnav-wrap-outside"
+      >
+        <div
+          className="o-header__subnav-wrap-inside"
+          data-o-header-subnav-wrapper={true}
+        >
+          <div
+            className="o-header__subnav-content"
+          >
+            <ol
+              aria-label="Breadcrumb"
+              className="o-header__subnav-list o-header__subnav-list--breadcrumb"
+              data-trackable="breadcrumb"
+            >
+              <li
+                className="o-header__subnav-item"
+              >
+                <a
+                  className="o-header__subnav-link "
+                  data-trackable="World"
+                  href="/world"
+                >
+                  World
+                </a>
+              </li>
+              <li
+                className="o-header__subnav-item"
+              >
+                <a
+                  aria-current="page"
+                  aria-label="UK, current page"
+                  className="o-header__subnav-link o-header__subnav-link--highlight"
+                  data-trackable="UK"
+                  href="/world/uk"
+                >
+                  UK
+                </a>
+              </li>
+            </ol>
+            <ul
+              aria-label="Subsections"
+              className="o-header__subnav-list o-header__subnav-list--subsections"
+              data-trackable="subsections"
+            >
+              <li
+                className="o-header__subnav-item"
+              >
+                <a
+                  className="o-header__subnav-link "
+                  data-trackable="UK Business & Economy"
+                  href="/uk-business-economy"
+                >
+                  UK Business & Economy
+                </a>
+              </li>
+              <li
+                className="o-header__subnav-item"
+              >
+                <a
+                  className="o-header__subnav-link "
+                  data-trackable="UK Politics & Policy"
+                  href="/world/uk/politics"
+                >
+                  UK Politics & Policy
+                </a>
+              </li>
+              <li
+                className="o-header__subnav-item"
+              >
+                <a
+                  className="o-header__subnav-link "
+                  data-trackable="UK Companies"
+                  href="/companies/uk"
+                >
+                  UK Companies
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <button
+          aria-hidden="true"
+          aria-label="scroll left"
+          className="o-header__subnav-button o-header__subnav-button--left"
+          disabled={true}
+          title="scroll left"
+        />
+        <button
+          aria-hidden="true"
+          aria-label="scroll right"
+          className="o-header__subnav-button o-header__subnav-button--right"
+          disabled={true}
+          title="scroll right"
+        />
+      </div>
+    </div>
+  </div>
+</header>
+`;

--- a/packages/dotcom-ui-header/src/index.tsx
+++ b/packages/dotcom-ui-header/src/index.tsx
@@ -103,4 +103,24 @@ function Drawer(props: THeaderProps) {
 
 Drawer.defaultProps = defaultProps
 
-export { THeaderProps, Header, MainHeader, StickyHeader, LogoOnly, Drawer }
+function NoOutboundLinksHeader(props: THeaderProps) {
+  const includeUserActionsNav = props.showUserNavigation && !props.userIsLoggedIn
+  const includeSubNavigation = props.showSubNavigation && (props.data.breadcrumb || props.data.subsections)
+
+  return (
+    <HeaderWrapper {...props}>
+      {includeUserActionsNav ? <UserActionsNav {...props} /> : null}
+      <TopWrapper>
+        {props.showLogoLink ? <TopColumnCenter /> : <TopColumnCenterNoLink />}
+      </TopWrapper>
+      <NavDesktop>
+        {props.showUserNavigation ? <NavListRight {...props} /> : null}
+      </NavDesktop>
+      {includeSubNavigation ? <SubNavigation {...props} /> : null}
+    </HeaderWrapper>
+  )
+}
+
+NoOutboundLinksHeader.defaultProps = defaultProps
+
+export { THeaderProps, Header, MainHeader, StickyHeader, LogoOnly, NoOutboundLinksHeader, Drawer }

--- a/packages/dotcom-ui-layout/README.md
+++ b/packages/dotcom-ui-layout/README.md
@@ -85,7 +85,7 @@ _Please note_ that the exact usage will depend on how you configure your Sass co
 | PROP            | TYPE                                            | OPTIONAL | DEFAULT     | DESCRIPTION                                                                                  |
 |-----------------|-------------------------------------------------|----------|-------------|----------------------------------------------------------------------------------------------|
 | navigationData  | [TNavigationData]                               | true*    | `undefined` | Required if using the built in header and/or footer components. See note below.              |
-| headerVariant   | 'simple' \| 'large-logo' \| 'logo-only'\| false | true     | `"simple"`  | The type of built in [header] to display                                                     |
+| headerVariant   | 'simple' \| 'large-logo' \| 'logo-only'\| 'no-outbound-links'\| false | true     | `"simple"`  | The type of built in [header] to display                                                     |
 | headerBefore    | string \| ReactElement                          | true     | `undefined` | A slot for content to appear before Header                                                   |
 | headerAfter     | string \| ReactElement                          | true     | `undefined` | A slot for content to appear after Header                                                    |
 | headerOptions   | THeaderProps                                    | true     | `undefined` | Pass options to the header component                                                         |

--- a/packages/dotcom-ui-layout/src/components/Layout.tsx
+++ b/packages/dotcom-ui-layout/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import {
   Header as HeaderSimple,
   Header as HeaderLarge,
   LogoOnly,
+  NoOutboundLinksHeader,
   Drawer,
   THeaderOptions
 } from '@financial-times/dotcom-ui-header/component'
@@ -13,7 +14,8 @@ import Template from './Template'
 enum Headers {
   simple = HeaderSimple,
   'large-logo' = HeaderLarge,
-  'logo-only' = LogoOnly
+  'logo-only' = LogoOnly,
+  'no-outbound-links' = NoOutboundLinksHeader
 }
 
 enum Footers {

--- a/packages/dotcom-ui-layout/src/components/__test__/Layout.spec.tsx
+++ b/packages/dotcom-ui-layout/src/components/__test__/Layout.spec.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 
 import { Layout as Subject } from '../Layout'
-import { Header, Drawer, LogoOnly } from '@financial-times/dotcom-ui-header'
+import { Header, Drawer, LogoOnly, NoOutboundLinksHeader } from '@financial-times/dotcom-ui-header'
 import { Footer, LegalFooter } from '@financial-times/dotcom-ui-footer'
 
 describe('dotcom-ui-layout/src/components/Layout', () => {
@@ -77,6 +77,26 @@ describe('dotcom-ui-layout/src/components/Layout', () => {
 
       it('renders the logo only header component', () => {
         expect(result.find(LogoOnly)).toExist()
+      })
+
+      it('does not render the drawer component', () => {
+        expect(result.find(Drawer)).not.toExist()
+      })
+
+      it('does not render the navigation skip link', () => {
+        expect(result.find('a[href="#site-navigation"]')).not.toExist()
+      })
+    })
+
+    describe('with the no-outbound-links variant', () => {
+      let result
+
+      beforeAll(() => {
+        result = shallow(<Subject headerVariant={'no-outbound-links' as any} />)
+      })
+
+      it('renders the no-outbound-links header component', () => {
+        expect(result.find(NoOutboundLinksHeader)).toExist()
       })
 
       it('does not render the drawer component', () => {


### PR DESCRIPTION
I'm working on a card that needs to remove any outbound links in the header that may lead to content / a barrier due to iOS complications.

Apps on iOS have to pay a percentage of any subscriptions taken via the app directly to Apple so to try and mitigate the frequency of this, we want to have a header that is used on the `MyAccount` section of the website (one of the few areas of the website that is embedded on the app) that removes any links that may link to content and potentially a barrier page.

Happy to discuss options!

https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1108&projectKey=ACC&modal=detail&selectedIssue=ACC-396

Desktop Anon:
![desktop-anon](https://user-images.githubusercontent.com/6599523/83790121-9810e680-a68f-11ea-9a9a-24867bcba4f6.png)

Desktop Logged In:
![desktop-loggedin](https://user-images.githubusercontent.com/6599523/83790126-99421380-a68f-11ea-8a59-ce7866b6ea37.png)

Mobile Logged In:
![mobile-loggedin](https://user-images.githubusercontent.com/6599523/83790128-9a734080-a68f-11ea-8e67-cf30bbe4e5c4.png)

Mobile Anon:
![mobile-anon](https://user-images.githubusercontent.com/6599523/83790132-9a734080-a68f-11ea-884c-aff69bf812a9.png)
