### PR TITLE
Updating to n-topic-search v4

### DIFF
--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -24,8 +24,8 @@
   "license": "MIT",
   "dependencies": {
     "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
-    "n-topic-search": "^3.2.3",
-    "n-ui-foundations": "^7.0.0"
+    "n-topic-search": "^4.0.0",
+    "n-ui-foundations": "^9.0.0"
   },
   "devDependencies": {
     "@financial-times/logo-images": "^1.10.1",


### PR DESCRIPTION
this upgrades to v4 of n-topic-search, which directly pulls in ftdomdelegate without relying on n-ui-foundations to provide it. therefore we can also update to use v9 of n-ui-foundations here