### PR TITLE
Remove `aria-hidden="true"` from mobile navigation

### DIFF
--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -22,7 +22,6 @@ const NavMobile = ({ items }: { items: TNavMenuItem[] }) => {
     <nav
       id="o-header-nav-mobile"
       className="o-header__row o-header__nav o-header__nav--mobile"
-      aria-hidden="true"
       data-trackable="header-nav:mobile"
     >
       <ul className="o-header__nav-list">


### PR DESCRIPTION
`aria-hidden="true"` is always applied on the mobile navigation. This means assistive tech users can't navigate to markets data on mobile.
It seems unnecessary as `display: none` is set on desktop.

![Screenshot 2022-10-12 at 11 51 47](https://user-images.githubusercontent.com/10405691/195324370-10d3484a-29fa-4884-a2da-8e56303250b3.png)
![Screenshot 2022-10-12 at 11 51 18](https://user-images.githubusercontent.com/10405691/195324376-6388c980-e90c-40d8-8e7a-26d892f5cfc4.png)
