### PR TITLE
Add prependData option to dotcom-build-sass

### DIFF
--- a/examples/building-sass-files/__test__/integration.test.js
+++ b/examples/building-sass-files/__test__/integration.test.js
@@ -15,6 +15,9 @@ describe('examples/building-sass-files', () => {
       // Styles should be defined by the o-normalise package
       expect(outputContents).toContain('.o-normalise-visually-hidden')
     })
+    it('can prepend data to the output', () => {
+      expect(outputContents).toContain('.prepended-flag-exists')
+    })
   })
 
   describe('PostCSS', () => {

--- a/examples/building-sass-files/webpack.config.js
+++ b/examples/building-sass-files/webpack.config.js
@@ -5,5 +5,8 @@ module.exports = {
   entry: {
     styles: './src/main.scss'
   },
-  plugins: [new PageKitBasePlugin(), new PageKitSassPlugin()]
+  plugins: [
+    new PageKitBasePlugin(),
+    new PageKitSassPlugin({ prependData: '.prepended-flag-exists::after { content: "true"; }' })
+  ]
 }

--- a/packages/dotcom-build-sass/README.md
+++ b/packages/dotcom-build-sass/README.md
@@ -69,4 +69,5 @@ The CSS loader has `@import` and `url()` resolution disabled as these should be 
 | Option            | Type     | Default | Description                                                        |
 |-------------------|----------|---------|--------------------------------------------------------------------|
 | `webpackImporter` | Boolean  | `false` | See https://github.com/webpack-contrib/sass-loader#webpackimporter |
+| `prependData`     | String   | `''`    | See https://webpack.js.org/loaders/sass-loader/#prependdata        |
 | `includePaths`    | String[] | `[]`    | See https://sass-lang.com/documentation/js-api#includepaths        |

--- a/packages/dotcom-build-sass/src/index.ts
+++ b/packages/dotcom-build-sass/src/index.ts
@@ -4,15 +4,18 @@ import type webpack from 'webpack'
 
 export type TPluginOptions = {
   includePaths?: string[]
+  prependData?: string
   webpackImporter?: boolean
 }
 
 export class PageKitSassPlugin {
   includePaths: string[]
+  prependData: string
   webpackImporter: boolean
 
-  constructor({ includePaths = [], webpackImporter }: TPluginOptions = {}) {
+  constructor({ includePaths = [], prependData = '', webpackImporter }: TPluginOptions = {}) {
     this.includePaths = includePaths
+    this.prependData = prependData
     this.webpackImporter = webpackImporter
   }
 
@@ -23,6 +26,7 @@ export class PageKitSassPlugin {
       webpackImporter: this.webpackImporter,
       // Prefer `dart-sass`.
       implementation: require('sass'),
+      prependData: this.prependData,
       sassOptions: {
         // Disable formatting so that we don't spend time pretty printing
         outputStyle: 'compressed',

--- a/packages/dotcom-build-sass/src/index.ts
+++ b/packages/dotcom-build-sass/src/index.ts
@@ -26,6 +26,9 @@ export class PageKitSassPlugin {
       webpackImporter: this.webpackImporter,
       // Prefer `dart-sass`.
       implementation: require('sass'),
+      // Prepends SCSS code before the actual entry file.
+      // Introduced to maintain snappy grid after n-ui-foundations removed it as the default.
+      // Once user-facing apps and components move away from using snappy grid then this can be removed.
       prependData: this.prependData,
       sassOptions: {
         // Disable formatting so that we don't spend time pretty printing


### PR DESCRIPTION
`dotcom-page-kit` uses `n-ui-foundations` in some of its packages and so was included as part of the [`n-ui-foundations` v5 to v6 migration](https://github.com/Financial-Times/n-ui-foundations#user-content-v5-to-v6) - see: https://github.com/Financial-Times/dotcom-page-kit/pull/839.

When making the final updates to a user-facing app (i.e. the endpoint of the migration), the styling of the header and footer components does not remain consistent with production:

#### Front page - local (at third commit of this PR: https://github.com/Financial-Times/next-front-page/pull/2364)
<img width="1440" alt="front-local" src="https://user-images.githubusercontent.com/10484515/86233968-2775c080-bb8e-11ea-837d-1c2af1372344.png">

#### Front page - production
<img width="1438" alt="front-prod" src="https://user-images.githubusercontent.com/10484515/86234002-36f50980-bb8e-11ea-8fdc-c0d046b35b92.png">

It is caused by `o-header` using the `oGridContainer` mixin, which used to inherit the global snappy grid setting, but the global snappy setting has now been removed from `n-ui-foundations`.

Currently, these classes are added to the CSS: `o-header__container--snappy` and `o-footer__container--snappy`, but we cannot add those classes as not all apps may want this by default, i.e. it would have to configurable which would get messy as there are several locations these `--snappy` classes would need to be applied.

This approach seems the cleanest way of maintaining the consuming apps' current snappy behaviour and requires the [following change in the consuming app](https://github.com/Financial-Times/next-front-page/pull/2364/commits/a266b23393f796615955317180be39a8fe7a76ce).

The long term approach is to move away from snappy grid behaviour but it would be better if that were a planned change, rather than one we make through force of circumstance.

N.B. I have yet to address the issue of the changes fonts as I am not sure these were the intended changes made by `n-ui-foundations`.

#### References:
- [Webpack - sass-loader: prependData](https://webpack.js.org/loaders/sass-loader/#prependdata).