### PR TITLE
Hive 279 drawer amend

### DIFF
--- a/packages/dotcom-types-navigation/index.d.ts
+++ b/packages/dotcom-types-navigation/index.d.ts
@@ -50,6 +50,7 @@ export type TNavMenuItem = {
   selected?: boolean
   meganav?: TNavMeganav[]
   disableTracking?: boolean
+  index?: number
 }
 
 export type TNavMeganav = INavMeganavSections | INavMeganavArticles

--- a/packages/dotcom-ui-header/src/__stories__/story-data/drawerUK.ts
+++ b/packages/dotcom-ui-header/src/__stories__/story-data/drawerUK.ts
@@ -900,6 +900,30 @@ const data: TNavMenu = {
             label: 'Newsletters',
             url: '/newsletters',
             submenu: null
+          },
+          {
+            url: '/tour/community',
+            submenu: {
+              label: null,
+              items: [
+                {
+                  label: 'FT Live',
+                  url: 'http://live.ft.com/',
+                  submenu: null
+                },
+                {
+                  label: 'FT Forums',
+                  url: 'https://forums.ft.com/',
+                  submenu: null
+                },
+                {
+                  label: 'Board Director Programme',
+                  url: 'https://bdp.ft.com/',
+                  submenu: null
+                }
+              ]
+            },
+            label: 'FT Community'
           }
         ]
       }

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -1173,7 +1173,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
               FT Community
             </a>
             <button
-              aria-controls="o-header-drawer-child-9"
+              aria-controls="o-header-drawer-child-inner9"
               className="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--unselected"
               data-trackable="sub-level-toggle | FT Community"
             >
@@ -1183,7 +1183,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
           <ul
             className="o-header__drawer-menu-list o-header__drawer-menu-list--child"
             data-trackable="sub-level"
-            id="o-header-drawer-child-9"
+            id="o-header-drawer-child-inner9"
           >
             <li
               className="o-header__drawer-menu-item"
@@ -2507,7 +2507,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
               FT Community
             </a>
             <button
-              aria-controls="o-header-drawer-child-9"
+              aria-controls="o-header-drawer-child-inner9"
               className="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--unselected"
               data-trackable="sub-level-toggle | FT Community"
             >
@@ -2517,7 +2517,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
           <ul
             className="o-header__drawer-menu-list o-header__drawer-menu-list--child"
             data-trackable="sub-level"
-            id="o-header-drawer-child-9"
+            id="o-header-drawer-child-inner9"
           >
             <li
               className="o-header__drawer-menu-item"

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -1160,6 +1160,67 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
           </a>
         </li>
         <li
+          className="o-header__drawer-menu-item"
+        >
+          <div
+            className="o-header__drawer-menu-toggle-wrapper"
+          >
+            <a
+              className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--parent"
+              data-trackable="FT Community"
+              href="/tour/community"
+            >
+              FT Community
+            </a>
+            <button
+              aria-controls="o-header-drawer-child-9"
+              className="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--unselected"
+              data-trackable="sub-level-toggle | FT Community"
+            >
+              Show more FT Community
+            </button>
+          </div>
+          <ul
+            className="o-header__drawer-menu-list o-header__drawer-menu-list--child"
+            data-trackable="sub-level"
+            id="o-header-drawer-child-9"
+          >
+            <li
+              className="o-header__drawer-menu-item"
+            >
+              <a
+                className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--child"
+                data-trackable="FT Live"
+                href="http://live.ft.com/"
+              >
+                FT Live
+              </a>
+            </li>
+            <li
+              className="o-header__drawer-menu-item"
+            >
+              <a
+                className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--child"
+                data-trackable="FT Forums"
+                href="https://forums.ft.com/"
+              >
+                FT Forums
+              </a>
+            </li>
+            <li
+              className="o-header__drawer-menu-item"
+            >
+              <a
+                className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--child"
+                data-trackable="Board Director Programme"
+                href="https://bdp.ft.com/"
+              >
+                Board Director Programme
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li
           className="o-header__drawer-menu-item o-header__drawer-menu-item--divide"
         >
           <a
