### PR TITLE
ACQ-1621: remove o-typogragy from ui-layout since was unneeded

### DIFF
--- a/packages/dotcom-ui-layout/package.json
+++ b/packages/dotcom-ui-layout/package.json
@@ -31,8 +31,7 @@
     "n-ui-foundations": "^9.0.0"
   },
   "peerDependencies": {
-    "react": "16.x || 17.x",
-    "@financial-times/o-typography": "^7.2.0"
+    "react": "16.x || 17.x"
   },
   "engines": {
     "node": ">= 14.0.0",
@@ -49,7 +48,6 @@
   },
   "devDependencies": {
     "check-engine": "^1.10.1",
-    "@financial-times/o-typography": "^7.2.0",
     "react": "^16.8.6"
   }
 }


### PR DESCRIPTION
Remove o-typogragy from dotcom-ui-layout since it was not used there.

**Context**: https://financialtimes.slack.com/archives/C3TJ6KXEU/p1651072879410939?thread_ts=1651072094.582689&cid=C3TJ6KXEU