### PR TITLE
CPP-675 Update to npm 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+
+orbs:
+  node: circleci/node@4.6.0
 
 references:
 
@@ -71,6 +74,8 @@ jobs:
     steps:
       - checkout
       - *restore_cache
+      - node/install-npm:
+          version: "8"
       - run:
           name: Install project dependencies
           command: npm install

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "prettier": "prettier --write '**/*.{ts,tsx,js,jsx,json}'",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "storybook:ci": "start-storybook -c .storybook --ci --smoke-test",
-    "deploy-storybook:ci": "storybook-to-ghpages --ci"
+    "deploy-storybook:ci": "storybook-to-ghpages --ci",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "lint-staged": {
     "**/*.{ts,tsx,js,jsx}": [
@@ -59,6 +60,7 @@
     "@typescript-eslint/parser": "^3.0.0",
     "babel-loader": "^8.0.4",
     "bower": "^1.8.8",
+    "check-engine": "^1.10.1",
     "css-loader": "^3.0.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.1",
@@ -69,7 +71,7 @@
     "husky": "^4.0.0",
     "jest": "^26.0.0",
     "jest-enzyme": "^7.1.1",
-    "jest-puppeteer": "^4.2.0",
+    "jest-puppeteer": "^5.0.4",
     "lint-staged": "^10.0.0",
     "prettier": "^2.0.2",
     "puppeteer": "^3.0.0",
@@ -84,7 +86,8 @@
     "typescript": "3.9.5"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "husky": {
     "hooks": {
@@ -94,5 +97,9 @@
   "workspaces": [
     "packages/*",
     "examples/*"
-  ]
+  ],
+  "volta": {
+    "node": "12.22.7",
+    "npm": "8.1.3"
+  }
 }

--- a/packages/dotcom-build-base/package.json
+++ b/packages/dotcom-build-base/package.json
@@ -12,7 +12,8 @@
     "clean:node_modules": "rm -rf node_modules",
     "build": "npm run build:node",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -23,18 +24,23 @@
     "webpack-assets-manifest": "^3.1.1"
   },
   "devDependencies": {
-    "@types/webpack": "^4.41.7"
+    "@types/webpack": "^4.41.7",
+    "check-engine": "^1.10.1"
   },
   "peerDependencies": {
     "webpack": "^4.39.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-build-base"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-base"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-base",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/dotcom-build-bower-resolve/package.json
+++ b/packages/dotcom-build-bower-resolve/package.json
@@ -12,7 +12,8 @@
     "clean:node_modules": "rm -rf node_modules",
     "build": "npm run build:node",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -24,15 +25,20 @@
     "bower-resolve-webpack-plugin": "^1.0.5"
   },
   "devDependencies": {
-    "@types/webpack": "^4.41.7"
+    "@types/webpack": "^4.41.7",
+    "check-engine": "^1.10.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-build-bower-resolve"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-bower-resolve"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-bower-resolve",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/dotcom-build-code-splitting/package.json
+++ b/packages/dotcom-build-code-splitting/package.json
@@ -12,7 +12,8 @@
     "clean:node_modules": "rm -rf node_modules",
     "build": "npm run build:node",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -28,15 +29,20 @@
     "reliable-module-ids-plugin": "^1.0.1"
   },
   "devDependencies": {
-    "@types/webpack": "^4.41.7"
+    "@types/webpack": "^4.41.7",
+    "check-engine": "^1.10.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-build-code-splitting"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-code-splitting"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-code-splitting",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/dotcom-build-images/package.json
+++ b/packages/dotcom-build-images/package.json
@@ -12,7 +12,8 @@
     "clean:node_modules": "rm -rf node_modules",
     "build": "npm run build:node",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -25,15 +26,20 @@
     "glob": "^7.1.6"
   },
   "devDependencies": {
-    "@types/webpack": "^4.41.7"
+    "@types/webpack": "^4.41.7",
+    "check-engine": "^1.10.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-build-images"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-images"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-images",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/dotcom-build-js/package.json
+++ b/packages/dotcom-build-js/package.json
@@ -12,7 +12,8 @@
     "clean:node_modules": "rm -rf node_modules",
     "build": "npm run build:node",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -32,15 +33,20 @@
     "babel-loader": "^8.0.6"
   },
   "devDependencies": {
-    "@types/webpack": "^4.41.7"
+    "@types/webpack": "^4.41.7",
+    "check-engine": "^1.10.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-build-js"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-js"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-js",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/dotcom-build-sass/package.json
+++ b/packages/dotcom-build-sass/package.json
@@ -12,7 +12,8 @@
     "clean:node_modules": "rm -rf node_modules",
     "build": "npm run build:node",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -31,15 +32,20 @@
     "webpack-fix-style-only-entries": "^0.5.0"
   },
   "devDependencies": {
-    "@types/webpack": "^4.41.7"
+    "@types/webpack": "^4.41.7",
+    "check-engine": "^1.10.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-build-sass"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-sass"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-sass",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/dotcom-middleware-app-context/package.json
+++ b/packages/dotcom-middleware-app-context/package.json
@@ -12,25 +12,31 @@
     "clean:node_modules": "rm -rf node_modules",
     "build": "npm run build:node",
     "dev": "npm run build:node -- --watch",
-    "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node"
+    "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "check-engine": "^1.10.1",
     "node-mocks-http": "^1.7.5"
   },
   "dependencies": {
-    "@types/express": "^4.16.1",
-    "@financial-times/dotcom-server-app-context": "file:../dotcom-server-app-context"
+    "@financial-times/dotcom-server-app-context": "file:../dotcom-server-app-context",
+    "@types/express": "^4.16.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-middleware-app-context"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-middleware-app-context"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-middleware-app-context",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/dotcom-middleware-asset-loader/package.json
+++ b/packages/dotcom-middleware-asset-loader/package.json
@@ -12,26 +12,32 @@
     "clean:node_modules": "rm -rf node_modules",
     "build": "npm run build:node",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@financial-times/dotcom-server-asset-loader": "file:../../packages/dotcom-server-asset-loader",
     "@types/express": "^4.16.0",
-    "express": "^4.16.4",
-    "@financial-times/dotcom-server-asset-loader": "file:../../packages/dotcom-server-asset-loader"
+    "express": "^4.16.4"
   },
   "devDependencies": {
+    "check-engine": "^1.10.1",
     "node-mocks-http": "^1.7.3"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-middleware-asset-loader"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-middleware-asset-loader"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-middleware-asset-loader",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/dotcom-middleware-navigation/package.json
+++ b/packages/dotcom-middleware-navigation/package.json
@@ -12,7 +12,8 @@
     "clean:node_modules": "rm -rf node_modules",
     "build": "npm run build:node",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -22,15 +23,20 @@
     "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation"
   },
   "devDependencies": {
+    "check-engine": "^1.10.1",
     "node-mocks-http": "^1.7.3"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-middleware-navigation"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-middleware-navigation"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-middleware-navigation",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/dotcom-server-app-context/package.json
+++ b/packages/dotcom-server-app-context/package.json
@@ -13,7 +13,8 @@
     "clean:node_modules": "rm -rf node_modules",
     "build": "npm run build:node",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -22,15 +23,20 @@
     "ajv": "^6.10.0"
   },
   "devDependencies": {
+    "check-engine": "^1.10.1",
     "json-schema-to-markdown": "^1.1.0"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-server-app-context"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-app-context"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-app-context",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/dotcom-server-asset-loader/package.json
+++ b/packages/dotcom-server-asset-loader/package.json
@@ -12,13 +12,15 @@
     "clean:node_modules": "rm -rf node_modules",
     "build": "npm run build:node",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
@@ -28,5 +30,11 @@
   "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-asset-loader",
   "dependencies": {
     "url-join": "^4.0.1"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "devDependencies": {
+    "check-engine": "^1.10.1"
   }
 }

--- a/packages/dotcom-server-handlebars/package.json
+++ b/packages/dotcom-server-handlebars/package.json
@@ -12,7 +12,8 @@
     "clean:node_modules": "rm -rf node_modules",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
     "build": "npm run build:node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -27,12 +28,19 @@
     "react-dom": "^16.12.0"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-server-handlebars"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-handlebars"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-handlebars",
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "devDependencies": {
+    "check-engine": "^1.10.1"
+  }
 }

--- a/packages/dotcom-server-navigation/package.json
+++ b/packages/dotcom-server-navigation/package.json
@@ -12,7 +12,8 @@
     "clean:node_modules": "rm -rf node_modules",
     "build": "npm run build:node",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -26,16 +27,21 @@
     "node-fetch": "^2.2.1"
   },
   "devDependencies": {
+    "check-engine": "^1.10.1",
     "dlv": "^1.1.2",
     "nock": "^12.0.0"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-server-navigation"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-navigation"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-navigation",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/dotcom-server-react-jsx/package.json
+++ b/packages/dotcom-server-react-jsx/package.json
@@ -12,7 +12,8 @@
     "clean:node_modules": "rm -rf node_modules",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
     "build": "npm run build:node",
-    "dev": "npm run clean:dist && npm run build:node -- --watch"
+    "dev": "npm run clean:dist && npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -22,12 +23,19 @@
     "react-dom": "^16.8.6"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-server-react-jsx"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-react-jsx"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-server-react-jsx",
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "devDependencies": {
+    "check-engine": "^1.10.1"
+  }
 }

