### PR TITLE
bump cache keys to clear errors in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ references:
   #
   create_cache: &create_cache
     save_cache:
-      key: cache-v1-{{ .Branch }}-{{ checksum "./package.json" }}
+      key: cache-v2-{{ .Branch }}-{{ checksum "./package.json" }}
       paths:
         - ./node_modules/
 
@@ -32,7 +32,7 @@ references:
   restore_cache: &restore_cache
     restore_cache:
       keys:
-        - cache-v1-{{ .Branch }}-{{ checksum "./package.json" }}
+        - cache-v2-{{ .Branch }}-{{ checksum "./package.json" }}
 
   #
   # Filters


### PR DESCRIPTION
might solve [these errors](https://app.circleci.com/pipelines/github/Financial-Times/dotcom-page-kit/3847/workflows/deb9e618-e3ec-4ae0-8066-3e5ce021376b/jobs/6977).