### PR TITLE
Update n-ui-foundations to v6.0.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.0.0
+
+- Shell UI Component: use an SVG icon in header and fallback to PNG, thanks @JakeChampion
+- Header UI Component: Update drawer menu accessible name for plain english alternative
+- (Breaking change) Header, Layout and Base styles UI Components: Small breaking release to update `n-ui-foundation` to version 6.
+
+Follow the [`n-ui-foundation` v5 to v6 migration guide](https://github.com/Financial-Times/n-ui-foundations#user-content-v5-to-v6) to check if you need to update anything in your application.
+
+## 1.1.0
+
+- Header UI Component: add new header variant aimed at app users
+
 ## 1.0.0
 
 - This is the first major stable release of Page Kit. N.B. It includes no changes since the last v0.x release.

--- a/packages/dotcom-ui-base-styles/bower.json
+++ b/packages/dotcom-ui-base-styles/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "dotcom-ui-base-styles",
   "dependencies": {
-    "n-ui-foundations": "^4.0.0",
+    "n-ui-foundations": "^6.0.0",
     "o-typography": "^6.4.0"
   },
   "main": ["browser.js", "styles.scss"]

--- a/packages/dotcom-ui-header/bower.json
+++ b/packages/dotcom-ui-header/bower.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "o-header": "^8.2.0",
     "n-topic-search": "^2.0.0",
-    "n-ui-foundations": "^4.0.0-beta.2"
+    "n-ui-foundations": "^6.0.0"
   },
   "main": ["browser.js", "styles.scss"]
 }

--- a/packages/dotcom-ui-header/bower.json
+++ b/packages/dotcom-ui-header/bower.json
@@ -2,7 +2,7 @@
   "name": "dotcom-ui-header",
   "dependencies": {
     "o-header": "^8.2.0",
-    "n-topic-search": "^2.0.0",
+    "n-topic-search": "^3.0.0",
     "n-ui-foundations": "^6.0.0"
   },
   "main": ["browser.js", "styles.scss"]

--- a/packages/dotcom-ui-layout/bower.json
+++ b/packages/dotcom-ui-layout/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "dotcom-ui-layout",
   "dependencies": {
-    "n-ui-foundations": "^4.0.0-beta.2",
+    "n-ui-foundations": "^6.0.0",
     "o-typography": "^6.4.0"
   },
   "main": ["browser.js", "styles.scss"]


### PR DESCRIPTION
Since Page kit depends on [n-topic-search](https://github.com/Financial-Times/n-topic-search/pull/34) I'd expect this to blow up, raising out of curiosity to learn more about bower dependency resolution...

Update: it did! So that's good :P Hopefully we'll see it pass once we include a new version of n-topic-search

#### References:
- [`n-ui-foundations` Migration guide v5 to v6](https://github.com/Financial-Times/n-ui-foundations#user-content-v5-to-v6).