### PR TITLE
Revert "[NOPS-103] Add Smart App Banner for the iOS app (dotcom-ui-shell)"

### DIFF
--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/DocumentHead.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/DocumentHead.test.tsx.snap
@@ -53,10 +53,6 @@ Array [
     content="@twitter_page"
     property="twitter:site"
   />,
-  <meta
-    content="app-id=1200842933, app-argument=https://my.site"
-    name="apple-itunes-app"
-  />,
   <link
     href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=svg"
     rel="icon"

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -56,10 +56,6 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
       content="@FinancialTimes"
       property="twitter:site"
     />
-    <meta
-      content="app-id=1200842933"
-      name="apple-itunes-app"
-    />
     <link
       href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=svg"
       rel="icon"

--- a/packages/dotcom-ui-shell/src/components/DocumentHead.tsx
+++ b/packages/dotcom-ui-shell/src/components/DocumentHead.tsx
@@ -43,12 +43,6 @@ const DocumentHead = (props: TDocumentHeadProps) => (
     <meta property="twitter:site" content={props.twitterSite} />
     <OpenGraph openGraph={props.openGraph} />
 
-    {/* native apps */}
-    <meta
-      name="apple-itunes-app"
-      content={props.canonicalURL ? `app-id=1200842933, app-argument=${props.canonicalURL}` : 'app-id=1200842933'}
-    />
-
     {/* packaging */}
     <link
       rel="icon"


### PR DESCRIPTION
Reverts Financial-Times/dotcom-page-kit#895

testing to see if this clears the errors