### PR TITLE
Correct subnav markup

### DIFF
--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -1780,7 +1780,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
             </ol>
             <ul
               aria-label="Subsections"
-              className="o-header__subnav-list o-header__subnav-list--subsections"
+              className="o-header__subnav-list o-header__subnav-list--children"
               data-trackable="subsections"
             >
               <li
@@ -3619,7 +3619,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
             </ol>
             <ul
               aria-label="Subsections"
-              className="o-header__subnav-list o-header__subnav-list--subsections"
+              className="o-header__subnav-list o-header__subnav-list--children"
               data-trackable="subsections"
             >
               <li

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/NoOutboundLinks.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/NoOutboundLinks.spec.tsx.snap
@@ -109,7 +109,7 @@ exports[`dotcom-ui-header/src/components/NoOutboundLinksHeader renders as a logg
             </ol>
             <ul
               aria-label="Subsections"
-              className="o-header__subnav-list o-header__subnav-list--subsections"
+              className="o-header__subnav-list o-header__subnav-list--children"
               data-trackable="subsections"
             >
               <li
@@ -277,7 +277,7 @@ exports[`dotcom-ui-header/src/components/NoOutboundLinksHeader renders as an ano
             </ol>
             <ul
               aria-label="Subsections"
-              className="o-header__subnav-list o-header__subnav-list--subsections"
+              className="o-header__subnav-list o-header__subnav-list--children"
               data-trackable="subsections"
             >
               <li

--- a/packages/dotcom-ui-header/src/components/sub-navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sub-navigation/partials.tsx
@@ -68,7 +68,7 @@ const BreadCrumb = ({ items }: { items: TNavMenuItem[] }) => (
 const SubSections = ({ items }: { items: TNavMenuItem[] }) => {
   return (
     <ul
-      className="o-header__subnav-list o-header__subnav-list--subsections"
+      className="o-header__subnav-list o-header__subnav-list--children"
       aria-label="Subsections"
       data-trackable="subsections">
       {items.map((item, index) => {


### PR DESCRIPTION
The class `o-header__subnav-list--subsections` does not exist.
Instead it should be `o-header__subnav-list--children`.

This will increase the padding between subnav items for PageKit
projects, which is currently too small.

![Screenshot 2020-09-02 at 12 38 57](https://user-images.githubusercontent.com/10405691/91976713-4d981800-ed19-11ea-9ef4-81889ec1ca47.png)