@@ -2431,6 +2492,67 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
           >
             Newsletters
           </a>
+        </li>
+        <li
+          className="o-header__drawer-menu-item"
+        >
+          <div
+            className="o-header__drawer-menu-toggle-wrapper"
+          >
+            <a
+              className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--parent"
+              data-trackable="FT Community"
+              href="/tour/community"
+            >
+              FT Community
+            </a>
+            <button
+              aria-controls="o-header-drawer-child-9"
+              className="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--unselected"
+              data-trackable="sub-level-toggle | FT Community"
+            >
+              Show more FT Community
+            </button>
+          </div>
+          <ul
+            className="o-header__drawer-menu-list o-header__drawer-menu-list--child"
+            data-trackable="sub-level"
+            id="o-header-drawer-child-9"
+          >
+            <li
+              className="o-header__drawer-menu-item"
+            >
+              <a
+                className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--child"
+                data-trackable="FT Live"
+                href="http://live.ft.com/"
+              >
+                FT Live
+              </a>
+            </li>
+            <li
+              className="o-header__drawer-menu-item"
+            >
+              <a
+                className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--child"
+                data-trackable="FT Forums"
+                href="https://forums.ft.com/"
+              >
+                FT Forums
+              </a>
+            </li>
+            <li
+              className="o-header__drawer-menu-item"
+            >
+              <a
+                className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--child"
+                data-trackable="Board Director Programme"
+                href="https://bdp.ft.com/"
+              >
+                Board Director Programme
+              </a>
+            </li>
+          </ul>
         </li>
         <li
           className="o-header__drawer-menu-item o-header__drawer-menu-item--divide"

--- a/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
@@ -4,10 +4,10 @@ import { TNavMenuItem, TNavEditions } from '@financial-times/dotcom-types-naviga
 
 export type TDrawerParentItemProps = {
   item: TNavMenuItem
-  index: number
+  idSuffix: string
 }
 