--- a/packages/dotcom-types-navigation/package.json
+++ b/packages/dotcom-types-navigation/package.json
@@ -7,18 +7,26 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:node_modules",
-    "clean:node_modules": "rm -rf node_modules"
+    "clean:node_modules": "rm -rf node_modules",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-types-navigation"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-types-navigation"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-types-navigation",
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "devDependencies": {
+    "check-engine": "^1.10.1"
+  }
 }

--- a/packages/dotcom-ui-app-context/package.json
+++ b/packages/dotcom-ui-app-context/package.json
@@ -15,13 +15,15 @@
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
     "build:browser": "npm run tsc -- --module es2015 --outDir ./dist/browser",
     "build": "npm run build:node && npm run build:browser",
-    "dev": "echo -n node browser | parallel -u -d ' ' npm run build:{} -- --watch"
+    "dev": "echo -n node browser | parallel -u -d ' ' npm run build:{} -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
@@ -31,5 +33,11 @@
   "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-app-context",
   "dependencies": {
     "@financial-times/dotcom-ui-data-embed": "file:../dotcom-ui-data-embed"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "devDependencies": {
+    "check-engine": "^1.10.1"
   }
 }

--- a/packages/dotcom-ui-base-styles/package.json
+++ b/packages/dotcom-ui-base-styles/package.json
@@ -16,7 +16,8 @@
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
     "build:browser": "npm run tsc -- --module es2015 --outDir ./dist/browser",
     "build": "npm run build:node && npm run build:browser",
