### PR TITLE
ACQ-1754: Update docs userIsSubscribed option for Header

### DIFF
--- a/packages/dotcom-ui-header/README.md
+++ b/packages/dotcom-ui-header/README.md
@@ -35,7 +35,7 @@ import { Header, Drawer } from '@financial-times/dotcom-ui-header'
 
 const SiteHeader = (props) => (
   <Header data={props.navigationData} userIsLoggedIn={props.userIsLoggedIn} />
-  <Drawer data={props.navigationData} userIsLoggedIn={props.userIsLoggedIn} />
+  <Drawer data={props.navigationData} userIsLoggedIn={props.userIsLoggedIn} userIsSubscribed={props.userIsSubscribed} />
 )
 ```
 
@@ -71,6 +71,7 @@ All header components with the exception of `<LogoOnly />` require the following
 | variant            | 'simple' \| 'large-logo' \| string | true     | 'simple' | Adds a class name to the header element
 | userIsAnonymous    | boolean                            | true     | true     | Marks a user as anonymous - can be set by middleware included with n-express   |
 | userIsLoggedIn     | boolean                            | true     | false    | Marks a user as logged in - can be set by middleware included with n-express   |
+| userIsSubscribed     | boolean                            | true     | false    | Marks a user as subscribed - set by middleware(ammit task in preflight) included with n-express   |
 | showUserNavigation | boolean                            | true     | true     | Show user navigation options such as `Sign out` or `Subscribe`                 |
 | showSubNavigation  | boolean                            | true     | true     | Show the sub-navigation component which may include the crumbtrail             |
 | showStickyHeader   | boolean                            | true     | true     | Enable rendering of the sticky header component                            |


### PR DESCRIPTION
Update docs to reflect `userIsSubscribed` option for Header

Ticket: https://financialtimes.atlassian.net/browse/ACQ-1754
