### PR TITLE
update to use npm 8.5.3 in circleci config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
       - checkout
       - *restore_cache
       - node/install-npm:
-          version: "8"
+          version: "8.5.3"
       - run:
           name: Install project dependencies
           command: npm install
@@ -102,6 +102,8 @@ jobs:
     <<: *container_config_node
     steps:
       - *attach_workspace
+      - node/install-npm:
+          version: "8.5.3"
       - browser-tools/install-chrome
       - run:
           name: Check code style


### PR DESCRIPTION
use the exact npm version of 8.5.3 in circleci (as per volta pin in package.json) to fix [test step not bundling o-toggle ](https://app.circleci.com/pipelines/github/Financial-Times/dotcom-page-kit/4106/workflows/166a0a4d-3d4a-479c-aa8d-9d443f2e811e/jobs/7522)