### PR TITLE
Update drawer menu accessible name for plain english alternative

### DIFF
--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -26,12 +26,12 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
             className="o-header__top-link o-header__top-link--menu"
             data-trackable="drawer-toggle"
             href="#o-header-drawer"
-            title="Open drawer menu"
+            title="Open side navigation menu"
           >
             <span
               className="o-header__top-link-label"
             >
-              Open drawer menu
+              Open side navigation menu
             </span>
           </a>
           <a
@@ -1865,12 +1865,12 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
             className="o-header__top-link o-header__top-link--menu"
             data-trackable="drawer-toggle"
             href="#o-header-drawer"
-            title="Open drawer menu"
+            title="Open side navigation menu"
           >
             <span
               className="o-header__top-link-label"
             >
-              Open drawer menu
+              Open side navigation menu
             </span>
           </a>
           <a

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -17,9 +17,9 @@ const DrawerIcon = () => (
     href="#o-header-drawer"
     className="o-header__top-link o-header__top-link--menu"
     aria-controls="o-header-drawer"
-    title="Open drawer menu"
+    title="Open side navigation menu"
     data-trackable="drawer-toggle">
-    <span className="o-header__top-link-label">Open drawer menu</span>
+    <span className="o-header__top-link-label">Open side navigation menu</span>
   </a>
 )
 


### PR DESCRIPTION
Drawer is an internal description, so 'side navigation' is more common place
so is more likely to be understood by people.

This change has been pushed upstream to the Origami examples:
https://github.com/Financial-Times/o-header/pull/386

This was recommended by the Digital Accessibility Center (DAC) audit

DAC ID: IDAC_Non-Descriptive_Form_Elements_Issue1

Jira ticket: CPP-113