-    "dev": "echo -n node browser | parallel -u -d ' ' npm run build:{} -- --watch"
+    "dev": "echo -n node browser | parallel -u -d ' ' npm run build:{} -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -25,18 +26,23 @@
     "focus-visible": "^5.0.0"
   },
   "devDependencies": {
+    "check-engine": "^1.10.1",
     "react": "^16.8.6"
   },
   "peerDependencies": {
     "react": "^16.8.6"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-base-styles"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-base-styles"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-base-styles",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/dotcom-ui-bootstrap/package.json
+++ b/packages/dotcom-ui-bootstrap/package.json
@@ -14,13 +14,15 @@
     "clean:install": "npm run clean && npm i",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
     "build": "npm run build:node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "dependencies": {
     "find-up": "^5.0.0"
@@ -33,5 +35,11 @@
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-bootstrap"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-bootstrap"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-bootstrap",
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "devDependencies": {
+    "check-engine": "^1.10.1"
+  }
 }

--- a/packages/dotcom-ui-data-embed/package.json
+++ b/packages/dotcom-ui-data-embed/package.json
@@ -15,13 +15,15 @@
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
     "build:browser": "npm run tsc -- --module es2015 --outDir ./dist/browser",
     "build": "npm run build:node && npm run build:browser",
-    "dev": "echo -n node browser | parallel -u -d ' ' npm run build:{} -- --watch"
+    "dev": "echo -n node browser | parallel -u -d ' ' npm run build:{} -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "peerDependencies": {
     "react": "^16.8.6"
@@ -32,5 +34,10 @@
     "directory": "packages/dotcom-ui-data-embed"
   },
   "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-data-embed",
-  "devDependencies": {}
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "devDependencies": {
+    "check-engine": "^1.10.1"
+  }
 }

--- a/packages/dotcom-ui-flags/package.json
+++ b/packages/dotcom-ui-flags/package.json
@@ -15,13 +15,15 @@
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
     "build:browser": "npm run tsc -- --module es2015 --outDir ./dist/browser",
     "build": "npm run build:node && npm run build:browser",
