### PR TITLE
ACQ-1536: add user subscription status as field in app context

### DIFF
--- a/packages/dotcom-middleware-app-context/src/index.ts
+++ b/packages/dotcom-middleware-app-context/src/index.ts
@@ -23,6 +23,7 @@ export function init(options: TMiddlewareOptions = {}) {
       // This is set by the membership session service as part of preflight
       // https://github.com/Financial-Times/next-preflight/blob/HEAD/server/tasks/membership/session.js
       isUserLoggedIn: request.get('ft-anonymous-user') === 'false',
+      isUserSubscribed: request.get('ft-user-subscription-status') === 'subscribed',
       pageKitVersion: pkg.version === '0.0.0' ? 'development' : pkg.version,
       ...options.appContext
     }

--- a/packages/dotcom-server-app-context/schema.md
+++ b/packages/dotcom-server-app-context/schema.md
@@ -78,6 +78,12 @@ If the visitor is signed in to an FT account
 
 Default: `false`
 
+## `isUserSubscribed` (boolean)
+
+If the visitor has a valid FT subscription
+
+Default: `false`
+
 ## `product` (string)
 
 The product name

--- a/packages/dotcom-server-app-context/src/schema.json
+++ b/packages/dotcom-server-app-context/src/schema.json
@@ -61,6 +61,11 @@
       "description": "If the visitor is signed in to an FT account",
       "default": false
     },
+    "isUserSubscribed": {
+      "type": "boolean",
+      "description": "If the visitor is subscribed to a FT subscription",
+      "default": false
+    },
     "product": {
       "type": "string",
       "description": "The product name",

--- a/packages/dotcom-server-app-context/src/types.d.ts
+++ b/packages/dotcom-server-app-context/src/types.d.ts
@@ -10,6 +10,7 @@ export interface TAppContext {
   conceptType?: string
   isProduction: boolean
   isUserLoggedIn?: boolean
+  isUserSubscribed?: boolean
   publishReference?: string
   [key: string]: any
 }


### PR DESCRIPTION
As part of the following tasks https://financialtimes.atlassian.net/browse/ACQ-1393, we want to render different components based on user status in homepage, in particular, know whether the user is under the following categories: anonymous, registered, subscribed.

In that sense we want to include this information [provided by preflight](https://github.com/Financial-Times/next-preflight/blob/0157653677c5aa834bf9051393f3a6b7959f1249/server/tasks/next/ammit.js#L43) as part of the app context and make it available for the consumers.

At the moment we have already `isUserLoggedIn` which allow to know if the user is **anon** or not, so by adding this new field `isUserSubscribed` we can distinguish the other two status **registered** and **subscribed**.