### PR TITLE
CPP-442 Upgrade GitHub repos from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,10 @@ references:
   #
   # Filters
   #
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
       only:
-        - master
+        - main
 
   filters_only_renovate_nori: &filters_only_renovate_nori
     branches:
@@ -52,10 +52,10 @@ references:
     branches:
       ignore: /(^renovate-.*|^nori\/.*|^gh-pages)/
 
-  filters_master_branch: &filters_master_branch
+  filters_main_branch: &filters_main_branch
     branches:
       only:
-        - master
+        - main
 
   filters_release_build: &filters_release_build
     tags:
@@ -138,7 +138,7 @@ workflows:
             - build
       - deploy:
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
           requires:
             - test
 

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,6 @@
 _extends: github-apps-config-next
 branches:
-  - name: master
+  - name: main
     protection:
       required_pull_request_reviews:
         required_approving_review_count: 1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FT.com Page Kit
 
-[![CircleCI](https://circleci.com/gh/Financial-Times/dotcom-page-kit/tree/master.svg?style=svg&circle-token=2149091698510f3908776e16620b30494fdca26c)](https://circleci.com/gh/Financial-Times/dotcom-page-kit/tree/master)
+[![CircleCI](https://circleci.com/gh/Financial-Times/dotcom-page-kit/tree/main.svg?style=svg&circle-token=2149091698510f3908776e16620b30494fdca26c)](https://circleci.com/gh/Financial-Times/dotcom-page-kit/tree/main)
 
 Page Kit provides a high quality, well tested, and thoroughly documented set of tools for assembling and delivering FT.com based upon the best industry standards.
 

--- a/contribution.md
+++ b/contribution.md
@@ -79,11 +79,11 @@ Please do! All of the code in Page Kit is peer-reviewed by members of the FT cus
 
 This project follows a workflow designed around project releases. It is less strict than [Gitflow] but we encourage the separation of stable, development, and experimental branches in order to follow a scheduled release cycle.
 
-- The `master` branch is for the current stable release. Bug fixes should be merged into this branch.
+- The `main` branch is for the current stable release. Bug fixes should be merged into this branch.
 
-- The `development-` branches are for upcoming major or minor releases. New features and refactors should be merged into this branch. The `master` branch should be merged into it periodically.
+- The `development-` branches are for upcoming major or minor releases. New features and refactors should be merged into this branch. The `main` branch should be merged into it periodically.
 
-- The `release-vX.X.X` branches are for old releases which are still used in production. Important bug fixes should be [cherry-picked] from the `master` branch as required.
+- The `release-vX.X.X` branches are for old releases which are still used in production. Important bug fixes should be [cherry-picked] from the `main` branch as required.
 
 [Gitflow]: https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow
 [cherry-picked]: https://git-scm.com/docs/git-cherry-pick
@@ -134,7 +134,7 @@ We have implemented [ESLint] to statically analyse code for problems.
 [Supertest]: https://github.com/visionmedia/supertest
 [Puppeteer]: https://github.com/smooth-code/jest-puppeteer
 [Enzyme]: https://github.com/airbnb/enzyme
-[enzyme-matchers]: https://github.com/FormidableLabs/enzyme-matchers/blob/master/packages/jest-enzyme
+[enzyme-matchers]: https://github.com/FormidableLabs/enzyme-matchers/blob/HEAD/packages/jest-enzyme
 [ESLint]: https://eslint.org/
 
 

--- a/examples/kitchen-sink/client/async.scss
+++ b/examples/kitchen-sink/client/async.scss
@@ -1,5 +1,5 @@
 // This stylesheet is loaded asynchonously; that is, it doesn't block the browser from rendering while it loads. 
-// See: href="https://github.com/Financial-Times/dotcom-page-kit/blob/master/packages/dotcom-ui-shell/README.md
+// See: href="https://github.com/Financial-Times/dotcom-page-kit/blob/HEAD/packages/dotcom-ui-shell/README.md
 
 .asynchronous-example {
     font-size: medium;

--- a/examples/kitchen-sink/server/controllers/home.js
+++ b/examples/kitchen-sink/server/controllers/home.js
@@ -59,7 +59,7 @@ module.exports = (_, response, next) => {
               <p>
                 The CSS for this section was loaded asynchonously; that is, the stylesheet didn't block the
                 browser from rendering while it loaded.{' '}
-                <a href="https://github.com/Financial-Times/dotcom-page-kit/blob/master/packages/dotcom-ui-shell/README.md">
+                <a href="https://github.com/Financial-Times/dotcom-page-kit/blob/HEAD/packages/dotcom-ui-shell/README.md">
                   See the README for details
                 </a>
                 .

--- a/packages/dotcom-build-base/package.json
+++ b/packages/dotcom-build-base/package.json
@@ -36,5 +36,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-build-base"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-build-base"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-base"
 }

--- a/packages/dotcom-build-bower-resolve/package.json
+++ b/packages/dotcom-build-bower-resolve/package.json
@@ -34,5 +34,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-build-bower-resolve"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-build-bower-resolve"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-bower-resolve"
 }

--- a/packages/dotcom-build-code-splitting/package.json
+++ b/packages/dotcom-build-code-splitting/package.json
@@ -38,5 +38,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-build-code-splitting"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-build-code-splitting"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-code-splitting"
 }

--- a/packages/dotcom-build-images/package.json
+++ b/packages/dotcom-build-images/package.json
@@ -35,5 +35,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-build-images"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-build-images"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-images"
 }

--- a/packages/dotcom-build-js/package.json
+++ b/packages/dotcom-build-js/package.json
@@ -42,5 +42,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-build-js"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-build-js"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-js"
 }

--- a/packages/dotcom-build-sass/package.json
+++ b/packages/dotcom-build-sass/package.json
@@ -41,5 +41,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-build-sass"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-build-sass"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-sass"
 }

