### PR TITLE
Footer localiser example

### DIFF
--- a/examples/ft-ui/README.md
+++ b/examples/ft-ui/README.md
@@ -1,5 +1,21 @@
 # FT UI
 
-This example demonstrates all the FT.com layout which includes the header, navigation, and footer components. It uses [Sucrase] to provide support for JSX syntax and ESM.
+This example demonstrates all the FT.com layout which includes the header, navigation, footer and privacy-footer-localiser components. It uses [Sucrase] to provide support for JSX syntax and ESM.
 
 [Sucrase]: https://github.com/alangpierce/sucrase
+
+## Comments on `privacy-footer-localiser`
+
+Any of the two methods imported from `dotcom-privacy-footer-localiser` could well be called from `dotcom-ui-footer` if they needed to be applied to footer of all pages.
+Currently, these methods will only change the defaut footer if the user is found to be in California by the `compliance-region` service.
+The `compliance-region` service doesn't support CORS and it saves the user compliance-region in sessionStorage. Therefore, in order to get this example to make client-side changes to the footer, the following needs to happen:
+
+  - The example is rendered from `local.ft.com` with a clean sessionStorage 
+  - The user is located in California or uses a VPN to pretend to be there
+
+Alternatively a record can be saved in sessionStorage with:
+
+```
+key: user-compliance
+value: {"region":"US-CA","legislation":"ccpa,gdpr"}
+```

--- a/examples/ft-ui/README.md
+++ b/examples/ft-ui/README.md
@@ -1,6 +1,6 @@
 # FT UI
 
-This example demonstrates all the FT.com layout which includes the header, navigation and footer components. It uses [Sucrase] to provide support for JSX syntax and ESM.
+This example demonstrates all the FT.com layout which includes the header, navigation, and footer components. It uses [Sucrase] to provide support for JSX syntax and ESM.
 
 It also shows how to use the utils exposed by privacy-footer-localiser on the client-side.
 

--- a/examples/ft-ui/README.md
+++ b/examples/ft-ui/README.md
@@ -1,6 +1,8 @@
 # FT UI
 
-This example demonstrates all the FT.com layout which includes the header, navigation, footer and privacy-footer-localiser components. It uses [Sucrase] to provide support for JSX syntax and ESM.
+This example demonstrates all the FT.com layout which includes the header, navigation and footer components. It uses [Sucrase] to provide support for JSX syntax and ESM.
+
+It also shows how to use the utils exposed by privacy-footer-localiser on the client-side.
 
 [Sucrase]: https://github.com/alangpierce/sucrase
 

--- a/examples/ft-ui/client/main.js
+++ b/examples/ft-ui/client/main.js
@@ -1,6 +1,13 @@
 import readyState from 'ready-state'
 import * as layout from '@financial-times/dotcom-ui-layout'
+import {
+  addDNSLinkToFooter,
+  adaptPrivacyLinkToLegislation
+} from '@financial-times/dotcom-privacy-footer-localiser'
 
 readyState.domready.then(() => {
   layout.init()
+
+  addDNSLinkToFooter()
+  adaptPrivacyLinkToLegislation()
 })

--- a/examples/ft-ui/client/main.js
+++ b/examples/ft-ui/client/main.js
@@ -8,6 +8,9 @@ import {
 readyState.domready.then(() => {
   layout.init()
 
+  // These methods won't perform any changes to the footer unless the user is
+  // deemed to be in California.
+  // See this example's README for details on how to fake that.
   addDNSLinkToFooter()
   adaptPrivacyLinkToLegislation()
 })

--- a/examples/ft-ui/package.json
+++ b/examples/ft-ui/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@financial-times/dotcom-middleware-navigation": "file:../../packages/dotcom-middleware-navigation",
+    "@financial-times/dotcom-privacy-footer-localiser": "file:../../packages/dotcom-privacy-footer-localiser",
     "@financial-times/dotcom-ui-layout": "file:../../packages/dotcom-ui-layout",
     "@financial-times/dotcom-ui-shell": "file:../../packages/dotcom-ui-shell",
     "express": "^4.16.2",

--- a/packages/dotcom-privacy-footer-localiser/README.md
+++ b/packages/dotcom-privacy-footer-localiser/README.md
@@ -1,6 +1,8 @@
 # @financial-times/dotcom-privacy-footer-localiser
 
-This package is meant to modify the default footer of dotcom pages based on the requirements of any local legislation that might apply to a user.
+This package provides utilities to adapt the default footer of dotcom pages based on the specific requirements of the legislation that applies to each user.
+
+This module relies on `@financial-times/privacy-legislation-client` for determining the legislation that applies to the user.
 
 
 ## Getting started


### PR DESCRIPTION
Adding examples of use of the new `dotcom-privacy-footer-localiser` to the `ft-ui` example