### PR TITLE
Recommend rendering some scripts at end of the document

### DIFF
--- a/packages/dotcom-ui-app-context/README.md
+++ b/packages/dotcom-ui-app-context/README.md
@@ -30,10 +30,10 @@ export default (props) => (
     <head>
       <meta charSet="utf-8" />
       <title>My Amazing Website</title>
-      <AppContextEmbed appContext={appContext} />
     </head>
     <body>
       ...
+      <AppContextEmbed appContext={appContext} />
     </body>
   </html>
 )
@@ -48,12 +48,12 @@ function page() {
     <head>
       <meta charset="utf-8">
       <title>My Amazing Website</title>
-      <script type="application/json" id="page-kit-app-context">
-        {"appName":"app-name","contextProperty":"my-property"}
-      </script>
     </head>
     <body>
       ...
+      <script type="application/json" id="page-kit-app-context">
+        {"appName":"app-name","contextProperty":"my-property"}
+      </script>
     </body>
   </html>`
 }

--- a/packages/dotcom-ui-data-embed/README.md
+++ b/packages/dotcom-ui-data-embed/README.md
@@ -26,10 +26,10 @@ export default (props) => (
     <head>
       <meta charSet="utf-8" />
       <title>My Amazing Website</title>
-      <DataEmbed id={DATA_EMBED_ID} data={data} />
     </head>
     <body>
       ...
+      <DataEmbed id={DATA_EMBED_ID} data={data} />
     </body>
   </html>
 )
@@ -43,12 +43,12 @@ Otherwise you can insert a JSON formatted string into a `<script>` element with 
     <head>
         <meta charset="utf-8">
         <title>My Amazing Website</title>
-        <script type="application/json" id="data-embed">
-        {"property":"value","secondProperty":"second-value"}
-        </script>
     </head>
     <body>
         ...
+        <script type="application/json" id="data-embed">
+        {"property":"value","secondProperty":"second-value"}
+        </script>
     </body>
 </html>
 ```

--- a/packages/dotcom-ui-flags/README.md
+++ b/packages/dotcom-ui-flags/README.md
@@ -25,10 +25,10 @@ export default (props) => (
     <head>
       <meta charSet="utf-8" />
       <title>My Amazing Website</title>
-      <FlagsEmbed flags={props.flagsData} />
     </head>
     <body>
       ...
+      <FlagsEmbed flags={props.flagsData} />
     </body>
   </html>
 )
@@ -45,12 +45,12 @@ function page() {
     <head>
       <meta charset="utf-8">
       <title>My Amazing Website</title>
-      <script type="application/json" id="page-kit-flags-embed">
-        ${formatFlagsJSON(flagsData)}
-      </script>
     </head>
     <body>
       ...
+      <script type="application/json" id="page-kit-flags-embed">
+        ${formatFlagsJSON(flagsData)}
+      </script>
     </body>
   </html>`
 }


### PR DESCRIPTION
This is so they do not block the render of the page, and matches how they're used in the `dotcom-ui-shell` package.

This is a simple change, I think we may need to explain more about ordering explicitly but I'm thinking we do this first and see if it comes up again.

Closes https://github.com/Financial-Times/dotcom-page-kit/issues/822