### PR TITLE
Correct comment referencing next-session-client -> next-session

### DIFF
--- a/packages/dotcom-ui-shell/src/components/ResourceHints.tsx
+++ b/packages/dotcom-ui-shell/src/components/ResourceHints.tsx
@@ -16,7 +16,7 @@ const ResourceHints = (props: TResourceHintsProps) => {
       <link rel="preconnect" href="https://spoor-api.ft.com" />
       {/*
         The session API is used to validate users and retrieve information about them
-        <https://github.com/Financial-Times/next-session-client>
+        <https://github.com/Financial-Times/next-session>
       */}
       <link rel="preconnect" href="https://session-next.ft.com" crossOrigin="use-credentials" />
       {/*


### PR DESCRIPTION
The comment that accompanies the link to `https://session-next.ft.com` cites the repo for [`next-session-client`](https://github.com/Financial-Times/next-session-client).

However, it is actually [`next-session`](https://github.com/Financial-Times/next-session) that provides that endpoint (as described by its README), which the link points to without employing `next-session-client`.

I randomly encountered this while investigating whether we can remove `next-session-client` and so was scrutinising all of its mentions.