### PR TITLE
Require the latest o-typography/o-fonts release

### DIFF
--- a/packages/dotcom-ui-base-styles/bower.json
+++ b/packages/dotcom-ui-base-styles/bower.json
@@ -2,7 +2,7 @@
   "name": "dotcom-ui-base-styles",
   "dependencies": {
     "n-ui-foundations": "^6.0.0",
-    "o-typography": "^6.4.0"
+    "o-typography": "^6.4.6"
   },
   "main": ["browser.js", "styles.scss"]
 }

--- a/packages/dotcom-ui-base-styles/src/lib/fontFaces.ts
+++ b/packages/dotcom-ui-base-styles/src/lib/fontFaces.ts
@@ -1,8 +1,8 @@
 // NOTE: please also update ./styles.css when updating the URLs defined below. They
 // need to stay in-sync to ensure our CSS output matches the resource hints we set.
 export const fontFaceURLs = [
-  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Regular.woff2',
-  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Semibold.woff2',
-  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Regular.woff2',
-  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Bold.woff2'
+  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.7.0/MetricWeb-Regular.woff2',
+  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.7.0/MetricWeb-Semibold.woff2',
+  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.7.0/FinancierDisplayWeb-Regular.woff2',
+  'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.7.0/FinancierDisplayWeb-Bold.woff2'
 ]

--- a/packages/dotcom-ui-base-styles/styles.scss
+++ b/packages/dotcom-ui-base-styles/styles.scss
@@ -2,7 +2,7 @@ $system-code: 'page-kit-base-styles' !default;
 
 // NOTE: please also update ./src/lib/fontFaces.ts when updating the URL below. They
 // need to stay in-sync to ensure our CSS output matches the resource hints we set.
-$o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/';
+$o-fonts-path: 'https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.7.0/';
 
 // TODO: Migrate into this package existing usage of n-ui-foundations that
 // falls under definition of this package, with the intention of ideally

--- a/packages/dotcom-ui-layout/bower.json
+++ b/packages/dotcom-ui-layout/bower.json
@@ -2,7 +2,7 @@
   "name": "dotcom-ui-layout",
   "dependencies": {
     "n-ui-foundations": "^6.0.0",
-    "o-typography": "^6.4.0"
+    "o-typography": "^6.4.6"
   },
   "main": ["browser.js", "styles.scss"]
 }

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -108,28 +108,28 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Regular.woff2"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.7.0/MetricWeb-Regular.woff2"
       rel="preload"
       type="font/woff2"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Semibold.woff2"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.7.0/MetricWeb-Semibold.woff2"
       rel="preload"
       type="font/woff2"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Regular.woff2"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.7.0/FinancierDisplayWeb-Regular.woff2"
       rel="preload"
       type="font/woff2"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Bold.woff2"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.7.0/FinancierDisplayWeb-Bold.woff2"
       rel="preload"
       type="font/woff2"
     />


### PR DESCRIPTION
`dotcom-page-kit` preloads fonts from `o-fonts-assets` however
the version to use is hard-coded and not tied to the actual
version of fonts being installed. This update makes sure the
fonts which are preloaded and used are aligned, as a new version
of `o-fonts-assets` has been released.

Ideally we'd add a JS API to Origami, in addition to the o-font
Sass variable, so `dotcom-page-kit` can grab the correct font
urls to preload. This might tie in to some future work the
core team are considering to define variables in a JS/JSON format
which compile to Sass (a.k.a design tokens) so for now let's keep
this in sync manually.

Similar past PR:
https://github.com/Financial-Times/dotcom-page-kit/pull/826