### PR TITLE
Fix kitchen sink test

### DIFF
--- a/examples/building-sass-files/__test__/integration.test.js
+++ b/examples/building-sass-files/__test__/integration.test.js
@@ -22,7 +22,7 @@ describe('examples/building-sass-files', () => {
 
   describe('PostCSS', () => {
     it('uses Autoprefixer to apply vendor prefixes', () => {
-      expect(outputContents).toContain('-webkit-hyphens:auto;-ms-hyphens:auto;hyphens:auto')
+      expect(outputContents).toContain('-webkit-hyphens:auto;hyphens:auto')
     })
 
     it('uses cssnano to minify the output', () => {

--- a/examples/kitchen-sink/__test__/build.test.js
+++ b/examples/kitchen-sink/__test__/build.test.js
@@ -13,7 +13,6 @@ const expected = [
   'manifest.json',
   'page-kit-components.bundle.js',
   'page-kit-layout-styles.css',
-  'regenerator-runtime.bundle.js',
   'scripts.bundle.js',
   'shared.stable.bundle.js',
   'styles.css',

--- a/packages/dotcom-build-js/README.md
+++ b/packages/dotcom-build-js/README.md
@@ -28,11 +28,10 @@ module.exports = {
 
 This plugin configures [Babel](https://babeljs.io/) to compile JavaScript syntax and features that aren't supported by every browser into JavaScript that is. The browsers we target are:
 
-* the last 2 versions of Chrome
-* the last 2 versions of Edge
+* the latest version of Chrome
+* the lastest version of Edge
 * Safari 9.1
-* Firefox Extended Support Release (currently v68)
-* Internet Explorer 11
+* Firefox Extended Support Release
 
 As well as features in current JavaScript standards, we also compile these non-standard features:
 

--- a/packages/dotcom-build-js/src/babel.ts
+++ b/packages/dotcom-build-js/src/babel.ts
@@ -2,7 +2,7 @@ import { PluginOptions } from './types'
 
 function getBabelConfig(options: PluginOptions = {}) {
   const presetEnvOpts = {
-    targets: ['last 2 Chrome versions', 'ie 11', 'Safari >= 9.1', 'ff ESR', 'last 2 Edge versions'],
+    targets: ['last 1 Chrome versions', 'Safari >= 13', 'ff ESR', 'last 1 Edge versions'],
     // Exclude transforms that make all code slower
     // See https://github.com/facebook/create-react-app/pull/5278
     exclude: ['transform-typeof-symbol']

--- a/packages/dotcom-build-sass/src/index.ts
+++ b/packages/dotcom-build-sass/src/index.ts
@@ -40,13 +40,7 @@ export class PageKitSassPlugin {
 
     const autoprefixerOptions = {
       // https://github.com/browserslist/browserslist
-      overrideBrowserslist: [
-        'last 2 Chrome versions',
-        'ie 11',
-        'Safari >= 9.1',
-        'ff ESR',
-        'last 2 Edge versions'
-      ],
+      overrideBrowserslist: ['last 1 Chrome versions', 'Safari >= 13', 'ff ESR', 'last 1 Edge versions'],
       grid: true
     }
 


### PR DESCRIPTION
The regenerator runtime is used to support polyfills of generator functions. It stopped being output by Webpack since the last commit to main, possibly because all dependencies that were using it have been updated to no longer require it and it is now tree shaken? Fortunately, after updating our browserslist config to the [current browsers we support](https://docs.google.com/document/d/1z6kecy_o9qHYIznTmqQ-IJqre72jhfd0nVa4JMsS7Q4), we no longer need the Babel transform as all of our supported browsers now support generators, so we can safely assume it is not a required Webpack bundle.