### PR TITLE
CPP-215 - removes whitespace when loading partials

### DIFF
--- a/packages/dotcom-server-handlebars/src/loadFileContents.ts
+++ b/packages/dotcom-server-handlebars/src/loadFileContents.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
 
 export default function loadFileContents(filePath: string): string {
-  return fs.readFileSync(filePath).toString()
+  return fs.readFileSync(filePath).toString().trim()
 }


### PR DESCRIPTION
[CPP-215 Ticket](https://financialtimes.atlassian.net/browse/CPP-215)

As part of [the migration](https://github.com/Financial-Times/next-myft-email/pull/940) from `n-handlebars` to `PageKitHandlebars` on `next-myft-email` it was found that `PageKitHandlebars` adds a whitespace when compiling partials.

```diff
-<span ... >JULY 29, 2020</span>
+<span ... >JULY 29, 2020 </span>
```

adding the `trim()` on the `loadFileContents` function made the output generated by `n-handlebars` and the output generated by `PKH` be identical when digesting emails in `next-myft-email`