-export const DrawerParentItem = ({ item, index }: TDrawerParentItemProps) => {
+export const DrawerParentItem = ({ item, idSuffix }: TDrawerParentItemProps) => {
   const selected = item.selected ? 'selected' : 'unselected'
   return (
     <React.Fragment>
@@ -16,20 +16,23 @@ export const DrawerParentItem = ({ item, index }: TDrawerParentItemProps) => {
           className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected} o-header__drawer-menu-link--parent`}
           href={item.url}
           {...ariaSelected(item)}
-          data-trackable={item.label}>
+          data-trackable={item.label}
+        >
           {item.label}
         </a>
         <button
           className={`o-header__drawer-menu-toggle o-header__drawer-menu-toggle--${selected}`}
-          aria-controls={`o-header-drawer-child-${index}`}
-          data-trackable={`sub-level-toggle | ${item.label}`}>
+          aria-controls={`o-header-drawer-child-${idSuffix}`}
+          data-trackable={`sub-level-toggle | ${item.label}`}
+        >
           {`Show more ${item.label}`}
         </button>
       </div>
       <ul
         className="o-header__drawer-menu-list o-header__drawer-menu-list--child"
-        id={`o-header-drawer-child-${index}`}
-        data-trackable="sub-level">
+        id={`o-header-drawer-child-${idSuffix}`}
+        data-trackable="sub-level"
+      >
         {(item.submenu.items as TNavMenuItem[]).map((item) => {
           const selected = item.selected ? 'selected' : 'unselected'
           return (
@@ -38,7 +41,8 @@ export const DrawerParentItem = ({ item, index }: TDrawerParentItemProps) => {
                 className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected} o-header__drawer-menu-link--child`}
                 href={item.url}
                 data-trackable={item.label}
-                {...ariaSelected(item)}>
+                {...ariaSelected(item)}
+              >
                 {item.label}
               </a>
             </li>
@@ -56,7 +60,8 @@ export const DrawerSingleItem = (item: TNavMenuItem) => {
       className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected}`}
       href={item.url}
       data-trackable={item.label}
-      {...ariaSelected(item)}>
+      {...ariaSelected(item)}
+    >
       {item.label}
     </a>
   )
@@ -69,7 +74,8 @@ export const DrawerSpecialItem = (item: TNavMenuItem) => {
       className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected} o-header__drawer-menu-link--secondary`}
       href={item.url}
       data-trackable={item.label}
-      {...ariaSelected(item)}>
+      {...ariaSelected(item)}
+    >
       {item.label}
     </a>
   )

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -96,7 +96,11 @@ const SectionPrimary = (props: TNavMenuItem) => {
       <li className="o-header__drawer-menu-item o-header__drawer-menu-item--heading">{props.label}</li>
       {(props.submenu.items as TNavMenuItem[]).map((item, index) => (
         <li key={item.url} className="o-header__drawer-menu-item">
-          {item.submenu ? <DrawerParentItem item={item} index={index} /> : <DrawerSingleItem {...item} />}
+          {item.submenu ? (
+            <DrawerParentItem item={item} idSuffix={`${index}`} />
+          ) : (
+            <DrawerSingleItem {...item} />
+          )}
         </li>
       ))}
     </React.Fragment>
@@ -108,7 +112,11 @@ const SectionSecondary = (props: TNavMenuItem) => (
     <li className="o-header__drawer-menu-item o-header__drawer-menu-item--heading">{props.label}</li>
     {(props.submenu.items as TNavMenuItem[]).map((item, index) => (
       <li key={item.url} className="o-header__drawer-menu-item">
-        {item.submenu ? <DrawerParentItem item={item} index={index} /> : <DrawerSingleItem {...item} />}
+        {item.submenu ? (
+          <DrawerParentItem item={item} idSuffix={'inner' + index} />
+        ) : (
+          <DrawerSingleItem {...item} />
+        )}
       </li>
     ))}
   </React.Fragment>

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -19,7 +19,8 @@ const Drawer = (props: THeaderProps) => {
       data-o-header-drawer
       data-o-header-drawer--no-js
       data-trackable="drawer"
-      data-trackable-terminate>
+      data-trackable-terminate
+    >
       <div className="o-header__drawer-inner">
         <DrawerTools {...editions} />
         <Search />
@@ -44,7 +45,8 @@ const DrawerTools = (props: TNavEditions) => (
       className="o-header__drawer-tools-close"
       title="Close drawer menu"
       aria-controls="o-header-drawer"
-      data-trackable="close">
+      data-trackable="close"
+    >
       <span className="o-header__visually-hidden">Close drawer menu</span>
     </button>
     <a className="o-header__drawer-tools-logo" href="/" data-trackable="logo">
@@ -63,7 +65,8 @@ const Search = () => (
       aria-label="Site search"
       data-n-topic-search
       data-n-topic-search-categories="concepts,equities"
-      data-n-topic-search-view-all>
+      data-n-topic-search-view-all
+    >
       <label className="o-header__visually-hidden" htmlFor="o-header-drawer-search-term">
         Search the <abbr title="Financial Times">FT</abbr>
       </label>
@@ -103,9 +106,9 @@ const SectionPrimary = (props: TNavMenuItem) => {
 const SectionSecondary = (props: TNavMenuItem) => (
   <React.Fragment>
     <li className="o-header__drawer-menu-item o-header__drawer-menu-item--heading">{props.label}</li>
-    {(props.submenu.items as TNavMenuItem[]).map((item) => (
+    {(props.submenu.items as TNavMenuItem[]).map((item, index) => (
       <li key={item.url} className="o-header__drawer-menu-item">
-        <DrawerSingleItem {...item} />
+        {item.submenu ? <DrawerParentItem item={item} index={index} /> : <DrawerSingleItem {...item} />}
       </li>
     ))}
   </React.Fragment>


### PR DESCRIPTION
This is enabling a second level drawer submenu in the dotcom-ui-header.

<img width="317" alt="Screenshot 2021-09-20 at 17 18 41" src="https://user-images.githubusercontent.com/1950034/134018566-9fd6aa30-6cfb-48e7-a6a5-25fca9009694.png">
