### PR TITLE
Upgrade ft-poller from v5 to v7

### DIFF
--- a/packages/dotcom-server-navigation/package.json
+++ b/packages/dotcom-server-navigation/package.json
@@ -20,9 +20,10 @@
   "license": "MIT",
   "dependencies": {
     "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
+    "@financial-times/n-logger": "^10.1.0",
     "@types/deep-freeze": "^0.1.1",
     "deep-freeze": "0.0.1",
-    "ft-poller": "^5.0.0",
+    "ft-poller": "^7.0.0",
     "http-errors": "^1.7.1",
     "node-fetch": "^2.2.1"
   },

--- a/packages/dotcom-server-navigation/src/navigation.ts
+++ b/packages/dotcom-server-navigation/src/navigation.ts
@@ -64,6 +64,8 @@ export class Navigation {
     } catch (error) {
       // getData throws if the most recent fetch resulted in an error.
       // In that case, continue to use the latest navigation we have available.
+      // In the future we may want to handle this differently. See ticket FTDCS-258
+      // for some ideas on how this code could be improved.
       logger.warn('ERROR_FETCHING_NAVIGATION', error)
     }
 


### PR DESCRIPTION
This is a breaking change in ft-poller which fixes a bug in that nothing listening to the `emit('error')` event results in an unhandled promise rejection warning that causes Node 16 apps to crash. It also drops support for Node 12.

See https://github.com/Financial-Times/ft-poller/pull/91 for context.

This change appears to be the first use of n-logger in Page Kit.