### PR TITLE
proposal/modal sass compilation

### DIFF
--- a/examples/building-sass-files/package.json
+++ b/examples/building-sass-files/package.json
@@ -7,9 +7,9 @@
     "test": "../../node_modules/.bin/jest"
   },
   "devDependencies": {
-    "@financial-times/dotcom-build-sass": "file:../../packages/dotcom-build-sass",
     "@financial-times/dotcom-build-base": "file:../../packages/dotcom-build-base",
-    "@financial-times/o-normalise": "^1.7.2",
+    "@financial-times/dotcom-build-sass": "file:../../packages/dotcom-build-sass",
+    "@financial-times/o-normalise": "3.0.3",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11"
   }

--- a/packages/dotcom-build-sass/src/index.ts
+++ b/packages/dotcom-build-sass/src/index.ts
@@ -95,33 +95,48 @@ export class PageKitSassPlugin {
       silent: true
     }
 
+    // Rulesets
+    //--------------------------------------------------------------------------
+    const prodOptions = [
+      // Extracts CSS into separate, non-JS files
+      // https://github.com/webpack-contrib/mini-css-extract-plugin
+      {
+        loader: MiniCssExtractPlugin.loader
+      },
+      // Add support for handling .css files
+      // https://github.com/webpack-contrib/css-loader
+      {
+        loader: require.resolve('css-loader'),
+        options: cssLoaderOptions
+      },
+      // Enable use of PostCSS for CSS postprocessing
+      // https://github.com/postcss/postcss-loader
+      {
+        loader: require.resolve('postcss-loader'),
+        options: postcssLoaderOptions
+      },
+      // Enable use of Sass for CSS preprocessing
+      // https://github.com/webpack-contrib/sass-loader
+      {
+        loader: require.resolve('sass-loader'),
+        options: sassLoaderOptions
+      }
+    ]
+
+    const devOptions = [
+      {
+        loader: require.resolve('css-loader'),
+        options: cssLoaderOptions
+      },
+      {
+        loader: require.resolve('sass-loader'),
+        options: sassLoaderOptions
+      }
+    ]
+
     compiler.options.module.rules.push({
       test: [/\.sass|scss$/],
-      use: [
-        // Extracts CSS into separate, non-JS files
-        // https://github.com/webpack-contrib/mini-css-extract-plugin
-        {
-          loader: MiniCssExtractPlugin.loader
-        },
-        // Add support for handling .css files
-        // https://github.com/webpack-contrib/css-loader
-        {
-          loader: require.resolve('css-loader'),
-          options: cssLoaderOptions
-        },
-        // Enable use of PostCSS for CSS postprocessing
-        // https://github.com/postcss/postcss-loader
-        {
-          loader: require.resolve('postcss-loader'),
-          options: postcssLoaderOptions
-        },
-        // Enable use of Sass for CSS preprocessing
-        // https://github.com/webpack-contrib/sass-loader
-        {
-          loader: require.resolve('sass-loader'),
-          options: sassLoaderOptions
-        }
-      ]
+      use: compiler.options.mode === "development" ? devOptions : prodOptions
     })
 
     new StylesOnlyPlugin(stylesOnlyPluginOptions).apply(compiler)

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -112,30 +112,30 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Regular.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Regular.woff2"
       rel="preload"
-      type="font/woff"
+      type="font/woff2"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Semibold.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Semibold.woff2"
       rel="preload"
-      type="font/woff"
+      type="font/woff2"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Regular.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Regular.woff2"
       rel="preload"
-      type="font/woff"
+      type="font/woff2"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Bold.woff"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Bold.woff2"
       rel="preload"
-      type="font/woff"
+      type="font/woff2"
     />
     <script
       dangerouslySetInnerHTML={

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -112,30 +112,30 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Regular.woff2"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Regular.woff"
       rel="preload"
-      type="font/woff2"
+      type="font/woff"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/MetricWeb-Semibold.woff2"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/MetricWeb-Semibold.woff"
       rel="preload"
-      type="font/woff2"
+      type="font/woff"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Regular.woff2"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Regular.woff"
       rel="preload"
-      type="font/woff2"
+      type="font/woff"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.5.0/FinancierDisplayWeb-Bold.woff2"
+      href="https://www.ft.com/__origami/service/build/v2/files/o-fonts-assets@1.4.1/FinancierDisplayWeb-Bold.woff"
       rel="preload"
-      type="font/woff2"
+      type="font/woff"
     />
     <script
       dangerouslySetInnerHTML={


### PR DESCRIPTION
This PR introduces a development mode for Sass compilation that removes some of the optimisations – `mini-css-extract-plugin` in particular – not required for local development.

It enables the proposal for `next-article` here: https://github.com/Financial-Times/next-article/issues/4534