--- a/packages/dotcom-middleware-app-context/package.json
+++ b/packages/dotcom-middleware-app-context/package.json
@@ -32,5 +32,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-middleware-app-context"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-middleware-app-context"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-middleware-app-context"
 }

--- a/packages/dotcom-middleware-app-context/src/index.ts
+++ b/packages/dotcom-middleware-app-context/src/index.ts
@@ -11,17 +11,17 @@ export function init(options: TMiddlewareOptions = {}) {
     const appContext = {
       // TODO: improve how we retrieve the app name.
       // HACK: this is plucked from the debug headers set by n-express:
-      // https://github.com/Financial-Times/n-express/blob/master/main.js#L76-L80
+      // https://github.com/Financial-Times/n-express/blob/HEAD/main.js#L76-L80
       appName: response.get('ft-app-name'),
       product: 'next',
       edition: request.get('ft-edition'),
       appVersion: process.env.CIRCLE_SHA1 || process.env.SOURCE_VERSION || process.env.HEROKU_SLUG_COMMIT,
       // Many headers are set to a default value of "-" by the CDN so we need to ignore those
-      // https://github.com/Financial-Times/ft.com-cdn/blob/master/src/vcl/next-preflight.vcl
+      // https://github.com/Financial-Times/ft.com-cdn/blob/HEAD/src/vcl/next-preflight.vcl
       abTestState: request.get('ft-ab') === '-' ? undefined : request.get('ft-ab'),
       isProduction: process.env.NODE_ENV === 'production',
       // This is set by the membership session service as part of preflight
-      // https://github.com/Financial-Times/next-preflight/blob/master/server/tasks/membership/session.js
+      // https://github.com/Financial-Times/next-preflight/blob/HEAD/server/tasks/membership/session.js
       isUserLoggedIn: request.get('ft-anonymous-user') === 'false',
       pageKitVersion: pkg.version === '0.0.0' ? 'development' : pkg.version,
       ...options.appContext

--- a/packages/dotcom-middleware-asset-loader/README.md
+++ b/packages/dotcom-middleware-asset-loader/README.md
@@ -5,7 +5,7 @@ This package provides an [Express] compatible middleware which integrates the [a
 In addition this package can also be used to [serve static files].
 
 [Express]: https://expressjs.com/
-[asset loader]: https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-server-asset-loader
+[asset loader]: https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-asset-loader
 [serve static files]: https://expressjs.com/en/starter/static-files.html
 
 
@@ -74,4 +74,4 @@ See the [asset loader documentation] for more details.
 
 See the [asset loader documentation] for more details.
 
-[asset loader documentation]: https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-server-asset-loader#options
+[asset loader documentation]: https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-asset-loader#options

--- a/packages/dotcom-middleware-asset-loader/package.json
+++ b/packages/dotcom-middleware-asset-loader/package.json
@@ -33,5 +33,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-middleware-asset-loader"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-middleware-asset-loader"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-middleware-asset-loader"
 }

--- a/packages/dotcom-middleware-navigation/README.md
+++ b/packages/dotcom-middleware-navigation/README.md
@@ -65,4 +65,4 @@ See the [FT navigation documentation] for more details.
 
 See the [FT navigation documentation] for more details.
 
-[FT navigation documentation]: https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-server-navigation#options
+[FT navigation documentation]: https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-navigation#options

--- a/packages/dotcom-middleware-navigation/package.json
+++ b/packages/dotcom-middleware-navigation/package.json
@@ -32,5 +32,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-middleware-navigation"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-middleware-navigation"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-middleware-navigation"
 }

--- a/packages/dotcom-middleware-navigation/src/handleEdition.ts
+++ b/packages/dotcom-middleware-navigation/src/handleEdition.ts
@@ -7,8 +7,8 @@ export default (request: Request, response: Response): string => {
   // NOTE: The FT-Edition header is set by the CDN and/or next-router...
   // If an edition is selected with a cookie or query string it will be set to that.
   // Otherwise the router will choose the best setting based on GeoIP.
-  // <https://github.com/Financial-Times/ft.com-cdn/blob/master/src/vcl/next-editions.vcl>
-  // <https://github.com/Financial-Times/next-router/blob/master/server/middleware/editions.js>
+  // <https://github.com/Financial-Times/ft.com-cdn/blob/HEAD/src/vcl/next-editions.vcl>
+  // <https://github.com/Financial-Times/next-router/blob/HEAD/server/middleware/editions.js>
   let currentEdition = request.get('FT-Edition') || defaultEdition
 
   if (typeof request.query.edition === 'string' && isEdition(request.query.edition)) {
@@ -21,7 +21,7 @@ export default (request: Request, response: Response): string => {
   }
 
   // NOTE: n-express overrides res.set() and res.vary() in order to merge all vary headers together.
-  // <https://github.com/Financial-Times/n-express/blob/master/src/middleware/vary.js>
+  // <https://github.com/Financial-Times/n-express/blob/HEAD/src/middleware/vary.js>
   response.vary('FT-Edition')
 
   return currentEdition

--- a/packages/dotcom-server-app-context/package.json
+++ b/packages/dotcom-server-app-context/package.json
@@ -32,5 +32,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-server-app-context"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-server-app-context"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-app-context"
 }

--- a/packages/dotcom-server-asset-loader/package.json
+++ b/packages/dotcom-server-asset-loader/package.json
@@ -25,7 +25,7 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-server-asset-loader"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-server-asset-loader",
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-asset-loader",
   "dependencies": {
     "url-join": "^4.0.1"
   }

--- a/packages/dotcom-server-handlebars/package.json
+++ b/packages/dotcom-server-handlebars/package.json
@@ -34,5 +34,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-server-handlebars"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-server-handlebars"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-handlebars"
 }

--- a/packages/dotcom-server-navigation/README.md
+++ b/packages/dotcom-server-navigation/README.md
@@ -2,7 +2,7 @@
 
 This package provides tools to fetch and format navigation data for FT.com.
 
-It is primarily intended to be consumed via the [`dotcom-middleware-navigation`](https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-middleware-navigation) package which can be used by Express applications.
+It is primarily intended to be consumed via the [`dotcom-middleware-navigation`](https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-middleware-navigation) package which can be used by Express applications.
 
 Data for the menus will be periodically fetched and updated from the [Next Navigation API](https://github.com/Financial-Times/next-navigation-api). This data is managed by editorial staff and is used to render the navigation components across FT.com including the header, drop-down menus, drawer, and footer.
 

--- a/packages/dotcom-server-navigation/package.json
+++ b/packages/dotcom-server-navigation/package.json
@@ -37,5 +37,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-server-navigation"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-server-navigation"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-navigation"
 }

--- a/packages/dotcom-server-react-jsx/package.json
+++ b/packages/dotcom-server-react-jsx/package.json
@@ -29,5 +29,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-server-react-jsx"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-server-react-jsx"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-react-jsx"
 }

