### PR TITLE
cpp-722 widen react versions for peer deps

### DIFF
--- a/packages/dotcom-ui-bootstrap/package.json
+++ b/packages/dotcom-ui-bootstrap/package.json
@@ -28,7 +28,7 @@
     "find-up": "^5.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.6"
+    "react": "16.x || 17.x"
   },
   "repository": {
     "type": "git",
@@ -40,6 +40,7 @@
     "extends": "../../package.json"
   },
   "devDependencies": {
-    "check-engine": "^1.10.1"
+    "check-engine": "^1.10.1",
+    "react": "^16.8.6"
   }
 }

--- a/packages/dotcom-ui-data-embed/package.json
+++ b/packages/dotcom-ui-data-embed/package.json
@@ -26,7 +26,7 @@
     "npm": "7.x || 8.x"
   },
   "peerDependencies": {
-    "react": "^16.8.6"
+    "react": "16.x || 17.x"
   },
   "repository": {
     "type": "git",
@@ -38,6 +38,7 @@
     "extends": "../../package.json"
   },
   "devDependencies": {
-    "check-engine": "^1.10.1"
+    "check-engine": "^1.10.1",
+    "react": "^16.8.6"
   }
 }

--- a/packages/dotcom-ui-flags/package.json
+++ b/packages/dotcom-ui-flags/package.json
@@ -29,7 +29,7 @@
     "@financial-times/dotcom-ui-data-embed": "file:../dotcom-ui-data-embed"
   },
   "peerDependencies": {
-    "react": "^16.8.6"
+    "react": "16.x || 17.x"
   },
   "repository": {
     "type": "git",
@@ -41,6 +41,7 @@
     "extends": "../../package.json"
   },
   "devDependencies": {
-    "check-engine": "^1.10.1"
+    "check-engine": "^1.10.1",
+    "react": "^16.8.6"
   }
 }

--- a/packages/dotcom-ui-footer/package.json
+++ b/packages/dotcom-ui-footer/package.json
@@ -25,7 +25,7 @@
     "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
+    "react": "16.x || 17.x",
     "@financial-times/o-footer": "^9.2.0"
   },
   "engines": {
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "check-engine": "^1.10.1",
-    "@financial-times/o-footer": "^9.2.0"
+    "@financial-times/o-footer": "^9.2.0",
+    "react": "^16.8.6"
   }
 }

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -32,12 +32,13 @@
     "@svgr/core": "^5.0.0",
     "camelcase": "^6.0.0",
     "check-engine": "^1.10.1",
-    "@financial-times/o-header": "^9.2.0"
+    "@financial-times/o-header": "^9.2.0",
+    "react": "^16.8.6"
   },
   "peerDependencies": {
     "@financial-times/o-header": "^9.2.0",
     "@financial-times/logo-images": "^1.10.1",
-    "react": "^16.8.6"
+    "react": "16.x || 17.x"
   },
   "engines": {
     "node": ">= 12.0.0",

--- a/packages/dotcom-ui-layout/package.json
+++ b/packages/dotcom-ui-layout/package.json
@@ -31,7 +31,7 @@
     "n-ui-foundations": "^7.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
+    "react": "16.x || 17.x",
     "@financial-times/o-typography": "^7.2.0"
   },
   "engines": {
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "check-engine": "^1.10.1",
-    "@financial-times/o-typography": "^7.2.0"
+    "@financial-times/o-typography": "^7.2.0",
+    "react": "^16.8.6"
   }
 }

--- a/packages/dotcom-ui-shell/package.json
+++ b/packages/dotcom-ui-shell/package.json
@@ -29,7 +29,7 @@
     "mime-types": "^2.1.26"
   },
   "peerDependencies": {
-    "react": "^16.8.6"
+    "react": "16.x || 17.x"
   },
   "engines": {
     "node": ">= 12.0.0",
@@ -45,6 +45,7 @@
     "extends": "../../package.json"
   },
   "devDependencies": {
-    "check-engine": "^1.10.1"
+    "check-engine": "^1.10.1",
+    "react": "^16.8.6"
   }
 }


### PR DESCRIPTION
Page Kit packages currently only allow React v16 as peerDependencies. This should be widened to allow version 17 to unblock the content disco team. We could also add v18, but it's only on 18.0.0-rc.0, so not sure we'd want to do that yet? 