### PR TITLE
CI-827 - Make includeDoctype an option on instantiation

### DIFF
--- a/packages/dotcom-server-react-jsx/src/PageKitReactJSX.ts
+++ b/packages/dotcom-server-react-jsx/src/PageKitReactJSX.ts
@@ -10,7 +10,7 @@ export interface TPageKitReactJSXOptions {
 
 const defaultOptions: TPageKitReactJSXOptions = {
   useStaticRendering: false,
-  includeDoctype: false
+  includeDoctype: true
 }
 
 export class PageKitReactJSX {


### PR DESCRIPTION
As per [CI-827](https://financialtimes.atlassian.net/browse/CI-827), there were two doctypes appearing in article pages. The second doctype was caused by [includeDoctype being set to true](https://github.com/Financial-Times/dotcom-page-kit/blob/main/packages/dotcom-server-react-jsx/src/PageKitReactJSX.ts#L43) in the renderView method here. This method seems to be the only place that this includeDoctype conditional is being modified/set (the render method of this class does not appear to be called directly anywhere external to this).

PageKitReactJSX().engine is called in a few locations. It was presumed in the negative that any of the other usage locations relied on the doctype returned by this package. Therefore, made includeDoctype false by default. Where truly required, it can be set on class instantiation: `new PageKitReactJSX({ includeDoctype: true }).engine`.

Feedback on the potential impact of the chosen changes or switching the default would be most welcome.

Some other approaches considered:
1. Removing the addition of the docType entirely
	https://github.com/Financial-Times/dotcom-page-kit/compare/remove-included-doctype
2. Modify the renderView function to allow passing a boolean through to the includeDoctype
	https://github.com/Financial-Times/dotcom-page-kit/compare/includeDoctype-passthrough-parameter
	https://github.com/Financial-Times/next-article/compare/includeDoctype-passthrough-parameter
