### PR TITLE
rename HTSI label

### DIFF
--- a/__fixtures__/menus.json
+++ b/__fixtures__/menus.json
@@ -2217,7 +2217,7 @@
           }
         ]
       },
-      { "label": "How to Spend It", "url": "https://howtospendit.ft.com/", "submenu": null }
+      { "label": "HTSI", "url": "https://howtospendit.ft.com/", "submenu": null }
     ]
   },
   "navbar-international": {
@@ -3220,7 +3220,7 @@
           }
         ]
       },
-      { "label": "How to Spend It", "url": "https://howtospendit.ft.com/", "submenu": null }
+      { "label": "HTSI", "url": "https://howtospendit.ft.com/", "submenu": null }
     ]
   }
 }

--- a/packages/dotcom-ui-header/src/__stories__/story-data/navbarUK.ts
+++ b/packages/dotcom-ui-header/src/__stories__/story-data/navbarUK.ts
@@ -989,7 +989,7 @@ const data: TNavMenu = {
         }
       ]
     },
-    { label: 'How to Spend It', url: 'https://howtospendit.ft.com/', submenu: null }
+    { label: 'HTSI', url: 'https://howtospendit.ft.com/', submenu: null }
   ]
 }
 

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -1727,11 +1727,11 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
         >
           <a
             className="o-header__nav-link o-header__nav-link--primary"
-            data-trackable="How to Spend It"
+            data-trackable="HTSI"
             href="https://howtospendit.ft.com/"
             id="o-header-link-10"
           >
-            How to Spend It
+            HTSI
           </a>
         </li>
       </ul>
@@ -3570,11 +3570,11 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
         >
           <a
             className="o-header__nav-link o-header__nav-link--primary"
-            data-trackable="How to Spend It"
+            data-trackable="HTSI"
             href="https://howtospendit.ft.com/"
             id="o-header-link-10"
           >
-            How to Spend It
+            HTSI
           </a>
         </li>
       </ul>
@@ -5425,11 +5425,11 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
         >
           <a
             className="o-header__nav-link o-header__nav-link--primary"
-            data-trackable="How to Spend It"
+            data-trackable="HTSI"
             href="https://howtospendit.ft.com/"
             id="o-header-link-10"
           >
-            How to Spend It
+            HTSI
           </a>
         </li>
       </ul>

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
@@ -185,11 +185,11 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as a logged in use
                 >
                   <a
                     className="o-header__nav-link o-header__nav-link--primary"
-                    data-trackable="How to Spend It"
+                    data-trackable="HTSI"
                     href="https://howtospendit.ft.com/"
                     tabIndex={-1}
                   >
-                    How to Spend It
+                    HTSI
                   </a>
                 </li>
               </ul>
@@ -493,11 +493,11 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as an anonymous us
                 >
                   <a
                     className="o-header__nav-link o-header__nav-link--primary"
-                    data-trackable="How to Spend It"
+                    data-trackable="HTSI"
                     href="https://howtospendit.ft.com/"
                     tabIndex={-1}
                   >
-                    How to Spend It
+                    HTSI
                   </a>
                 </li>
               </ul>


### PR DESCRIPTION
## Description

Rename the navigation label from "How To Spend It" to "HTSI"

for more info see [this Slack thread](https://financialtimes.slack.com/archives/C04RUBL9G/p1654008631395689)