### PR TITLE
ACQ-1535: relocate nav and top buttons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@4.6.0
-  browser-tools: circleci/browser-tools@1.2.3
+  node: circleci/node@4.9.0
+  browser-tools: circleci/browser-tools@1.2.4
 
 references:
 

--- a/examples/ft-ui/__test__/anonymous-user.test.js
+++ b/examples/ft-ui/__test__/anonymous-user.test.js
@@ -6,7 +6,7 @@ describe('examples/ft-ui', () => {
 
   describe('Header link elements', () => {
     it('renders the expected anonymous user Header link elements', async () => {
-      await expect(page).toMatchElement('.o-header__top-column--right a[href="/myft"]', { text: 'myFT' })
+      await expect(page).toMatchElement('a[href="/myft"]', { text: 'myFT' })
       await expect(page).toMatchElement('.o-header__nav-list--right a[href="/login?location=/"]', {
         text: 'Sign In'
       })
@@ -22,9 +22,7 @@ describe('examples/ft-ui', () => {
           text: 'Settings & Account'
         }
       )
-      await expect(
-        page
-      ).not.toMatchElement(
+      await expect(page).not.toMatchElement(
         `.o-header__nav-list--right a[href="https://markets.ft.com/data/portfolio/dashboard"]`,
         { text: 'Portfolio' }
       )

--- a/examples/ft-ui/__test__/anonymous-user.test.js
+++ b/examples/ft-ui/__test__/anonymous-user.test.js
@@ -7,23 +7,23 @@ describe('examples/ft-ui', () => {
   describe('Header link elements', () => {
     it('renders the expected anonymous user Header link elements', async () => {
       await expect(page).toMatchElement('a[href="/myft"]', { text: 'myFT' })
-      await expect(page).toMatchElement('.o-header__nav-list--right a[href="/login?location=/"]', {
+      await expect(page).toMatchElement('.o-header__top-column--right a[href="/login?location=/"]', {
         text: 'Sign In'
       })
-      await expect(page).toMatchElement('.o-header__nav-list--right a[href^="/products?"]', {
+      await expect(page).toMatchElement('.o-header__top-column--right a[href^="/products?"]', {
         text: 'Subscribe'
       })
     })
 
     it('does not render the logged-in user Header link elements', async () => {
       await expect(page).not.toMatchElement(
-        '.o-header__nav-list--right a[href="https://www.ft.com/myaccount"]',
+        '.o-header__top-column--right a[href="https://www.ft.com/myaccount"]',
         {
           text: 'Settings & Account'
         }
       )
       await expect(page).not.toMatchElement(
-        `.o-header__nav-list--right a[href="https://markets.ft.com/data/portfolio/dashboard"]`,
+        `.o-header__top-column--right a[href="https://markets.ft.com/data/portfolio/dashboard"]`,
         { text: 'Portfolio' }
       )
     })

--- a/examples/ft-ui/__test__/logged-in-user.test.js
+++ b/examples/ft-ui/__test__/logged-in-user.test.js
@@ -18,10 +18,10 @@ describe('examples/ft-ui', () => {
     })
 
     it('does not render the anonymous user Header link elements', async () => {
-      await expect(page).not.toMatchElement('.o-header__nav-list--right a[href="/login?location=/"]', {
+      await expect(page).not.toMatchElement('.o-header__top-column--right a[href="/login?location=/"]', {
         text: 'Sign In'
       })
-      await expect(page).toMatchElement('.o-header__nav-list--right a[href^="/products?"]', {
+      await expect(page).toMatchElement('.o-header__top-column--right a[href^="/products?"]', {
         text: 'Subscribe'
       })
     })

--- a/examples/ft-ui/__test__/subscribed-user.test.js
+++ b/examples/ft-ui/__test__/subscribed-user.test.js
@@ -1,7 +1,7 @@
 describe('examples/ft-ui', () => {
   beforeAll(async () => {
     await page.setViewport({ width: 1920, height: 1080 })
-    await page.goto('http://localhost:3456?userIsLoggedIn=true', { waitUntil: 'load' })
+    await page.goto('http://localhost:3456?userIsLoggedIn=true&userIsSubscribed=true', { waitUntil: 'load' })
   })
 
   describe('Header link elements', () => {
@@ -21,7 +21,7 @@ describe('examples/ft-ui', () => {
       await expect(page).not.toMatchElement('.o-header__nav-list--right a[href="/login?location=/"]', {
         text: 'Sign In'
       })
-      await expect(page).toMatchElement('.o-header__nav-list--right a[href^="/products?"]', {
+      await expect(page).not.toMatchElement('.o-header__nav-list--right a[href^="/products?"]', {
         text: 'Subscribe'
       })
     })

--- a/examples/ft-ui/__test__/subscribed-user.test.js
+++ b/examples/ft-ui/__test__/subscribed-user.test.js
@@ -18,10 +18,10 @@ describe('examples/ft-ui', () => {
     })
 
     it('does not render the anonymous user Header link elements', async () => {
-      await expect(page).not.toMatchElement('.o-header__nav-list--right a[href="/login?location=/"]', {
+      await expect(page).not.toMatchElement('.o-header__top-column--right a[href="/login?location=/"]', {
         text: 'Sign In'
       })
-      await expect(page).not.toMatchElement('.o-header__nav-list--right a[href^="/products?"]', {
+      await expect(page).not.toMatchElement('.o-header__top-column--right a[href^="/products?"]', {
         text: 'Subscribe'
       })
     })

--- a/examples/ft-ui/server/controllers/home.jsx
+++ b/examples/ft-ui/server/controllers/home.jsx
@@ -22,12 +22,13 @@ export function homeController(request, response, next) {
   }
 
   const userIsLoggedIn = request.query.userIsLoggedIn
+  const userIsSubscribed = request.query.userIsSubscribed === 'true'
 
   const layoutProps = {
     navigationData: response.locals.navigation,
     headerOptions: userIsLoggedIn
-      ? { userIsAnonymous: false, userIsLoggedIn: true }
-      : { userIsAnonymous: true, userIsLoggedIn: false }
+      ? { userIsAnonymous: false, userIsLoggedIn: true, userIsSubscribed }
+      : { userIsAnonymous: true, userIsLoggedIn: false, userIsSubscribed }
   }
 
   try {

--- a/examples/kitchen-sink/__test__/integration.test.js
+++ b/examples/kitchen-sink/__test__/integration.test.js
@@ -24,7 +24,6 @@ describe('examples/kitchen-sink/integration', () => {
   it('renders the header top components; search, menu and myFT', () => {
     expect(response.text).toContain('data-trackable="search-toggle">')
     expect(response.text).toContain('data-trackable="drawer-toggle"')
-    expect(response.text).toContain('href="/myft" data-trackable="my-ft"')
   })
 
   it('populates navigation elements with navigation data', () => {

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -32,11 +32,11 @@
     "@svgr/core": "^5.0.0",
     "camelcase": "^6.0.0",
     "check-engine": "^1.10.1",
-    "@financial-times/o-header": "^9.2.0",
+    "@financial-times/o-header": "^10.0.0",
     "react": "^16.8.6"
   },
   "peerDependencies": {
-    "@financial-times/o-header": "^9.2.0",
+    "@financial-times/o-header": "^10.0.0",
     "@financial-times/logo-images": "^1.10.1",
     "react": "16.x || 17.x"
   },

--- a/packages/dotcom-ui-header/src/__stories__/story.tsx
+++ b/packages/dotcom-ui-header/src/__stories__/story.tsx
@@ -51,6 +51,7 @@ DefaultHeaderWithDrawer.args = {
   showMegaNav: true,
   showUserNavigation: true,
   userIsLoggedIn: false,
+  userIsSubscribed: false,
   showLogoLink: false
 }
 
@@ -106,6 +107,7 @@ _StickyHeader.story = {
 _StickyHeader.args = {
   showUserNavigation: true,
   userIsLoggedIn: false,
+  userIsSubscribed: false,
   showStickyHeader: false
 }
 _StickyHeader.argTypes = {

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
         >
           <a
             aria-controls="o-header-drawer"
-            className="o-header__top-link o-header__top-link--menu"
+            className="o-header__top-icon-link o-header__top-icon-link--menu"
             data-trackable="drawer-toggle"
             href="#o-header-drawer"
             title="Open side navigation menu"
@@ -36,7 +36,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
           </a>
           <a
             aria-controls="o-header-search-primary"
-            className="o-header__top-link o-header__top-link--search"
+            className="o-header__top-icon-link o-header__top-icon-link--search"
             data-trackable="search-toggle"
             href="#o-header-search-primary"
             title="Open search bar"
@@ -80,7 +80,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
           className="o-header__top-column o-header__top-column--right"
         >
           <a
-            className="o-header__top-button"
+            className="o-header__top-button o-header__top-button--hide-m"
             data-trackable="Subscribe"
             href="/products?segmentId=#"
             role="button"
@@ -89,7 +89,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
           </a>
           <a
             aria-label="My F T"
-            className="o-header__top-link o-header__top-link--myft"
+            className="o-header__top-icon-link o-header__top-icon-link--myft "
             data-tour-stage="myFt"
             data-trackable="my-ft"
             href="/myft"
@@ -1866,7 +1866,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
         >
           <a
             aria-controls="o-header-drawer"
-            className="o-header__top-link o-header__top-link--menu"
+            className="o-header__top-icon-link o-header__top-icon-link--menu"
             data-trackable="drawer-toggle"
             href="#o-header-drawer"
             title="Open side navigation menu"
@@ -1879,7 +1879,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
           </a>
           <a
             aria-controls="o-header-search-primary"
-            className="o-header__top-link o-header__top-link--search"
+            className="o-header__top-icon-link o-header__top-icon-link--search"
             data-trackable="search-toggle"
             href="#o-header-search-primary"
             title="Open search bar"
@@ -1923,7 +1923,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
           className="o-header__top-column o-header__top-column--right"
         >
           <a
-            className="o-header__top-button"
+            className="o-header__top-button o-header__top-button--hide-m"
             data-trackable="Subscribe"
             href="/products?segmentId=#"
             role="button"
@@ -1932,7 +1932,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
           </a>
           <a
             aria-label="My F T"
-            className="o-header__top-link o-header__top-link--myft"
+            className="o-header__top-icon-link o-header__top-icon-link--myft "
             data-tour-stage="myFt"
             data-trackable="my-ft"
             href="/myft"
@@ -3714,7 +3714,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
         >
           <a
             aria-controls="o-header-drawer"
-            className="o-header__top-link o-header__top-link--menu"
+            className="o-header__top-icon-link o-header__top-icon-link--menu"
             data-trackable="drawer-toggle"
             href="#o-header-drawer"
             title="Open side navigation menu"
@@ -3727,7 +3727,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
           </a>
           <a
             aria-controls="o-header-search-primary"
-            className="o-header__top-link o-header__top-link--search"
+            className="o-header__top-icon-link o-header__top-icon-link--search"
             data-trackable="search-toggle"
             href="#o-header-search-primary"
             title="Open search bar"
@@ -3771,7 +3771,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
           className="o-header__top-column o-header__top-column--right"
         >
           <a
-            className="o-header__top-button"
+            className="o-header__top-button o-header__top-button--hide-m"
             data-trackable="Subscribe"
             href="/products?segmentId=#"
             role="button"
@@ -3779,11 +3779,25 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
             Subscribe
           </a>
           <a
-            className="o-header__nav-link"
+            className="o-header__top-link o-header__top-link--hide-m"
             data-trackable="Sign In"
             href="/login?location=#"
           >
             Sign In
+          </a>
+          <a
+            aria-label="My F T"
+            className="o-header__top-icon-link o-header__top-icon-link--myft o-header__top-icon-link--show-m"
+            data-tour-stage="myFt"
+            data-trackable="my-ft"
+            href="/myft"
+            id="o-header-top-link-myft"
+          >
+            <span
+              className="o-header__visually-hidden"
+            >
+              myFT
+            </span>
           </a>
         </div>
       </div>

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -85,7 +85,16 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
           >
             <li
               className="o-header__nav-item"
-            />
+            >
+              <a
+                className="o-header__nav-button"
+                data-trackable="Subscribe"
+                href="/products?segmentId=#"
+                role="button"
+              >
+                Subscribe
+              </a>
+            </li>
             <li
               className="o-header__nav-item o-header__nav-item--hide-s"
             >
@@ -1932,7 +1941,16 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
           >
             <li
               className="o-header__nav-item"
-            />
+            >
+              <a
+                className="o-header__nav-button"
+                data-trackable="Subscribe"
+                href="/products?segmentId=#"
+                role="button"
+              >
+                Subscribe
+              </a>
+            </li>
             <li
               className="o-header__nav-item o-header__nav-item--hide-s"
             >

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -79,41 +79,28 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
         <div
           className="o-header__top-column o-header__top-column--right"
         >
-          <ul
-            className="o-header__nav-list o-header__nav-list--right"
-            data-trackable="user-nav"
+          <a
+            className="o-header__top-button"
+            data-trackable="Subscribe"
+            href="/products?segmentId=#"
+            role="button"
           >
-            <li
-              className="o-header__nav-item"
+            Subscribe
+          </a>
+          <a
+            aria-label="My F T"
+            className="o-header__top-link o-header__top-link--myft"
+            data-tour-stage="myFt"
+            data-trackable="my-ft"
+            href="/myft"
+            id="o-header-top-link-myft"
+          >
+            <span
+              className="o-header__visually-hidden"
             >
-              <a
-                className="o-header__nav-button"
-                data-trackable="Subscribe"
-                href="/products?segmentId=#"
-                role="button"
-              >
-                Subscribe
-              </a>
-            </li>
-            <li
-              className="o-header__nav-item o-header__nav-item--hide-s"
-            >
-              <a
-                aria-label="My F T"
-                className="o-header__top-link o-header__top-link--myft"
-                data-tour-stage="myFt"
-                data-trackable="my-ft"
-                href="/myft"
-                id="o-header-top-link-myft"
-              >
-                <span
-                  className="o-header__visually-hidden"
-                >
-                  myFT
-                </span>
-              </a>
-            </li>
-          </ul>
+              myFT
+            </span>
+          </a>
         </div>
       </div>
     </div>
@@ -1935,41 +1922,28 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
         <div
           className="o-header__top-column o-header__top-column--right"
         >
-          <ul
-            className="o-header__nav-list o-header__nav-list--right"
-            data-trackable="user-nav"
+          <a
+            className="o-header__top-button"
+            data-trackable="Subscribe"
+            href="/products?segmentId=#"
+            role="button"
           >
-            <li
-              className="o-header__nav-item"
+            Subscribe
+          </a>
+          <a
+            aria-label="My F T"
+            className="o-header__top-link o-header__top-link--myft"
+            data-tour-stage="myFt"
+            data-trackable="my-ft"
+            href="/myft"
+            id="o-header-top-link-myft"
+          >
+            <span
+              className="o-header__visually-hidden"
             >
-              <a
-                className="o-header__nav-button"
-                data-trackable="Subscribe"
-                href="/products?segmentId=#"
-                role="button"
-              >
-                Subscribe
-              </a>
-            </li>
-            <li
-              className="o-header__nav-item o-header__nav-item--hide-s"
-            >
-              <a
-                aria-label="My F T"
-                className="o-header__top-link o-header__top-link--myft"
-                data-tour-stage="myFt"
-                data-trackable="my-ft"
-                href="/myft"
-                id="o-header-top-link-myft"
-              >
-                <span
-                  className="o-header__visually-hidden"
-                >
-                  myFT
-                </span>
-              </a>
-            </li>
-          </ul>
+              myFT
+            </span>
+          </a>
         </div>
       </div>
     </div>
@@ -3796,35 +3770,21 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
         <div
           className="o-header__top-column o-header__top-column--right"
         >
-          <ul
-            className="o-header__nav-list o-header__nav-list--right"
-            data-trackable="user-nav"
+          <a
+            className="o-header__top-button"
+            data-trackable="Subscribe"
+            href="/products?segmentId=#"
+            role="button"
           >
-            <li
-              className="o-header__nav-item"
-            >
-              <a
-                className="o-header__nav-button"
-                data-trackable="Subscribe"
-                href="/products?segmentId=#"
-                role="button"
-              >
-                Subscribe
-              </a>
-            </li>
-            <span />
-            <li
-              className="o-header__nav-item o-header__nav-item--hide-s"
-            >
-              <a
-                className="o-header__nav-link"
-                data-trackable="Sign In"
-                href="/login?location=#"
-              >
-                Sign In
-              </a>
-            </li>
-          </ul>
+            Subscribe
+          </a>
+          <a
+            className="o-header__nav-link"
+            data-trackable="Sign In"
+            href="/login?location=#"
+          >
+            Sign In
+          </a>
         </div>
       </div>
     </div>

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -79,20 +79,32 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
         <div
           className="o-header__top-column o-header__top-column--right"
         >
-          <a
-            aria-label="My F T"
-            className="o-header__top-link o-header__top-link--myft"
-            data-tour-stage="myFt"
-            data-trackable="my-ft"
-            href="/myft"
-            id="o-header-top-link-myft"
+          <ul
+            className="o-header__nav-list o-header__nav-list--right"
+            data-trackable="user-nav"
           >
-            <span
-              className="o-header__visually-hidden"
+            <li
+              className="o-header__nav-item"
+            />
+            <li
+              className="o-header__nav-item o-header__nav-item--hide-s"
             >
-              myFT
-            </span>
-          </a>
+              <a
+                aria-label="My F T"
+                className="o-header__top-link o-header__top-link--myft"
+                data-tour-stage="myFt"
+                data-trackable="my-ft"
+                href="/myft"
+                id="o-header-top-link-myft"
+              >
+                <span
+                  className="o-header__visually-hidden"
+                >
+                  myFT
+                </span>
+              </a>
+            </li>
+          </ul>
         </div>
       </div>
     </div>
@@ -1914,20 +1926,32 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
         <div
           className="o-header__top-column o-header__top-column--right"
         >
-          <a
-            aria-label="My F T"
-            className="o-header__top-link o-header__top-link--myft"
-            data-tour-stage="myFt"
-            data-trackable="my-ft"
-            href="/myft"
-            id="o-header-top-link-myft"
+          <ul
+            className="o-header__nav-list o-header__nav-list--right"
+            data-trackable="user-nav"
           >
-            <span
-              className="o-header__visually-hidden"
+            <li
+              className="o-header__nav-item"
+            />
+            <li
+              className="o-header__nav-item o-header__nav-item--hide-s"
             >
-              myFT
-            </span>
-          </a>
+              <a
+                aria-label="My F T"
+                className="o-header__top-link o-header__top-link--myft"
+                data-tour-stage="myFt"
+                data-trackable="my-ft"
+                href="/myft"
+                id="o-header-top-link-myft"
+              >
+                <span
+                  className="o-header__visually-hidden"
+                >
+                  myFT
+                </span>
+              </a>
+            </li>
+          </ul>
         </div>
       </div>
     </div>
@@ -3754,20 +3778,35 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
         <div
           className="o-header__top-column o-header__top-column--right"
         >
-          <a
-            aria-label="My F T"
-            className="o-header__top-link o-header__top-link--myft"
-            data-tour-stage="myFt"
-            data-trackable="my-ft"
-            href="/myft"
-            id="o-header-top-link-myft"
+          <ul
+            className="o-header__nav-list o-header__nav-list--right"
+            data-trackable="user-nav"
           >
-            <span
-              className="o-header__visually-hidden"
+            <li
+              className="o-header__nav-item"
             >
-              myFT
-            </span>
-          </a>
+              <a
+                className="o-header__nav-button"
+                data-trackable="Subscribe"
+                href="/products?segmentId=#"
+                role="button"
+              >
+                Subscribe
+              </a>
+            </li>
+            <span />
+            <li
+              className="o-header__nav-item o-header__nav-item--hide-s"
+            >
+              <a
+                className="o-header__nav-link"
+                data-trackable="Sign In"
+                href="/login?location=#"
+              >
+                Sign In
+              </a>
+            </li>
+          </ul>
         </div>
       </div>
     </div>

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
@@ -215,39 +215,26 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as a logged in use
           <div
             className="o-header__top-column o-header__top-column--right"
           >
-            <ul
-              className="o-header__nav-list o-header__nav-list--right"
-              data-trackable="user-nav"
+            <a
+              className="o-header__top-button"
+              data-trackable="Subscribe"
+              href="/products?segmentId=#"
+              role="button"
             >
-              <li
-                className="o-header__nav-item"
+              Subscribe
+            </a>
+            <a
+              className="o-header__top-link o-header__top-link--myft"
+              data-trackable="my-ft"
+              href="/myft"
+              tabIndex={-1}
+            >
+              <span
+                className="o-header__visually-hidden"
               >
-                <a
-                  className="o-header__nav-button"
-                  data-trackable="Subscribe"
-                  href="/products?segmentId=#"
-                  role="button"
-                >
-                  Subscribe
-                </a>
-              </li>
-              <li
-                className="o-header__nav-item o-header__nav-item--hide-s"
-              >
-                <a
-                  className="o-header__top-link o-header__top-link--myft"
-                  data-trackable="my-ft"
-                  href="/myft"
-                  tabIndex={-1}
-                >
-                  <span
-                    className="o-header__visually-hidden"
-                  >
-                    myFT
-                  </span>
-                </a>
-              </li>
-            </ul>
+                myFT
+              </span>
+            </a>
           </div>
         </div>
       </div>

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
@@ -212,18 +212,34 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as a logged in use
         <div
           className="o-header__top-column o-header__top-column--right"
         >
-          <a
-            className="o-header__top-link o-header__top-link--myft"
-            data-trackable="my-ft"
-            href="/myft"
-            tabIndex={-1}
+          <div
+            className="o-header__top-column o-header__top-column--right"
           >
-            <span
-              className="o-header__visually-hidden"
+            <ul
+              className="o-header__nav-list o-header__nav-list--right"
+              data-trackable="user-nav"
             >
-              myFT
-            </span>
-          </a>
+              <li
+                className="o-header__nav-item"
+              />
+              <li
+                className="o-header__nav-item o-header__nav-item--hide-s"
+              >
+                <a
+                  className="o-header__top-link o-header__top-link--myft"
+                  data-trackable="my-ft"
+                  href="/myft"
+                  tabIndex={-1}
+                >
+                  <span
+                    className="o-header__visually-hidden"
+                  >
+                    myFT
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
@@ -22,7 +22,7 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as a logged in use
         >
           <a
             aria-controls="o-header-drawer"
-            className="o-header__top-link o-header__top-link--menu"
+            className="o-header__top-icon-link o-header__top-icon-link--menu"
             data-trackable="drawer-toggle"
             href="#"
             tabIndex={-1}
@@ -35,7 +35,7 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as a logged in use
           </a>
           <a
             aria-controls="o-header-search-sticky"
-            className="o-header__top-link o-header__top-link--search"
+            className="o-header__top-icon-link o-header__top-icon-link--search"
             data-trackable="search-toggle"
             href="#"
             tabIndex={-1}
@@ -216,7 +216,7 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as a logged in use
             className="o-header__top-column o-header__top-column--right"
           >
             <a
-              className="o-header__top-button"
+              className="o-header__top-button o-header__top-button--hide-m"
               data-trackable="Subscribe"
               href="/products?segmentId=#"
               role="button"
@@ -224,7 +224,7 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as a logged in use
               Subscribe
             </a>
             <a
-              className="o-header__top-link o-header__top-link--myft"
+              className="o-header__top-icon-link o-header__top-icon-link--myft "
               data-trackable="my-ft"
               href="/myft"
               tabIndex={-1}
@@ -330,7 +330,7 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as an anonymous us
         >
           <a
             aria-controls="o-header-drawer"
-            className="o-header__top-link o-header__top-link--menu"
+            className="o-header__top-icon-link o-header__top-icon-link--menu"
             data-trackable="drawer-toggle"
             href="#"
             tabIndex={-1}
@@ -343,7 +343,7 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as an anonymous us
           </a>
           <a
             aria-controls="o-header-search-sticky"
-            className="o-header__top-link o-header__top-link--search"
+            className="o-header__top-icon-link o-header__top-icon-link--search"
             data-trackable="search-toggle"
             href="#"
             tabIndex={-1}

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
@@ -221,7 +221,16 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as a logged in use
             >
               <li
                 className="o-header__nav-item"
-              />
+              >
+                <a
+                  className="o-header__nav-button"
+                  data-trackable="Subscribe"
+                  href="/products?segmentId=#"
+                  role="button"
+                >
+                  Subscribe
+                </a>
+              </li>
               <li
                 className="o-header__nav-item o-header__nav-item--hide-s"
               >

--- a/packages/dotcom-ui-header/src/__test__/enzyme/component.spec.tsx
+++ b/packages/dotcom-ui-header/src/__test__/enzyme/component.spec.tsx
@@ -89,8 +89,12 @@ describe('dotcom-ui-header', () => {
     const header = mount(anonymousUserHeader)
 
     it('renders the expected anonymous user header links', () => {
-      expect(header.find('.o-header__anon-item a[data-trackable="Subscribe"]')).toExist()
-      expect(header.find('.o-header__nav-item a[data-trackable="Sign In"]')).toExist()
+      expect(
+        header.find('.o-header__top-column .o-header__top-column--right a[data-trackable="Subscribe"]')
+      ).toExist()
+      expect(
+        header.find('.o-header__top-column .o-header__top-column--right a[data-trackable="Sign In"]')
+      ).toExist()
     })
 
     it('does not render the logged in user header links', () => {

--- a/packages/dotcom-ui-header/src/__test__/enzyme/component.spec.tsx
+++ b/packages/dotcom-ui-header/src/__test__/enzyme/component.spec.tsx
@@ -13,6 +13,7 @@ const headerFixture = {
   ...dataFixture,
   data: { ...dataFixture.data, currentPath: '/' }
 }
+const subscribedUserFixture = { ...dataFixture, showUserNavigation: true, userIsSubscribed: true }
 const loggedInUserFixture = { ...dataFixture, showUserNavigation: true }
 const anonymousUserFixture = {
   ...dataFixture,
@@ -22,6 +23,7 @@ const anonymousUserFixture = {
 }
 
 const commonHeader = <Header {...headerFixture} />
+const subscribedUserHeader = <Header {...subscribedUserFixture} />
 const loggedInUserHeader = <Header {...loggedInUserFixture} />
 const anonymousUserHeader = <Header {...anonymousUserFixture} />
 
@@ -55,6 +57,20 @@ describe('dotcom-ui-header', () => {
     expect(header.find('#o-header-nav-mobile')).toExist()
   })
 
+  describe('When the user is subscribed', () => {
+    const header = mount(subscribedUserHeader)
+
+    it('renders the expected logged in user header links', () => {
+      expect(header.find('a[data-trackable="Portfolio"]')).toExist()
+      expect(header.find('a[data-trackable="Settings & Account"]')).toExist()
+    })
+
+    it('does not render sign in link', () => {
+      expect(header.find('a[data-trackable="Subscribe"]')).not.toExist()
+      expect(header.find('a[data-trackable="Sign In"]')).not.toExist()
+    })
+  })
+
   describe('When the user is logged in', () => {
     const header = mount(loggedInUserHeader)
 
@@ -63,8 +79,8 @@ describe('dotcom-ui-header', () => {
       expect(header.find('a[data-trackable="Settings & Account"]')).toExist()
     })
 
-    it('does not render subscribe button and sign in link', () => {
-      expect(header.find('a[data-trackable="Subscribe"]')).not.toExist()
+    it('does not render sign in link', () => {
+      expect(header.find('a[data-trackable="Subscribe"]')).toExist()
       expect(header.find('a[data-trackable="Sign In"]')).not.toExist()
     })
   })

--- a/packages/dotcom-ui-header/src/__test__/enzyme/component.spec.tsx
+++ b/packages/dotcom-ui-header/src/__test__/enzyme/component.spec.tsx
@@ -34,12 +34,14 @@ describe('dotcom-ui-header', () => {
     expect(header).not.toBeEmptyRender()
     expect(header.find('div[data-trackable="header-top"] .o-header__top-logo')).toExist()
     expect(
-      header.find('div[data-trackable="header-top"] .o-header__top-link--search .o-header__top-link-label')
+      header.find(
+        'div[data-trackable="header-top"] .o-header__top-icon-link--search .o-header__top-link-label'
+      )
     ).toExist()
     expect(
-      header.find('div[data-trackable="header-top"] .o-header__top-link--menu .o-header__top-link-label')
+      header.find('div[data-trackable="header-top"] .o-header__top-icon-link--menu .o-header__top-link-label')
     ).toExist()
-    expect(header.find('div[data-trackable="header-top"] .o-header__top-link--myft')).toExist()
+    expect(header.find('div[data-trackable="header-top"] .o-header__top-icon-link--myft')).toExist()
   })
 
   it('renders an inlined SVG logo image', () => {

--- a/packages/dotcom-ui-header/src/__test__/enzyme/component.spec.tsx
+++ b/packages/dotcom-ui-header/src/__test__/enzyme/component.spec.tsx
@@ -63,7 +63,7 @@ describe('dotcom-ui-header', () => {
       expect(header.find('a[data-trackable="Settings & Account"]')).toExist()
     })
 
-    it('does not render the anonymous user header links', () => {
+    it('does not render subscribe button and sign in link', () => {
       expect(header.find('a[data-trackable="Subscribe"]')).not.toExist()
       expect(header.find('a[data-trackable="Sign In"]')).not.toExist()
     })

--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -94,47 +94,6 @@ const NavListRightLoggedIn = ({ items }: { items: TNavMenuItem[] }) => {
   )
 }
 
-const SignInLink = ({ item, variant }: { item: TNavMenuItem; variant?: string }) => {
-  const setTabIndex = variant === 'sticky' ? { tabIndex: -1 } : null
-  return (
-    <a className="o-header__nav-link" href={item.url} data-trackable={item.label} {...setTabIndex}>
-      {item.label}
-    </a>
-  )
-}
-const SubscribeButton = ({ item, variant }: { item: TNavMenuItem; variant?: string }) => {
-  const setTabIndex = variant === 'sticky' ? { tabIndex: -1 } : null
-  return (
-    <a
-      className="o-header__nav-button"
-      // Added as the result of a DAC audit. This will be confusing for users of voice activation software
-      // as it looks like a button but behaves like a link without this role.
-      role="button"
-      href={item.url}
-      data-trackable={item.label}
-      {...setTabIndex}
-    >
-      {item.label}
-    </a>
-  )
-}
-
-const NavListRightAnon = ({ items, variant }: { items: TNavMenuItem[]; variant?: string }) => {
-  // If user is anonymous the second list item is styled as a button
-  const [signInAction, subscribeAction] = items
-  return (
-    <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
-      <li className="o-header__nav-item">
-        {subscribeAction && <SubscribeButton item={subscribeAction} variant={variant} />}
-      </li>
-      <span></span>
-      <li className="o-header__nav-item o-header__nav-item--hide-s">
-        {signInAction && <SignInLink item={signInAction} variant={variant} />}
-      </li>
-    </ul>
-  )
-}
-
 const MegaNav = ({ label, meganav, index }: { label: string; meganav: TNavMeganav[]; index: number }) => {
   const sections = meganav.find(({ component }) => component === 'sectionlist')
   const articles = meganav.find(({ component }) => component === 'articlelist')
@@ -226,4 +185,4 @@ const UserActionsNav = (props: THeaderProps) => {
   )
 }
 
-export { NavDesktop, NavListLeft, NavListRight, NavListRightAnon, UserActionsNav, MobileNav, SubscribeButton }
+export { NavDesktop, NavListLeft, NavListRight, UserActionsNav, MobileNav }

--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -23,7 +23,8 @@ const NavMobile = ({ items }: { items: TNavMenuItem[] }) => {
       id="o-header-nav-mobile"
       className="o-header__row o-header__nav o-header__nav--mobile"
       aria-hidden="true"
-      data-trackable="header-nav:mobile">
+      data-trackable="header-nav:mobile"
+    >
       <ul className="o-header__nav-list">
         {items.map((item, index) => (
           <li className="o-header__nav-item" key={`link-${index}`}>
@@ -31,7 +32,8 @@ const NavMobile = ({ items }: { items: TNavMenuItem[] }) => {
               className="o-header__nav-link o-header__nav-link--primary"
               href={item.url}
               {...ariaSelected(item)}
-              data-trackable={item.label}>
+              data-trackable={item.label}
+            >
               {item.label}
             </a>
           </li>
@@ -47,7 +49,8 @@ const NavDesktop = (props) => (
     className="o-header__row o-header__nav o-header__nav--desktop"
     role="navigation"
     aria-label="Primary navigation"
-    data-trackable="header-nav:desktop">
+    data-trackable="header-nav:desktop"
+  >
     <div className="o-header__container">{props.children}</div>
   </nav>
 )
@@ -61,7 +64,8 @@ const NavListLeft = (props: THeaderProps) => (
           href={item.url}
           id={`o-header-link-${index}`}
           {...ariaSelected(item)}
-          data-trackable={item.label}>
+          data-trackable={item.label}
+        >
           {item.label}
         </a>
         {props.showMegaNav && Array.isArray(item.meganav) ? (
@@ -73,11 +77,7 @@ const NavListLeft = (props: THeaderProps) => (
 )
 
 const NavListRight = (props: THeaderProps) => {
-  if (props.userIsLoggedIn) {
-    return <NavListRightLoggedIn items={props.data['navbar-right'].items} />
-  } else {
-    return <NavListRightAnon items={props.data['navbar-right-anon'].items} />
-  }
+  return props.userIsLoggedIn ? <NavListRightLoggedIn items={props.data['navbar-right'].items} /> : null
 }
 
 const NavListRightLoggedIn = ({ items }: { items: TNavMenuItem[] }) => {
@@ -94,28 +94,42 @@ const NavListRightLoggedIn = ({ items }: { items: TNavMenuItem[] }) => {
   )
 }
 
+const SignInLink = ({ item, variant }: { item: TNavMenuItem; variant?: string }) => {
+  const setTabIndex = variant === 'sticky' ? { tabIndex: -1 } : null
+  return (
+    <a className="o-header__nav-link" href={item.url} data-trackable={item.label} {...setTabIndex}>
+      {item.label}
+    </a>
+  )
+}
+const SubscribeButton = ({ item, variant }: { item: TNavMenuItem; variant?: string }) => {
+  const setTabIndex = variant === 'sticky' ? { tabIndex: -1 } : null
+  return (
+    <a
+      className="o-header__nav-button"
+      // Added as the result of a DAC audit. This will be confusing for users of voice activation software
+      // as it looks like a button but behaves like a link without this role.
+      role="button"
+      href={item.url}
+      data-trackable={item.label}
+      {...setTabIndex}
+    >
+      {item.label}
+    </a>
+  )
+}
+
 const NavListRightAnon = ({ items, variant }: { items: TNavMenuItem[]; variant?: string }) => {
   // If user is anonymous the second list item is styled as a button
-  const [first, second] = items
-  const setTabIndex = variant === 'sticky' ? { tabIndex: -1 } : null
+  const [signInAction, subscribeAction] = items
   return (
     <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
       <li className="o-header__nav-item">
-        <a className="o-header__nav-link" href={first.url} data-trackable={first.label} {...setTabIndex}>
-          {first.label}
-        </a>
+        {subscribeAction && <SubscribeButton item={subscribeAction} variant={variant} />}
       </li>
+      <span></span>
       <li className="o-header__nav-item o-header__nav-item--hide-s">
-        <a
-          className="o-header__nav-button"
-          // Added as the result of a DAC audit. This will be confusing for users of voice activation software
-          // as it looks like a button but behaves like a link without this role.
-          role="button"
-          href={second.url}
-          data-trackable={second.label}
-          {...setTabIndex}>
-          {second.label}
-        </a>
+        {signInAction && <SignInLink item={signInAction} variant={variant} />}
       </li>
     </ul>
   )
@@ -132,7 +146,8 @@ const MegaNav = ({ label, meganav, index }: { label: string; meganav: TNavMegana
       role="group"
       aria-labelledby={`o-header-link-${index}`}
       data-o-header-mega
-      data-trackable={`meganav | ${label}`}>
+      data-trackable={`meganav | ${label}`}
+    >
       <div className="o-header__container">
         <div className="o-header__mega-wrapper">
           {sections ? <SectionList {...(sections as INavMeganavSections)} /> : null}
@@ -156,7 +171,8 @@ const SectionList = ({ title, data }: INavMeganavSections) => {
                   className="o-header__mega-link"
                   href={item.url}
                   {...ariaSelected(item)}
-                  data-trackable="link">
+                  data-trackable="link"
+                >
                   {item.label}
                 </a>
               </li>
@@ -180,7 +196,8 @@ const ArticleList = ({ title, data }: INavMeganavArticles) => {
                 className="o-header__mega-link"
                 href={item.url}
                 {...ariaSelected(item)}
-                data-trackable="link">
+                data-trackable="link"
+              >
                 {item.label}
               </a>
             </li>
@@ -209,4 +226,4 @@ const UserActionsNav = (props: THeaderProps) => {
   )
 }
 
-export { NavDesktop, NavListLeft, NavListRight, NavListRightAnon, UserActionsNav, MobileNav }
+export { NavDesktop, NavListLeft, NavListRight, NavListRightAnon, UserActionsNav, MobileNav, SubscribeButton }

--- a/packages/dotcom-ui-header/src/components/sticky/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sticky/partials.tsx
@@ -125,7 +125,7 @@ const NavListRightLoggedInSticky = (props: THeaderProps) => {
     <div className="o-header__top-column o-header__top-column--right">
       <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
         <li className="o-header__nav-item">
-          {props.userIsSubscribed && subscribeAction && (
+          {!props.userIsSubscribed && subscribeAction && (
             <SubscribeButton item={subscribeAction} variant={props.variant} />
           )}
         </li>

--- a/packages/dotcom-ui-header/src/components/sticky/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sticky/partials.tsx
@@ -2,7 +2,7 @@
 /* This is the sticky header variant */
 
 import React from 'react'
-import { NavListRightAnon } from '../navigation/partials'
+import { NavListRightAnon, SubscribeButton } from '../navigation/partials'
 import { THeaderProps } from '../../interfaces'
 
 const StickyHeaderWrapper = (props: THeaderProps & { children: React.ReactNode }) => (
@@ -10,7 +10,8 @@ const StickyHeaderWrapper = (props: THeaderProps & { children: React.ReactNode }
     className={`o-header o-header--simple o-header--sticky o--if-js`}
     data-o-component="o-header"
     data-o-header--sticky
-    aria-hidden="true">
+    aria-hidden="true"
+  >
     {props.children}
   </header>
 )
@@ -21,7 +22,8 @@ const DrawerIconSticky = () => (
     className="o-header__top-link o-header__top-link--menu"
     aria-controls="o-header-drawer"
     data-trackable="drawer-toggle"
-    tabIndex={-1}>
+    tabIndex={-1}
+  >
     <span className="o-header__top-link-label">Menu</span>
   </a>
 )
@@ -32,7 +34,8 @@ const SearchIconSticky = () => (
     className="o-header__top-link o-header__top-link--search"
     aria-controls="o-header-search-sticky"
     data-trackable="search-toggle"
-    tabIndex={-1}>
+    tabIndex={-1}
+  >
     <span className="o-header__top-link-label">Search</span>
   </a>
 )
@@ -47,7 +50,8 @@ const Navigation = (props: THeaderProps) => (
               className="o-header__nav-link o-header__nav-link--primary"
               href={item.url}
               data-trackable={item.label}
-              tabIndex={-1}>
+              tabIndex={-1}
+            >
               {item.label}
             </a>
           </li>
@@ -63,7 +67,8 @@ const Logo = () => (
     data-trackable="logo"
     href="/"
     title="Go to Financial Times homepage"
-    tabIndex={-1}>
+    tabIndex={-1}
+  >
     <span className="o-header__visually-hidden">Financial Times</span>
   </a>
 )
@@ -83,7 +88,8 @@ const MyFtSticky = () => (
     className="o-header__top-link o-header__top-link--myft"
     href="/myft"
     data-trackable="my-ft"
-    tabIndex={-1}>
+    tabIndex={-1}
+  >
     <span className="o-header__visually-hidden">myFT</span>
   </a>
 )
@@ -113,6 +119,24 @@ const TopColumnCenterSticky = (props: THeaderProps) => {
   )
 }
 
+const NavListRightLoggedInSticky = (props: THeaderProps) => {
+  const subscribeAction = props.data['navbar-right-anon'].items?.[1]
+  return (
+    <div className="o-header__top-column o-header__top-column--right">
+      <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
+        <li className="o-header__nav-item">
+          {props.userIsSubscribed && subscribeAction && (
+            <SubscribeButton item={subscribeAction} variant={props.variant} />
+          )}
+        </li>
+        <li className="o-header__nav-item o-header__nav-item--hide-s">
+          <MyFtSticky />
+        </li>
+      </ul>
+    </div>
+  )
+}
+
 // This behaviour is similar to `NavListRight` in '../navigation/partials' but:
 // - The sticky header renders either the `navbar-right-anon` data or the myFT component
 // - The normal header renders either the `navbar-right-anon` or the `navbar-right` data
@@ -120,7 +144,7 @@ const TopColumnRightSticky = (props: THeaderProps) => {
   let children = null
 
   if (props.userIsLoggedIn) {
-    children = <MyFtSticky />
+    children = <NavListRightLoggedInSticky {...props} />
   } else if (props.showUserNavigation) {
     children = <NavListRightAnonSticky {...props} />
   }

--- a/packages/dotcom-ui-header/src/components/sticky/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sticky/partials.tsx
@@ -2,7 +2,7 @@
 /* This is the sticky header variant */
 
 import React from 'react'
-import { NavListRightAnon, SubscribeButton } from '../navigation/partials'
+import { TopColumnRightAnon, SubscribeButton } from '../top/partials'
 import { THeaderProps } from '../../interfaces'
 
 const StickyHeaderWrapper = (props: THeaderProps & { children: React.ReactNode }) => (
@@ -78,7 +78,7 @@ const NavListRightAnonSticky = (props: THeaderProps) => {
 
   return (
     <div className="o-header__nav">
-      <NavListRightAnon items={navbarItems} variant="sticky" />
+      <TopColumnRightAnon items={navbarItems} variant="sticky" />
     </div>
   )
 }
@@ -123,16 +123,10 @@ const NavListRightLoggedInSticky = (props: THeaderProps) => {
   const subscribeAction = props.data['navbar-right-anon'].items?.[1]
   return (
     <div className="o-header__top-column o-header__top-column--right">
-      <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
-        <li className="o-header__nav-item">
-          {!props.userIsSubscribed && subscribeAction && (
-            <SubscribeButton item={subscribeAction} variant={props.variant} />
-          )}
-        </li>
-        <li className="o-header__nav-item o-header__nav-item--hide-s">
-          <MyFtSticky />
-        </li>
-      </ul>
+      {!props.userIsSubscribed && subscribeAction && (
+        <SubscribeButton item={subscribeAction} variant={props.variant} />
+      )}
+      <MyFtSticky />
     </div>
   )
 }

--- a/packages/dotcom-ui-header/src/components/sticky/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sticky/partials.tsx
@@ -2,7 +2,7 @@
 /* This is the sticky header variant */
 
 import React from 'react'
-import { TopColumnRightAnon, SubscribeButton } from '../top/partials'
+import { SubscribeButton, SignInLink } from '../top/partials'
 import { THeaderProps } from '../../interfaces'
 
 const StickyHeaderWrapper = (props: THeaderProps & { children: React.ReactNode }) => (
@@ -19,7 +19,7 @@ const StickyHeaderWrapper = (props: THeaderProps & { children: React.ReactNode }
 const DrawerIconSticky = () => (
   <a
     href="#"
-    className="o-header__top-link o-header__top-link--menu"
+    className="o-header__top-icon-link o-header__top-icon-link--menu"
     aria-controls="o-header-drawer"
     data-trackable="drawer-toggle"
     tabIndex={-1}
@@ -31,7 +31,7 @@ const DrawerIconSticky = () => (
 const SearchIconSticky = () => (
   <a
     href="#"
-    className="o-header__top-link o-header__top-link--search"
+    className="o-header__top-icon-link o-header__top-icon-link--search"
     aria-controls="o-header-search-sticky"
     data-trackable="search-toggle"
     tabIndex={-1}
@@ -74,18 +74,24 @@ const Logo = () => (
 )
 
 const NavListRightAnonSticky = (props: THeaderProps) => {
-  const navbarItems = props.data['navbar-right-anon'].items
+  // If user is anonymous the second list item is styled as a button
+  const [signInAction, subscribeAction] = props.data['navbar-right-anon'].items
 
   return (
     <div className="o-header__nav">
-      <TopColumnRightAnon items={navbarItems} variant="sticky" />
+      <div className="o-header__top-column o-header__top-column--right">
+        {subscribeAction && (
+          <SubscribeButton item={subscribeAction} variant="sticky" className="o-header__top-button--hide-m" />
+        )}
+        {signInAction && <SignInLink item={signInAction} variant="sticky" className="" />}
+      </div>
     </div>
   )
 }
 
-const MyFtSticky = () => (
+const MyFtSticky = ({ className }: { className?: string }) => (
   <a
-    className="o-header__top-link o-header__top-link--myft"
+    className={`o-header__top-icon-link o-header__top-icon-link--myft ${className}`}
     href="/myft"
     data-trackable="my-ft"
     tabIndex={-1}
@@ -124,9 +130,13 @@ const NavListRightLoggedInSticky = (props: THeaderProps) => {
   return (
     <div className="o-header__top-column o-header__top-column--right">
       {!props.userIsSubscribed && subscribeAction && (
-        <SubscribeButton item={subscribeAction} variant={props.variant} />
+        <SubscribeButton
+          item={subscribeAction}
+          variant={props.variant}
+          className="o-header__top-button--hide-m"
+        />
       )}
-      <MyFtSticky />
+      <MyFtSticky className="" />
     </div>
   )
 }

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -18,7 +18,7 @@ const HeaderWrapper = (props) => (
 const DrawerIcon = () => (
   <a
     href="#o-header-drawer"
-    className="o-header__top-link o-header__top-link--menu"
+    className="o-header__top-icon-link o-header__top-icon-link--menu"
     aria-controls="o-header-drawer"
     title="Open side navigation menu"
     data-trackable="drawer-toggle"
@@ -30,7 +30,7 @@ const DrawerIcon = () => (
 const SearchIcon = () => (
   <a
     href={`#o-header-search-primary`}
-    className="o-header__top-link o-header__top-link--search"
+    className="o-header__top-icon-link o-header__top-icon-link--search"
     aria-controls={`o-header-search-primary`}
     title="Open search bar"
     data-trackable="search-toggle"
@@ -39,9 +39,9 @@ const SearchIcon = () => (
   </a>
 )
 
-const MyFt = () => (
+const MyFt = ({ className }: { className?: string }) => (
   <a
-    className="o-header__top-link o-header__top-link--myft"
+    className={`o-header__top-icon-link o-header__top-icon-link--myft ${className}`}
     id="o-header-top-link-myft"
     href="/myft"
     data-trackable="my-ft"
@@ -94,26 +94,51 @@ const TopColumnRightLoggedIn = (props: THeaderProps) => {
   return (
     <div className="o-header__top-column o-header__top-column--right">
       {!props.userIsSubscribed && subscribeAction && (
-        <SubscribeButton item={subscribeAction} variant={props.variant} />
+        <SubscribeButton
+          item={subscribeAction}
+          variant={props.variant}
+          className="o-header__top-button--hide-m"
+        />
       )}
-      <MyFt />
+      <MyFt className="" />
     </div>
   )
 }
 
-const SignInLink = ({ item, variant }: { item: TNavMenuItem; variant?: string }) => {
+const SignInLink = ({
+  item,
+  variant,
+  className
+}: {
+  item: TNavMenuItem
+  variant?: string
+  className?: string
+}) => {
   const setTabIndex = variant === 'sticky' ? { tabIndex: -1 } : null
   return (
-    <a className="o-header__nav-link" href={item.url} data-trackable={item.label} {...setTabIndex}>
+    <a
+      className={`o-header__top-link ${className}`}
+      href={item.url}
+      data-trackable={item.label}
+      {...setTabIndex}
+    >
       {item.label}
     </a>
   )
 }
-const SubscribeButton = ({ item, variant }: { item: TNavMenuItem; variant?: string }) => {
+const SubscribeButton = ({
+  item,
+  variant,
+  className
+}: {
+  item: TNavMenuItem
+  variant?: string
+  className?: string
+}) => {
   const setTabIndex = variant === 'sticky' ? { tabIndex: -1 } : null
   return (
     <a
-      className="o-header__top-button"
+      className={`o-header__top-button ${className}`}
       // Added as the result of a DAC audit. This will be confusing for users of voice activation software
       // as it looks like a button but behaves like a link without this role.
       role="button"
@@ -131,8 +156,13 @@ const TopColumnRightAnon = ({ items, variant }: { items: TNavMenuItem[]; variant
   const [signInAction, subscribeAction] = items
   return (
     <div className="o-header__top-column o-header__top-column--right">
-      {subscribeAction && <SubscribeButton item={subscribeAction} variant={variant} />}
-      {signInAction && <SignInLink item={signInAction} variant={variant} />}
+      {subscribeAction && (
+        <SubscribeButton item={subscribeAction} variant={variant} className="o-header__top-button--hide-m" />
+      )}
+      {signInAction && (
+        <SignInLink item={signInAction} variant={variant} className="o-header__top-link--hide-m" />
+      )}
+      <MyFt className="o-header__top-icon-link--show-m" />
     </div>
   )
 }
@@ -154,5 +184,6 @@ export {
   TopColumnCenterNoLink,
   TopColumnRight,
   TopColumnRightAnon,
-  SubscribeButton
+  SubscribeButton,
+  SignInLink
 }

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
+import { THeaderProps } from '../../interfaces'
 import BrandFtMastheadSvg from '../svg-components/BrandFtMasthead'
+import { NavListRightAnon, SubscribeButton } from '../navigation/partials'
 
 const HeaderWrapper = (props) => (
   <header
@@ -87,10 +89,39 @@ const TopColumnCenterNoLink = () => (
   </div>
 )
 
-const TopColumnRight = () => (
-  <div className="o-header__top-column o-header__top-column--right">
-    <MyFt />
-  </div>
-)
+const TopColumnRightLoggedIn = (props: THeaderProps) => {
+  const subscribeAction = props.data['navbar-right-anon']?.items?.[1]
+  return (
+    <div className="o-header__top-column o-header__top-column--right">
+      <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
+        <li className="o-header__nav-item">
+          {props.userIsSubscribed && subscribeAction && (
+            <SubscribeButton item={subscribeAction} variant={props.variant} />
+          )}
+        </li>
+        <li className="o-header__nav-item o-header__nav-item--hide-s">
+          <MyFt />
+        </li>
+      </ul>
+    </div>
+  )
+}
+
+const TopColumnRightAnon = (props: THeaderProps) => {
+  const userNavAnonItems = props.data['navbar-right-anon'].items
+  return (
+    <div className="o-header__top-column o-header__top-column--right">
+      <NavListRightAnon items={userNavAnonItems} variant={props.variant} />
+    </div>
+  )
+}
+
+const TopColumnRight = (props: THeaderProps) => {
+  if (props.userIsLoggedIn) {
+    return <TopColumnRightLoggedIn {...props} />
+  } else {
+    return <TopColumnRightAnon {...props} />
+  }
+}
 
 export { HeaderWrapper, TopWrapper, TopColumnLeft, TopColumnCenter, TopColumnCenterNoLink, TopColumnRight }

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -95,7 +95,7 @@ const TopColumnRightLoggedIn = (props: THeaderProps) => {
     <div className="o-header__top-column o-header__top-column--right">
       <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
         <li className="o-header__nav-item">
-          {props.userIsSubscribed && subscribeAction && (
+          {!props.userIsSubscribed && subscribeAction && (
             <SubscribeButton item={subscribeAction} variant={props.variant} />
           )}
         </li>

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { THeaderProps } from '../../interfaces'
 import BrandFtMastheadSvg from '../svg-components/BrandFtMasthead'
-import { NavListRightAnon, SubscribeButton } from '../navigation/partials'
+import { TNavMenuItem } from '@financial-times/dotcom-types-navigation'
 
 const HeaderWrapper = (props) => (
   <header
@@ -93,25 +93,46 @@ const TopColumnRightLoggedIn = (props: THeaderProps) => {
   const subscribeAction = props.data['navbar-right-anon']?.items?.[1]
   return (
     <div className="o-header__top-column o-header__top-column--right">
-      <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
-        <li className="o-header__nav-item">
-          {!props.userIsSubscribed && subscribeAction && (
-            <SubscribeButton item={subscribeAction} variant={props.variant} />
-          )}
-        </li>
-        <li className="o-header__nav-item o-header__nav-item--hide-s">
-          <MyFt />
-        </li>
-      </ul>
+      {!props.userIsSubscribed && subscribeAction && (
+        <SubscribeButton item={subscribeAction} variant={props.variant} />
+      )}
+      <MyFt />
     </div>
   )
 }
 
-const TopColumnRightAnon = (props: THeaderProps) => {
-  const userNavAnonItems = props.data['navbar-right-anon'].items
+const SignInLink = ({ item, variant }: { item: TNavMenuItem; variant?: string }) => {
+  const setTabIndex = variant === 'sticky' ? { tabIndex: -1 } : null
+  return (
+    <a className="o-header__nav-link" href={item.url} data-trackable={item.label} {...setTabIndex}>
+      {item.label}
+    </a>
+  )
+}
+const SubscribeButton = ({ item, variant }: { item: TNavMenuItem; variant?: string }) => {
+  const setTabIndex = variant === 'sticky' ? { tabIndex: -1 } : null
+  return (
+    <a
+      className="o-header__top-button"
+      // Added as the result of a DAC audit. This will be confusing for users of voice activation software
+      // as it looks like a button but behaves like a link without this role.
+      role="button"
+      href={item.url}
+      data-trackable={item.label}
+      {...setTabIndex}
+    >
+      {item.label}
+    </a>
+  )
+}
+
+const TopColumnRightAnon = ({ items, variant }: { items: TNavMenuItem[]; variant?: string }) => {
+  // If user is anonymous the second list item is styled as a button
+  const [signInAction, subscribeAction] = items
   return (
     <div className="o-header__top-column o-header__top-column--right">
-      <NavListRightAnon items={userNavAnonItems} variant={props.variant} />
+      {subscribeAction && <SubscribeButton item={subscribeAction} variant={variant} />}
+      {signInAction && <SignInLink item={signInAction} variant={variant} />}
     </div>
   )
 }
@@ -120,8 +141,18 @@ const TopColumnRight = (props: THeaderProps) => {
   if (props.userIsLoggedIn) {
     return <TopColumnRightLoggedIn {...props} />
   } else {
-    return <TopColumnRightAnon {...props} />
+    const userNavAnonItems = props.data['navbar-right-anon'].items
+    return <TopColumnRightAnon items={userNavAnonItems} variant={props.variant} />
   }
 }
 
-export { HeaderWrapper, TopWrapper, TopColumnLeft, TopColumnCenter, TopColumnCenterNoLink, TopColumnRight }
+export {
+  HeaderWrapper,
+  TopWrapper,
+  TopColumnLeft,
+  TopColumnCenter,
+  TopColumnCenterNoLink,
+  TopColumnRight,
+  TopColumnRightAnon,
+  SubscribeButton
+}

--- a/packages/dotcom-ui-header/src/index.tsx
+++ b/packages/dotcom-ui-header/src/index.tsx
@@ -46,7 +46,7 @@ function MainHeader(props: THeaderProps) {
       <TopWrapper>
         <TopColumnLeft />
         {props.showLogoLink ? <TopColumnCenter /> : <TopColumnCenterNoLink />}
-        <TopColumnRight />
+        <TopColumnRight {...props} />
       </TopWrapper>
       <Search instance="primary" />
       <MobileNav {...props} />

--- a/packages/dotcom-ui-header/src/interfaces.d.ts
+++ b/packages/dotcom-ui-header/src/interfaces.d.ts
@@ -4,6 +4,7 @@ export type THeaderOptions = {
   variant?: THeaderVariant
   userIsAnonymous?: boolean
   userIsLoggedIn?: boolean
+  userIsSubscribed?: boolean
   showSubNavigation?: boolean
   showUserNavigation?: boolean
   showStickyHeader?: boolean

--- a/packages/dotcom-ui-layout/package.json
+++ b/packages/dotcom-ui-layout/package.json
@@ -28,7 +28,7 @@
     "@financial-times/dotcom-ui-footer": "file:../dotcom-ui-footer",
     "@financial-times/dotcom-ui-header": "file:../dotcom-ui-header",
     "focus-visible": "^5.0.0",
-    "n-ui-foundations": "^7.0.0"
+    "n-ui-foundations": "^9.0.0"
   },
   "peerDependencies": {
     "react": "16.x || 17.x",


### PR DESCRIPTION
**Description**
Relocate header's top right buttons, and include Subscribe button for user registered but not subscribed. It depends on headerOptions sent by the consumer. The user status needed are filled in n-express [here](https://github.com/Financial-Times/n-express/blob/3aba289da097f64a7e7dbf44821000fa823d35ba/src/middleware/anon.js#L10)

https://financialtimes.atlassian.net/browse/ACQ-1535

**Screenshots**

**User subscribed**
<img width="1212" alt="image" src="https://user-images.githubusercontent.com/48696369/160915462-b0546132-6ef0-49d6-bf97-ea40aeb42134.png">
<img width="1211" alt="image" src="https://user-images.githubusercontent.com/48696369/160915955-0cf09afb-f978-40f9-9652-ffd42a51100d.png">
**User logged in**
<img width="1214" alt="image" src="https://user-images.githubusercontent.com/48696369/160914207-745b7375-1308-4a43-abbb-6b9ed3f77f1d.png">
<img width="1215" alt="image" src="https://user-images.githubusercontent.com/48696369/160914410-f76d58bb-dce0-4e8d-9035-815947b402f8.png">
**User logged out**
![image](https://user-images.githubusercontent.com/48696369/160915080-be8f8238-6a2c-42b4-b466-10fc9638e63e.png)
<img width="1211" alt="image" src="https://user-images.githubusercontent.com/48696369/160915289-fd811761-0830-4c1f-85c0-b80c59e7ef8a.png">
