### PR TITLE
ACQ-1605: correct segmentId for subscribe button in drawer menu

### DIFF
--- a/packages/dotcom-server-navigation/src/actions.ts
+++ b/packages/dotcom-server-navigation/src/actions.ts
@@ -4,6 +4,6 @@ export function getSubscribeAction(): TNavAction {
   return {
     id: 'subscribe',
     name: 'Subscribe for full access',
-    url: '/products?segmentId=72adc702-369e-fc3e-1b5d-cacb5d193d80'
+    url: '/products?segmentId=4526c036-7527-ab37-9a29-0b0403fa0b5f'
   }
 }


### PR DESCRIPTION
Segment ID for subscribe button in Drawer menu was wrong.

This is not likely to change anymore in the future, there was just an error on Analytics requirements.