--- a/packages/dotcom-server-react-jsx/src/types.d.ts
+++ b/packages/dotcom-server-react-jsx/src/types.d.ts
@@ -2,7 +2,7 @@ import React from 'react'
 
 // Extend @types/react to support optional additional .getInitialProps() method.
 // This is adapted from the @types/next:
-// <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/next/index.d.ts>
+// <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/HEAD/types/next/index.d.ts>
 
 /**
  * Next.js style counterpart of React.FunctionComponent.

--- a/packages/dotcom-types-navigation/package.json
+++ b/packages/dotcom-types-navigation/package.json
@@ -20,5 +20,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-types-navigation"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-types-navigation"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-types-navigation"
 }

--- a/packages/dotcom-ui-app-context/package.json
+++ b/packages/dotcom-ui-app-context/package.json
@@ -28,7 +28,7 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-app-context"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-ui-app-context",
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-app-context",
   "dependencies": {
     "@financial-times/dotcom-ui-data-embed": "file:../dotcom-ui-data-embed"
   }

--- a/packages/dotcom-ui-base-styles/package.json
+++ b/packages/dotcom-ui-base-styles/package.json
@@ -38,5 +38,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-base-styles"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-ui-base-styles"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-base-styles"
 }

--- a/packages/dotcom-ui-bootstrap/package.json
+++ b/packages/dotcom-ui-bootstrap/package.json
@@ -33,5 +33,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-bootstrap"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-ui-bootstrap"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-bootstrap"
 }

--- a/packages/dotcom-ui-data-embed/package.json
+++ b/packages/dotcom-ui-data-embed/package.json
@@ -31,6 +31,6 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-data-embed"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-ui-data-embed",
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-data-embed",
   "devDependencies": {}
 }

--- a/packages/dotcom-ui-flags/package.json
+++ b/packages/dotcom-ui-flags/package.json
@@ -34,6 +34,6 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-flags"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-ui-flags",
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-flags",
   "devDependencies": {}
 }

--- a/packages/dotcom-ui-footer/package.json
+++ b/packages/dotcom-ui-footer/package.json
@@ -34,5 +34,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-footer"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-ui-footer"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-footer"
 }

--- a/packages/dotcom-ui-footer/src/components/partials.tsx
+++ b/packages/dotcom-ui-footer/src/components/partials.tsx
@@ -61,7 +61,7 @@ const FooterContents = ({ footerData }: TFooterContentsProps) => (
     <nav className="o-footer__matrix" role="navigation" aria-label="Useful links">
       {footerData.map((item, index) => {
         // The Next navigation API splits footer links data into "columns"
-        // <https://github.com/Financial-Times/next-navigation-api/blob/master/server/transforms/footer.js>
+        // <https://github.com/Financial-Times/next-navigation-api/blob/HEAD/server/transforms/footer.js>
         const submenu = item.submenu.items as TNavMenuItem[][]
 
         return (
@@ -121,7 +121,7 @@ const CompressedLegal = ({ footerData }: TCompressedLegalProps) => {
     <React.Fragment>
       {data.map((legal, index) => (
         // The Next navigation API splits footer links data into "columns"
-        // <https://github.com/Financial-Times/next-navigation-api/blob/master/server/transforms/footer.js>
+        // <https://github.com/Financial-Times/next-navigation-api/blob/HEAD/server/transforms/footer.js>
         <div key={`column-${index}`}>
           {(legal.submenu.items as TNavMenuItem[][]).map((items, index) => (
             <ul className="o-footer__legal-links" key={`list-${index}`}>

--- a/packages/dotcom-ui-header/README.md
+++ b/packages/dotcom-ui-header/README.md
@@ -90,7 +90,7 @@ By default the logo serves as a home page link, which can be deactivated by prov
 
 _Please note_ that the myFT unread articles indicator code lives outside this package in [`n-myft-ui`].
 
-[`n-myft-ui`]: https://github.com/Financial-Times/n-myft-ui/blob/master/components/unread-articles-indicator
+[`n-myft-ui`]: https://github.com/Financial-Times/n-myft-ui/blob/HEAD/components/unread-articles-indicator
 
 ### Navigation
 

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -40,5 +40,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-header"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-ui-header"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-header"
 }

--- a/packages/dotcom-ui-layout/package.json
+++ b/packages/dotcom-ui-layout/package.json
@@ -39,5 +39,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-layout"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-ui-layout"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-layout"
 }

--- a/packages/dotcom-ui-polyfill-service/package.json
+++ b/packages/dotcom-ui-polyfill-service/package.json
@@ -27,5 +27,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-polyfill-service"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-ui-polyfill-service"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-polyfill-service"
 }

--- a/packages/dotcom-ui-shell/package.json
+++ b/packages/dotcom-ui-shell/package.json
@@ -38,5 +38,5 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-shell"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/master/packages/dotcom-ui-shell"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-shell"
 }

--- a/packages/dotcom-ui-shell/src/components/ResourceHints.tsx
+++ b/packages/dotcom-ui-shell/src/components/ResourceHints.tsx
@@ -26,7 +26,7 @@ const ResourceHints = (props: TResourceHintsProps) => {
       <link rel="preconnect" href="https://ads-api.ft.com" />
       {/*
         The Google Publisher Tag library (GPT) is hosted here which is used to deliver ads
-        <https://github.com/Financial-Times/o-ads/blob/master/src/js/ad-servers/gpt.js>
+        <https://github.com/Financial-Times/o-ads/blob/HEAD/src/js/ad-servers/gpt.js>
       */}
       <link rel="preconnect" href="https://securepubads.g.doubleclick.net" />
 

