### PR TITLE
Use version of express-serve-static-core type definition compatible with TypeScript 3.x

### DIFF
--- a/packages/dotcom-middleware-app-context/package.json
+++ b/packages/dotcom-middleware-app-context/package.json
@@ -19,6 +19,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@types/express-serve-static-core": "4.17.20",
     "check-engine": "^1.10.1",
     "node-mocks-http": "^1.7.5"
   },

--- a/packages/dotcom-middleware-asset-loader/package.json
+++ b/packages/dotcom-middleware-asset-loader/package.json
@@ -24,6 +24,7 @@
     "express": "^4.16.4"
   },
   "devDependencies": {
+    "@types/express-serve-static-core": "4.17.20",
     "check-engine": "^1.10.1",
     "node-mocks-http": "^1.7.3"
   },


### PR DESCRIPTION
The latest version of `@types/express-serve-static-core` causes our TypeScript builds to fail as it uses syntax that our older version of `tsc` can't parse (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/62300). Let's force it to use an older version to avoid this.

In theory, it would be better to use npm overrides to achieve this, but I can't get it to work in practice as they always seem to fail to handle one instance of a transitive dependency or other.

We could also work around this by updating to the latest version of `tsc` – which might be worthwhile but could introduce some other bugs I don't want to search for right now, or finally add a `package-lock.json` file to this monorepo. I think npm workspaces would be a suitable drop-in for the athloi workflow we have at the moment at this point.