### PR TITLE
UG-654: Add id to myFT link on the Header component

### DIFF
--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -85,6 +85,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
             data-tour-stage="myFt"
             data-trackable="my-ft"
             href="/myft"
+            id="o-header-top-link-myft"
           >
             <span
               className="o-header__visually-hidden"
@@ -1919,6 +1920,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
             data-tour-stage="myFt"
             data-trackable="my-ft"
             href="/myft"
+            id="o-header-top-link-myft"
           >
             <span
               className="o-header__visually-hidden"
@@ -3758,6 +3760,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
             data-tour-stage="myFt"
             data-trackable="my-ft"
             href="/myft"
+            id="o-header-top-link-myft"
           >
             <span
               className="o-header__visually-hidden"

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -7,7 +7,8 @@ const HeaderWrapper = (props) => (
     className={`o-header o-header--${props.variant || 'simple'}`}
     data-o-component="o-header"
     data-o-header--no-js={true}
-    tabIndex={-1}>
+    tabIndex={-1}
+  >
     {props.children}
   </header>
 )
@@ -18,7 +19,8 @@ const DrawerIcon = () => (
     className="o-header__top-link o-header__top-link--menu"
     aria-controls="o-header-drawer"
     title="Open side navigation menu"
-    data-trackable="drawer-toggle">
+    data-trackable="drawer-toggle"
+  >
     <span className="o-header__top-link-label">Open side navigation menu</span>
   </a>
 )
@@ -29,7 +31,8 @@ const SearchIcon = () => (
     className="o-header__top-link o-header__top-link--search"
     aria-controls={`o-header-search-primary`}
     title="Open search bar"
-    data-trackable="search-toggle">
+    data-trackable="search-toggle"
+  >
     <span className="o-header__top-link-label">Open search bar</span>
   </a>
 )
@@ -37,10 +40,12 @@ const SearchIcon = () => (
 const MyFt = () => (
   <a
     className="o-header__top-link o-header__top-link--myft"
+    id="o-header-top-link-myft"
     href="/myft"
     data-trackable="my-ft"
     data-tour-stage="myFt"
-    aria-label="My F T">
+    aria-label="My F T"
+  >
     <span className="o-header__visually-hidden">myFT</span>
   </a>
 )
@@ -67,7 +72,8 @@ const TopColumnCenter = () => (
       style={{ backgroundImage: 'none' }}
       data-trackable="logo"
       href="/"
-      title="Go to Financial Times homepage">
+      title="Go to Financial Times homepage"
+    >
       <BrandFtMastheadSvg title="Financial Times" />
     </a>
   </div>


### PR DESCRIPTION
As part of the [Onboarding for existing customers](https://financialtimes.atlassian.net/browse/UG-590) epic, we want to show a tooltip below the `myFT` link to indicate that their content preferences have been updated.

This PR adds an id to `myFT` link to allow the code on `next-front-page` to target an [o-tooltip](https://registry.origami.ft.com/components/o-tooltip@5.0.2/readme?brand=master#markup) to it.