-    "dev": "echo -n node browser | parallel -u -d ' ' npm run build:{} -- --watch"
+    "dev": "echo -n node browser | parallel -u -d ' ' npm run build:{} -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "dependencies": {
     "@financial-times/dotcom-ui-data-embed": "file:../dotcom-ui-data-embed"
@@ -35,5 +37,10 @@
     "directory": "packages/dotcom-ui-flags"
   },
   "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-flags",
-  "devDependencies": {}
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "devDependencies": {
+    "check-engine": "^1.10.1"
+  }
 }

--- a/packages/dotcom-ui-footer/package.json
+++ b/packages/dotcom-ui-footer/package.json
@@ -15,7 +15,8 @@
     "clean:install": "npm run clean && npm i",
     "build": "npm run build:node",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -27,12 +28,19 @@
     "react": "^16.8.6"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-footer"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-footer"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-footer",
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "devDependencies": {
+    "check-engine": "^1.10.1"
+  }
 }

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -16,7 +16,8 @@
     "build": "npm run build:node",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
     "build:svg-to-react": "node scripts/convertSvgsToReactComponents.js",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -27,18 +28,23 @@
   "devDependencies": {
     "@financial-times/logo-images": "^1.10.1",
     "@svgr/core": "^5.0.0",
-    "camelcase": "^6.0.0"
+    "camelcase": "^6.0.0",
+    "check-engine": "^1.10.1"
   },
   "peerDependencies": {
     "react": "^16.8.6"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-header"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-header"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-header",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/dotcom-ui-layout/package.json
+++ b/packages/dotcom-ui-layout/package.json
@@ -16,28 +16,36 @@
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
     "build:browser": "npm run tsc -- --module es2015 --outDir ./dist/browser",
     "build": "npm run build:node && npm run build:browser",
-    "dev": "echo -n node browser | parallel -u -d ' ' npm run build:{} -- --watch"
+    "dev": "echo -n node browser | parallel -u -d ' ' npm run build:{} -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@financial-times/dotcom-ui-base-styles": "file:../dotcom-ui-base-styles",
-    "@financial-times/dotcom-ui-header": "file:../dotcom-ui-header",
-    "@financial-times/dotcom-ui-footer": "file:../dotcom-ui-footer",
     "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
+    "@financial-times/dotcom-ui-base-styles": "file:../dotcom-ui-base-styles",
+    "@financial-times/dotcom-ui-footer": "file:../dotcom-ui-footer",
+    "@financial-times/dotcom-ui-header": "file:../dotcom-ui-header",
     "focus-visible": "^5.0.0"
   },
   "peerDependencies": {
     "react": "^16.8.6"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-layout"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-layout"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-layout",
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "devDependencies": {
+    "check-engine": "^1.10.1"
+  }
 }

--- a/packages/dotcom-ui-polyfill-service/package.json
+++ b/packages/dotcom-ui-polyfill-service/package.json
@@ -14,18 +14,26 @@
     "clean:install": "npm run clean && npm i",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
     "build": "npm run build:node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-polyfill-service"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-polyfill-service"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-polyfill-service",
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "devDependencies": {
+    "check-engine": "^1.10.1"
+  }
 }

--- a/packages/dotcom-ui-shell/package.json
+++ b/packages/dotcom-ui-shell/package.json
@@ -14,7 +14,8 @@
     "clean:install": "npm run clean && npm i",
     "build:node": "npm run tsc -- --module commonjs --outDir ./dist/node",
     "build": "npm run build:node",
-    "dev": "npm run build:node -- --watch"
+    "dev": "npm run build:node -- --watch",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "keywords": [],
   "author": "",
@@ -31,12 +32,19 @@
     "react": "^16.8.6"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.0.0",
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
     "directory": "packages/dotcom-ui-shell"
   },
-  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-shell"
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-ui-shell",
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "devDependencies": {
+    "check-engine": "^1.10.1"
+  }
 }


### PR DESCRIPTION
We are moving to npm 8 so we are ready to migrate away from bower. There was one breaking change where `jest-puppeteer` so that the newer version of `puppeteer` we were using was within its peer dependency requirements. The major update does not seem to have affected any other behaviour. Apart from that, it was as simple as pinning a new npm version with volta (you can also update your npm globally to test the changes) and making sure CircleCI uses the right npm version too. We have added a `preinstall` script to each package's `package.json` that will make sure that npm 8 is selected when running an install.