### PR TITLE
CPREL-336: Fix dotcom-server-navigation by updating and improving ft-poller handling

### DIFF
--- a/packages/dotcom-server-navigation/package.json
+++ b/packages/dotcom-server-navigation/package.json
@@ -20,10 +20,9 @@
   "license": "MIT",
   "dependencies": {
     "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
-    "@financial-times/n-logger": "^10.1.0",
     "@types/deep-freeze": "^0.1.1",
     "deep-freeze": "0.0.1",
-    "ft-poller": "^7.0.0",
+    "ft-poller": "^7.2.1",
     "http-errors": "^1.7.1",
     "node-fetch": "^2.2.1"
   },

--- a/packages/dotcom-server-navigation/src/navigation.ts
+++ b/packages/dotcom-server-navigation/src/navigation.ts
@@ -1,4 +1,3 @@
-import logger from '@financial-times/n-logger'
 import Poller from 'ft-poller'
 import httpError from 'http-errors'
 import deepFreeze from 'deep-freeze'
@@ -59,15 +58,7 @@ export class Navigation {
     // initialPromise does not return data but must resolve before `getData` can be called
     await this.initialPromise
 
-    try {
-      this.menuData = this.poller.getData()
-    } catch (error) {
-      // getData throws if the most recent fetch resulted in an error.
-      // In that case, continue to use the latest navigation we have available.
-      // In the future we may want to handle this differently. See ticket FTDCS-258
-      // for some ideas on how this code could be improved.
-      logger.warn('ERROR_FETCHING_NAVIGATION', error)
-    }
+    this.menuData = this.poller.getData()
 
     return this.menuData
 


### PR DESCRIPTION
Removed need for try/catch as latest version of ft-poller no longer throws and error.