--- a/release-guidelines.md
+++ b/release-guidelines.md
@@ -1,6 +1,6 @@
 # Release Guidelines
 
-All of our packages are versioned using [Semantic Versioning]. The following guide will outline how to tag and release a new version of all packages, it assumes that all the code you wish to release is now on the `master` branch.
+All of our packages are versioned using [Semantic Versioning]. The following guide will outline how to tag and release a new version of all packages, it assumes that all the code you wish to release is now on the `main` branch.
 
 
 ## When to release
@@ -16,7 +16,7 @@ _Please note_ for apps using [Renovate] we have configured Page Kit dependencies
 
 ### Patch versions
 
-  1. Pull requests for bug fixes should be raised against the `master` branch. Label the PR with the "bug" label and tag the Platforms team to review it.
+  1. Pull requests for bug fixes should be raised against the `main` branch. Label the PR with the "bug" label and tag the Platforms team to review it.
 
   2. Release the changes. Create a release using the GitHub UI (note there should be a "v" preceding the version number). This will automatically kick off a new build and publish each package.
 
@@ -26,7 +26,7 @@ _Please note_ for apps using [Renovate] we have configured Page Kit dependencies
 
 ### Major and minor versions
 
-  1. Raise a pull request for the current `development` branch against the `master` branch if there is not one already.
+  1. Raise a pull request for the current `development` branch against the `main` branch if there is not one already.
 
   2. Review the commits and work out whether this should be a major or minor version. Check with the team if you are not sure. Major releases are generally planned out; if a breaking change has snuck in without prior-planning it may be worth removing it or attempting to make it backwards-compatible.
 
