### PR TITLE
Pin sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react": "^16.8.2",
     "react-dom": "^16.8.6",
     "react-test-renderer": "^16.8.6",
-    "sass": "^1.25.0",
+    "sass": "1.30.0",
     "sass-loader": "^8.0.0",
     "style-loader": "^1.0.0",
     "supertest": "^4.0.2",


### PR DESCRIPTION
[sass version 1.32.0](https://github.com/sass/dart-sass/releases/tag/1.32.0) introduced a deprecation warning for passing non-% numbers as lightness and saturation to `hsl()`. This function is used by `o-colors`.

When building `next-article`, this warning is outputted in the console over _many pages_ and it flickers really badly for a while. For people sensitive to page flickering, this is not great. To prevent this, we're thinking about pinning the dependency to before the message was introduced. Thoughts?

You can replicate this by running the following commands in `next-article`:

```
make clean
make install .env
make build
```

![image](https://user-images.githubusercontent.com/30316203/103541429-50f00b80-4e93-11eb-9cb7-51c808f73a9d.png)
