### PR TITLE
added isolatedModules field to tsconfig

### DIFF
--- a/packages/dotcom-server-app-context/src/index.ts
+++ b/packages/dotcom-server-app-context/src/index.ts
@@ -1,2 +1,2 @@
 export * from './AppContext'
-export { TAppContext } from './types'
+export type { TAppContext } from './types'

--- a/packages/dotcom-ui-bootstrap/src/components/Bootstrap.tsx
+++ b/packages/dotcom-ui-bootstrap/src/components/Bootstrap.tsx
@@ -26,4 +26,5 @@ Bootstrap.defaultProps = {
   enhancedScripts: []
 }
 
-export { Bootstrap, TBootstrapProps }
+export { Bootstrap }
+export type { TBootstrapProps }

--- a/packages/dotcom-ui-flags/src/components/FlagsEmbed.ts
+++ b/packages/dotcom-ui-flags/src/components/FlagsEmbed.ts
@@ -15,4 +15,5 @@ FlagsEmbed.defaultProps = {
   flags: {}
 }
 
-export { FlagsEmbed, TFlagsEmbedProps }
+export { FlagsEmbed }
+export type { TFlagsEmbedProps }

--- a/packages/dotcom-ui-header/src/index.tsx
+++ b/packages/dotcom-ui-header/src/index.tsx
@@ -110,12 +110,8 @@ function NoOutboundLinksHeader(props: THeaderProps) {
   return (
     <HeaderWrapper {...props}>
       {includeUserActionsNav ? <UserActionsNav {...props} /> : null}
-      <TopWrapper>
-        {props.showLogoLink ? <TopColumnCenter /> : <TopColumnCenterNoLink />}
-      </TopWrapper>
-      <NavDesktop>
-        {props.showUserNavigation ? <NavListRight {...props} /> : null}
-      </NavDesktop>
+      <TopWrapper>{props.showLogoLink ? <TopColumnCenter /> : <TopColumnCenterNoLink />}</TopWrapper>
+      <NavDesktop>{props.showUserNavigation ? <NavListRight {...props} /> : null}</NavDesktop>
       {includeSubNavigation ? <SubNavigation {...props} /> : null}
     </HeaderWrapper>
   )
@@ -123,4 +119,5 @@ function NoOutboundLinksHeader(props: THeaderProps) {
 
 NoOutboundLinksHeader.defaultProps = defaultProps
 
-export { THeaderProps, Header, MainHeader, StickyHeader, LogoOnly, NoOutboundLinksHeader, Drawer }
+export { Header, MainHeader, StickyHeader, LogoOnly, NoOutboundLinksHeader, Drawer }
+export type { THeaderProps }

--- a/packages/dotcom-ui-shell/src/components/Shell.tsx
+++ b/packages/dotcom-ui-shell/src/components/Shell.tsx
@@ -89,7 +89,8 @@ Shell.defaultProps = {
   bodyAttributes: {}
 }
 
-export { Shell, TShellProps }
+export { Shell }
+export type { TShellProps }
 
 // Export sub-components to more-easily enable custom integrations
 export { DocumentHead, ResourceHints, Content }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -61,7 +61,8 @@
     "forceConsistentCasingInFileNames": true,
 
     // Required to import JSON files
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "isolatedModules": true
   },
   "exclude": [
     "**/__test__",


### PR DESCRIPTION
This PR adds --isolatedModules with a value of `true` to tsconfig. 

Some packages in this workspace re-exports modules imported as types as regular modules and not types. 

It is difficult to track which imports should be `types` or `modules` without  ` --isolatedModules` the flag. This is the case because of the export flow which leaves the decision of the export type (type || module) to the parent file.

See https://www.typescriptlang.org/tsconfig#isolatedModules for more information.




