### PR TITLE
Added showSmartBanner to DocumentHead

### DIFF
--- a/packages/dotcom-ui-shell/README.md
+++ b/packages/dotcom-ui-shell/README.md
@@ -199,6 +199,10 @@ An optional URL to a [web app manifest file](https://developers.google.com/web/f
 
 An optional property to insert additional metadata elements into the document `<head>`. This should only be used as a last-resort when you need to add information to the page which is not covered by any other option.
 
+#### `showSmartBanner` (boolean)
+
+An optional property to explicity say whether you want to show [Smart Banner](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners) at the top of the page or not. The default is `true` so the pages will always show smart banner. 
+
 ### Social and Open Graph
 
 #### `facebookPage` (string)

--- a/packages/dotcom-ui-shell/src/__test__/components/DocumentHead.test.tsx
+++ b/packages/dotcom-ui-shell/src/__test__/components/DocumentHead.test.tsx
@@ -17,4 +17,22 @@ describe('dotcom-ui-shell/src/components/DocumentHead', () => {
     const tree = renderer.create(<Subject {...props} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
+
+  it('should not render smart banner meta tag when showSmartBanner false', () => {
+    const props = {
+      description: 'Website description.',
+      facebookPage: 'facebook-page-id',
+      pageTitle: 'Page title',
+      siteTitle: 'Website title',
+      twitterSite: '@twitter_page',
+      canonicalURL: 'https://my.site',
+      metaTags: [{ rel: 'alternate', type: 'application/rss+xml', href: 'path/to/rss' }],
+      showSmartBanner: false
+    }
+
+    const tree = renderer.create(<Subject {...props} />).root
+    expect(() => {
+      tree.findByProps({name: 'apple-itunes-app'})
+    }).toThrow()
+  })
 })

--- a/packages/dotcom-ui-shell/src/components/DocumentHead.tsx
+++ b/packages/dotcom-ui-shell/src/components/DocumentHead.tsx
@@ -15,7 +15,8 @@ export type TDocumentHeadProps = TOpenGraphProps &
     twitterSite?: string
     canonicalURL?: string
     manifestFile?: string
-    additionalMetadata?: React.ReactNode
+    additionalMetadata?: React.ReactNode,
+    showSmartBanner?: boolean
   }
 
 const DocumentHead = (props: TDocumentHeadProps) => (
@@ -44,10 +45,14 @@ const DocumentHead = (props: TDocumentHeadProps) => (
     <OpenGraph openGraph={props.openGraph} />
 
     {/* native apps */}
-    <meta
-      name="apple-itunes-app"
-      content={props.canonicalURL ? `app-id=1200842933, app-argument=${props.canonicalURL}` : 'app-id=1200842933'}
-    />
+    {props.showSmartBanner && 
+      (
+        <meta
+          name="apple-itunes-app"
+          content={props.canonicalURL ? `app-id=1200842933, app-argument=${props.canonicalURL}` : 'app-id=1200842933'}
+        />
+      )
+    }
 
     {/* packaging */}
     <link
@@ -91,7 +96,8 @@ DocumentHead.defaultProps = {
   siteTitle: 'Financial Times',
   twitterSite: '@FinancialTimes',
   manifestFile: 'https://www.ft.com/__assets/creatives/manifest/manifest-v6.json',
-  additionalMetadata: null
+  additionalMetadata: null,
+  showSmartBanner: true
 }
 
 export default DocumentHead


### PR DESCRIPTION
Page Kit consumers will be able to decide whether they want iOs Smart Banner or not on their page.

Passing `showSmartBanner` prop as false, will not render the `apple-itunes-app` meta tag. This will be used by next-subscribe so we can hide the smart banner for users which are already using the app on subs journey.