@@ -36,7 +36,7 @@ _Please note_ for apps using [Renovate] we have configured Page Kit dependencies
 
 ### Maintenance versions
 
-When we need to fix a production bug we will normally raise a PR against the `master` branch and make a patch release once it is merged.
+When we need to fix a production bug we will normally raise a PR against the `main` branch and make a patch release once it is merged.
 
 Sometimes that fix will also be needed by apps which are still running an older version of Page Kit. Because we can't always immediately upgrade apps to use the latest version we'd have to make a new maintenance release for the older version as well.
 
@@ -48,7 +48,7 @@ For example, imagine that some production apps are running Page Kit `1.0.0` and 
 
   3. Create a new branch from this commit (`git checkout -b release-v1.x <hash>`.)
 
-  4. Cherry pick the relevant commits from the `master` branch onto the branch that has just been created (`git cherry-pick <hash>`.)
+  4. Cherry pick the relevant commits from the `main` branch onto the branch that has just been created (`git cherry-pick <hash>`.)
 
   5. Push the branch and create a new `1.0.1` release.
 


### PR DESCRIPTION
[Ticket CPP-442 Upgrade GitHub repos from `master` to `main`](https://financialtimes.atlassian.net/browse/CPP-442)<br/><br/>As an organisation we are moving away from the usage of `master` as a central branch and switching it to `main`, this is to avoid using unnecessary language that can be offensive. This PR is for making those changes.