### PR TITLE
Use shared renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,5 @@
 {
-  "extends": ["config:base", "schedule:nonOfficeHours", ":preserveSemverRanges"]
+  "extends": [
+    "github>financial-times/renovate-config-next"
+  ]
 }


### PR DESCRIPTION
I've moved the out of hours configuration into the main configuration here:
https://github.com/Financial-Times/renovate-config-next/pull/43