### PR TITLE
Upgrade o-header to 8.5.0.

### DIFF
--- a/packages/dotcom-ui-header/bower.json
+++ b/packages/dotcom-ui-header/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "dotcom-ui-header",
   "dependencies": {
-    "o-header": "^8.4.0",
+    "o-header": "^8.5.0",
     "n-topic-search": "^3.0.0",
     "n-ui-foundations": "^6.0.0"
   },

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -1,20 +1,8 @@
-
-// Drawer
-.o-header__drawer-current-edition {
-  color: oColorsByName('black-60');
-  margin: 0.5em 0;
-}
-
-.o-header__drawer-search {
-  border-top: 2px solid oColorsByName('black-10');
-}
-
-// Sticky header
-.o-header--sticky {
-  display: none;
-}
-
 // Search
+// At the time of writing o-header duplicates search markup.
+// Once for the a experience, once for an enhanced experience.
+// Instead since we can rely on the `core` class we can use the
+// one core experience search block and reveal it if needed.
 .core [data-o-header-search] {
   display: block;
 }
@@ -31,19 +19,6 @@
 
 .o-header--sticky {
   @include nUiZIndexFor('sticky-header');
-  display: block;
-}
-
-// myFT
-.o-header__top-link--myft {
-  position: relative;
-}
-
-// Print view
-@media print {
-  .o-header--sticky {
-    display: none;
-  }
 }
 
 // Search typeahead

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -1,8 +1,10 @@
 // Search
 // At the time of writing o-header duplicates search markup.
-// Once for the a experience, once for an enhanced experience.
+// Once for a core experience, once for an enhanced experience.
+// The enhanced version is hidden until toggled with JavaScript.
 // Instead since we can rely on the `core` class we can use the
-// one core experience search block and reveal it if needed.
+// one enhanced experience search block and reveal for the core 
+// experience if needed.
 .core [data-o-header-search] {
   display: block;
 }
@@ -25,4 +27,3 @@
 .n-typeahead {
   display: none;
 }
-


### PR DESCRIPTION
- drawer css has been added to o-header: https://github.com/Financial-Times/o-header/releases/tag/v8.5.0
- sticky `display` was immediately reset to block so can be removed
- myft relative positioning was added for an old tooltip: https://github.com/Financial-Times/n-ui/pull/592
- sticky header is hidden for print as part of o-header: https://github.com/Financial-Times/o-header/blob/d93390313442713629da29b470b44f42e77f90d8/src/scss/features/_sticky.scss#L17