### PR TITLE
Upgrade dotcom-build-base compression-webpack-plugin dev dependency ^3.0.0 -> ^4.0.0

### DIFF
--- a/packages/dotcom-build-base/package.json
+++ b/packages/dotcom-build-base/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "clean-webpack-plugin": "^3.0.0",
-    "compression-webpack-plugin": "^3.0.0",
+    "compression-webpack-plugin": "^4.0.0",
     "webpack-assets-manifest": "^3.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Jira card: [CPP-357 dotcom-page-kit - Address arbitrary code injection vulnerability](https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1051&modal=detail&selectedIssue=CPP-357)

Fixes vulnerability reported by Snyk: https://app.snyk.io/org/financial-times/project/dd7eb820-a794-407f-8653-6ce9f4ab1a38#issue-SNYK-JS-SERIALIZEJAVASCRIPT-570062.

> **Detailed paths and remediation**
> - Introduced through: @financial-times/dotcom-build-base@0.0.0 › compression-webpack-plugin@3.1.0 › serialize-javascript@2.1.2
> - Remediation: Upgrade to compression-webpack-plugin@4.0.0

The breaking changes between version 3 and 4 of `compression-webpack-plugin` relate to parts of the package that I cannot see are being used: https://github.com/webpack-contrib/compression-webpack-plugin/releases/tag/v4.0.0.