### PR TITLE
CPREL-337: Fix navigation type checking and add rendering fallbacks if Menu Items are missing

### DIFF
--- a/packages/dotcom-types-navigation/index.d.ts
+++ b/packages/dotcom-types-navigation/index.d.ts
@@ -61,14 +61,14 @@ export interface INavMeganavSections {
   dataset: 'subsections'
   title: string
   /** This data has been split into "columns" by the Next navigation API */
-  data: TNavMenuItem[][]
+  data?: TNavMenuItem[][]
 }
 
 export interface INavMeganavArticles {
   component: 'articlelist'
   dataset: 'popular'
   title: string
-  data: TNavMenuItem[]
+  data?: TNavMenuItem[]
 }
 
 export type TNavSubNavigation = {

--- a/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
@@ -14,7 +14,7 @@ export const DrawerParentItem = ({ item, idSuffix }: TDrawerParentItemProps) => 
       <div key={item.url} className="o-header__drawer-menu-toggle-wrapper">
         <a
           className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected} o-header__drawer-menu-link--parent`}
-          href={item.url}
+          href={`${item.url}`}
           {...ariaSelected(item)}
           data-trackable={item.label}
         >
@@ -33,13 +33,13 @@ export const DrawerParentItem = ({ item, idSuffix }: TDrawerParentItemProps) => 
         id={`o-header-drawer-child-${idSuffix}`}
         data-trackable="sub-level"
       >
-        {(item.submenu.items as TNavMenuItem[]).map((item) => {
+        {(item.submenu?.items as TNavMenuItem[]).map((item) => {
           const selected = item.selected ? 'selected' : 'unselected'
           return (
             <li key={item.url} className="o-header__drawer-menu-item">
               <a
                 className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected} o-header__drawer-menu-link--child`}
-                href={item.url}
+                href={`${item.url}`}
                 data-trackable={item.label}
                 {...ariaSelected(item)}
               >
@@ -58,7 +58,7 @@ export const DrawerSingleItem = (item: TNavMenuItem) => {
   return (
     <a
       className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected}`}
-      href={item.url}
+      href={`${item.url}`}
       data-trackable={item.label}
       {...ariaSelected(item)}
     >
@@ -72,7 +72,7 @@ export const DrawerSpecialItem = (item: TNavMenuItem) => {
   return (
     <a
       className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected} o-header__drawer-menu-link--secondary`}
-      href={item.url}
+      href={`${item.url}`}
       data-trackable={item.label}
       {...ariaSelected(item)}
     >

--- a/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
@@ -14,7 +14,7 @@ export const DrawerParentItem = ({ item, idSuffix }: TDrawerParentItemProps) => 
       <div key={item.url} className="o-header__drawer-menu-toggle-wrapper">
         <a
           className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected} o-header__drawer-menu-link--parent`}
-          href={`${item.url}`}
+          href={item.url ?? undefined}
           {...ariaSelected(item)}
           data-trackable={item.label}
         >
@@ -39,7 +39,7 @@ export const DrawerParentItem = ({ item, idSuffix }: TDrawerParentItemProps) => 
             <li key={item.url} className="o-header__drawer-menu-item">
               <a
                 className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected} o-header__drawer-menu-link--child`}
-                href={`${item.url}`}
+                href={item.url ?? undefined}
                 data-trackable={item.label}
                 {...ariaSelected(item)}
               >
@@ -58,7 +58,7 @@ export const DrawerSingleItem = (item: TNavMenuItem) => {
   return (
     <a
       className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected}`}
-      href={`${item.url}`}
+      href={item.url ?? undefined}
       data-trackable={item.label}
       {...ariaSelected(item)}
     >
@@ -72,7 +72,7 @@ export const DrawerSpecialItem = (item: TNavMenuItem) => {
   return (
     <a
       className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected} o-header__drawer-menu-link--secondary`}
-      href={`${item.url}`}
+      href={item.url ?? undefined}
       data-trackable={item.label}
       {...ariaSelected(item)}
     >

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -102,7 +102,7 @@ const SectionPrimary = (props: TNavMenuItem) => {
   return (
     <React.Fragment>
       <li className="o-header__drawer-menu-item o-header__drawer-menu-item--heading">{props.label}</li>
-      {(props.submenu.items as TNavMenuItem[]).map((item, index) => (
+      {(props.submenu?.items as TNavMenuItem[]).map((item, index) => (
         <li key={item.url} className="o-header__drawer-menu-item">
           {item.submenu ? (
             <DrawerParentItem item={item} idSuffix={`${index}`} />
@@ -118,7 +118,7 @@ const SectionPrimary = (props: TNavMenuItem) => {
 const SectionSecondary = (props: TNavMenuItem) => (
   <React.Fragment>
     <li className="o-header__drawer-menu-item o-header__drawer-menu-item--heading">{props.label}</li>
-    {(props.submenu.items as TNavMenuItem[]).map((item, index) => (
+    {(props.submenu?.items as TNavMenuItem[]).map((item, index) => (
       <li key={item.url} className="o-header__drawer-menu-item">
         {item.submenu ? (
           <DrawerParentItem item={item} idSuffix={'inner' + index} />
@@ -132,7 +132,7 @@ const SectionSecondary = (props: TNavMenuItem) => (
 
 const SectionTertiary = (props: TNavMenuItem) => (
   <React.Fragment>
-    {(props.submenu.items as TNavMenuItem[]).map((item, index) => {
+    {(props.submenu?.items as TNavMenuItem[]).map((item, index) => {
       const divideItem = index === 0 ? 'o-header__drawer-menu-item--divide' : ''
 
       return (
@@ -149,7 +149,7 @@ const UserMenu = (props: TNavMenu) => (
     <ul className="o-header__drawer-menu-list">
       {props.items.map((item) => (
         <li key={item.url} className="o-header__drawer-menu-item">
-          <a className="o-header__drawer-menu-link" href={item.url} data-trackable={item.label}>
+          <a className="o-header__drawer-menu-link" href={`${item.url}`} data-trackable={item.label}>
             {item.label}
           </a>
         </li>

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -149,7 +149,7 @@ const UserMenu = (props: TNavMenu) => (
     <ul className="o-header__drawer-menu-list">
       {props.items.map((item) => (
         <li key={item.url} className="o-header__drawer-menu-item">
-          <a className="o-header__drawer-menu-link" href={`${item.url}`} data-trackable={item.label}>
+          <a className="o-header__drawer-menu-link" href={item.url ?? undefined} data-trackable={item.label}>
             {item.label}
           </a>
         </li>

--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -12,7 +12,7 @@ const MobileNav = (props: THeaderProps) => {
   // Only display navigation on pages which are included in this menu
   const targetUrls = props.data['navbar-simple'].items.map((item) => item.url)
 
-  return targetUrls.includes(props.data.currentPath) ? (
+  return props.data.currentPath && targetUrls.includes(props.data.currentPath) ? (
     <NavMobile items={props.data['navbar-simple'].items} />
   ) : null
 }
@@ -30,7 +30,7 @@ const NavMobile = ({ items }: { items: TNavMenuItem[] }) => {
           <li className="o-header__nav-item" key={`link-${index}`}>
             <a
               className="o-header__nav-link o-header__nav-link--primary"
-              href={item.url}
+              href={`${item.url}`}
               {...ariaSelected(item)}
               data-trackable={item.label}
             >
@@ -61,7 +61,7 @@ const NavListLeft = (props: THeaderProps) => (
       <li className="o-header__nav-item" key={`link-${index}`}>
         <a
           className="o-header__nav-link o-header__nav-link--primary"
-          href={item.url}
+          href={`${item.url}`}
           id={`o-header-link-${index}`}
           {...ariaSelected(item)}
           data-trackable={item.label}
@@ -85,7 +85,7 @@ const NavListRightLoggedIn = ({ items }: { items: TNavMenuItem[] }) => {
     <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
       {items.map((item, index) => (
         <li className="o-header__nav-item" key={`link-${index}`}>
-          <a className="o-header__nav-link" href={item.url} data-trackable={item.label}>
+          <a className="o-header__nav-link" href={`${item.url}`} data-trackable={item.label}>
             {item.label}
           </a>
         </li>
@@ -123,12 +123,12 @@ const SectionList = ({ title, data }: INavMeganavSections) => {
       <div className="o-header__mega-heading">{title}</div>
       <div className="o-header__mega-content">
         <ul className="o-header__mega-list">
-          {data.map((column) =>
+          {data?.map((column) =>
             column.map((item, index) => (
               <li className="o-header__mega-item" key={`link-${index}`}>
                 <a
                   className="o-header__mega-link"
-                  href={item.url}
+                  href={`${item.url}`}
                   {...ariaSelected(item)}
                   data-trackable="link"
                 >
@@ -149,11 +149,11 @@ const ArticleList = ({ title, data }: INavMeganavArticles) => {
       <div className="o-header__mega-heading">{title}</div>
       <div className="o-header__mega-content">
         <ul className="o-header__mega-list">
-          {data.map((item, index) => (
+          {data?.map((item, index) => (
             <li className="o-header__mega-item" key={`link-${index}`}>
               <a
                 className="o-header__mega-link"
-                href={item.url}
+                href={`${item.url}`}
                 {...ariaSelected(item)}
                 data-trackable="link"
               >
@@ -175,7 +175,7 @@ const UserActionsNav = (props: THeaderProps) => {
       <ul className="o-header__anon-list">
         {userNavItems.map((item, index) => (
           <li className="o-header__anon-item" key={`link-${index}`}>
-            <a className="o-header__anon-link" href={item.url} data-trackable={item.label}>
+            <a className="o-header__anon-link" href={`${item.url}`} data-trackable={item.label}>
               {item.label}
             </a>
           </li>

--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -30,7 +30,7 @@ const NavMobile = ({ items }: { items: TNavMenuItem[] }) => {
           <li className="o-header__nav-item" key={`link-${index}`}>
             <a
               className="o-header__nav-link o-header__nav-link--primary"
-              href={`${item.url}`}
+              href={item.url ?? undefined}
               {...ariaSelected(item)}
               data-trackable={item.label}
             >
@@ -61,7 +61,7 @@ const NavListLeft = (props: THeaderProps) => (
       <li className="o-header__nav-item" key={`link-${index}`}>
         <a
           className="o-header__nav-link o-header__nav-link--primary"
-          href={`${item.url}`}
+          href={item.url ?? undefined}
           id={`o-header-link-${index}`}
           {...ariaSelected(item)}
           data-trackable={item.label}
@@ -85,7 +85,7 @@ const NavListRightLoggedIn = ({ items }: { items: TNavMenuItem[] }) => {
     <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
       {items.map((item, index) => (
         <li className="o-header__nav-item" key={`link-${index}`}>
-          <a className="o-header__nav-link" href={`${item.url}`} data-trackable={item.label}>
+          <a className="o-header__nav-link" href={item.url ?? undefined} data-trackable={item.label}>
             {item.label}
           </a>
         </li>
@@ -128,7 +128,7 @@ const SectionList = ({ title, data }: INavMeganavSections) => {
               <li className="o-header__mega-item" key={`link-${index}`}>
                 <a
                   className="o-header__mega-link"
-                  href={`${item.url}`}
+                  href={item.url ?? undefined}
                   {...ariaSelected(item)}
                   data-trackable="link"
                 >
@@ -153,7 +153,7 @@ const ArticleList = ({ title, data }: INavMeganavArticles) => {
             <li className="o-header__mega-item" key={`link-${index}`}>
               <a
                 className="o-header__mega-link"
-                href={`${item.url}`}
+                href={item.url ?? undefined}
                 {...ariaSelected(item)}
                 data-trackable="link"
               >
@@ -175,7 +175,7 @@ const UserActionsNav = (props: THeaderProps) => {
       <ul className="o-header__anon-list">
         {userNavItems.map((item, index) => (
           <li className="o-header__anon-item" key={`link-${index}`}>
-            <a className="o-header__anon-link" href={`${item.url}`} data-trackable={item.label}>
+            <a className="o-header__anon-link" href={item.url ?? undefined} data-trackable={item.label}>
               {item.label}
             </a>
           </li>

--- a/packages/dotcom-ui-header/src/components/sticky/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sticky/partials.tsx
@@ -48,7 +48,7 @@ const Navigation = (props: THeaderProps) => (
           <li className="o-header__nav-item" key={`link-${index}`}>
             <a
               className="o-header__nav-link o-header__nav-link--primary"
-              href={item.url}
+              href={`${item.url}`}
               data-trackable={item.label}
               tabIndex={-1}
             >
@@ -144,7 +144,7 @@ const NavListRightLoggedInSticky = (props: THeaderProps) => {
 // - The sticky header renders either the `navbar-right-anon` data or the myFT component
 // - The normal header renders either the `navbar-right-anon` or the `navbar-right` data
 const TopColumnRightSticky = (props: THeaderProps) => {
-  let children = null
+  let children: JSX.Element | undefined = undefined
 
   if (props.userIsLoggedIn) {
     children = <NavListRightLoggedInSticky {...props} />

--- a/packages/dotcom-ui-header/src/components/sticky/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sticky/partials.tsx
@@ -48,7 +48,7 @@ const Navigation = (props: THeaderProps) => (
           <li className="o-header__nav-item" key={`link-${index}`}>
             <a
               className="o-header__nav-link o-header__nav-link--primary"
-              href={`${item.url}`}
+              href={item.url ?? undefined}
               data-trackable={item.label}
               tabIndex={-1}
             >

--- a/packages/dotcom-ui-header/src/components/sub-navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sub-navigation/partials.tsx
@@ -43,19 +43,19 @@ const SubNavigationWrapper = (props) => (
   </div>
 )
 
-const BreadCrumb = ({ items }: { items: TNavMenuItem[] }) => (
+const BreadCrumb = ({ items }: { items?: TNavMenuItem[] }) => (
   <ol
     className="o-header__subnav-list o-header__subnav-list--breadcrumb"
     aria-label="Breadcrumb"
     data-trackable="breadcrumb">
-    {items.map((item, index) => {
+    {items?.map((item, index) => {
       const selected = item.selected ? 'o-header__subnav-link--highlight' : ''
 
       return (
         <li className="o-header__subnav-item" key={`item-${index}`}>
           <a
             className={`o-header__subnav-link ${selected}`}
-            href={item.url}
+            href={`${item.url}`}
             {...ariaSelected(item)}
             data-trackable={item.label}>
             {item.label}
@@ -66,7 +66,7 @@ const BreadCrumb = ({ items }: { items: TNavMenuItem[] }) => (
   </ol>
 )
 
-const SubSections = ({ items, rightAlignment }: { items: TNavMenuItem[]; rightAlignment?: boolean }) => {
+const SubSections = ({ items, rightAlignment }: { items?: TNavMenuItem[]; rightAlignment?: boolean }) => {
   if (!items || items.length === 0) {
     return null
   }
@@ -86,7 +86,7 @@ const SubSections = ({ items, rightAlignment }: { items: TNavMenuItem[]; rightAl
           <li className="o-header__subnav-item" key={`item-${index}`}>
             <a
               className={`o-header__subnav-link ${selected}`}
-              href={item.url}
+              href={`${item.url}`}
               {...ariaSelected(item)}
               data-trackable={item.label}>
               {item.label}

--- a/packages/dotcom-ui-header/src/components/sub-navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sub-navigation/partials.tsx
@@ -17,7 +17,8 @@ const SubNavigationWrapper = (props) => (
     role="navigation"
     aria-label="Sub navigation"
     data-o-header-subnav
-    data-trackable="header-subnav">
+    data-trackable="header-subnav"
+  >
     <div className="o-header__container">
       <div className="o-header__subnav-wrap-outside">
         <div className="o-header__subnav-wrap-inside" data-o-header-subnav-wrapper>
@@ -47,7 +48,8 @@ const BreadCrumb = ({ items }: { items?: TNavMenuItem[] }) => (
   <ol
     className="o-header__subnav-list o-header__subnav-list--breadcrumb"
     aria-label="Breadcrumb"
-    data-trackable="breadcrumb">
+    data-trackable="breadcrumb"
+  >
     {items?.map((item, index) => {
       const selected = item.selected ? 'o-header__subnav-link--highlight' : ''
 
@@ -55,9 +57,10 @@ const BreadCrumb = ({ items }: { items?: TNavMenuItem[] }) => (
         <li className="o-header__subnav-item" key={`item-${index}`}>
           <a
             className={`o-header__subnav-link ${selected}`}
-            href={`${item.url}`}
+            href={item.url ?? undefined}
             {...ariaSelected(item)}
-            data-trackable={item.label}>
+            data-trackable={item.label}
+          >
             {item.label}
           </a>
         </li>
@@ -78,7 +81,8 @@ const SubSections = ({ items, rightAlignment }: { items?: TNavMenuItem[]; rightA
         (rightAlignment ? ' o-header__subnav-list--right' : '')
       }
       aria-label={rightAlignment ? 'Additional Sub Navigation' : 'Subsections'}
-      data-trackable="subsections">
+      data-trackable="subsections"
+    >
       {items.map((item, index) => {
         const selected = item.selected ? 'o-header__subnav-link--highlight' : ''
 
@@ -86,9 +90,10 @@ const SubSections = ({ items, rightAlignment }: { items?: TNavMenuItem[]; rightA
           <li className="o-header__subnav-item" key={`item-${index}`}>
             <a
               className={`o-header__subnav-link ${selected}`}
-              href={`${item.url}`}
+              href={item.url ?? undefined}
               {...ariaSelected(item)}
-              data-trackable={item.label}>
+              data-trackable={item.label}
+            >
               {item.label}
             </a>
           </li>

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -118,7 +118,7 @@ const SignInLink = ({
   return (
     <a
       className={`o-header__top-link ${className}`}
-      href={item.url}
+      href={`${item.url}`}
       data-trackable={item.label}
       {...setTabIndex}
     >
@@ -142,7 +142,7 @@ const SubscribeButton = ({
       // Added as the result of a DAC audit. This will be confusing for users of voice activation software
       // as it looks like a button but behaves like a link without this role.
       role="button"
-      href={item.url}
+      href={`${item.url}`}
       data-trackable={item.label}
       {...setTabIndex}
     >

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -118,7 +118,7 @@ const SignInLink = ({
   return (
     <a
       className={`o-header__top-link ${className}`}
-      href={`${item.url}`}
+      href={item.url ?? undefined}
       data-trackable={item.label}
       {...setTabIndex}
     >
@@ -142,7 +142,7 @@ const SubscribeButton = ({
       // Added as the result of a DAC audit. This will be confusing for users of voice activation software
       // as it looks like a button but behaves like a link without this role.
       role="button"
-      href={`${item.url}`}
+      href={item.url ?? undefined}
       data-trackable={item.label}
       {...setTabIndex}
     >

--- a/packages/dotcom-ui-header/tsconfig.json
+++ b/packages/dotcom-ui-header/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "./src/",
+    "strictNullChecks": true
   },
   "extends": "../../tsconfig.json"
 }

--- a/packages/dotcom-ui-header/tsconfig.json
+++ b/packages/dotcom-ui-header/tsconfig.json
@@ -1,4 +1,6 @@
 {
-  "rootDir": "./src/",
+  "compilerOptions": {
+    "rootDir": "./src/",
+  },
   "extends": "../../tsconfig.json"
 }


### PR DESCRIPTION
We have aligned our navigation types to allow for `sectionlist` and `articlelist` to be `null` or `undefined`. The Origami Navigation Services allow for these type to be null but our templates did not reflect this. Our templates failed to render in https://github.com/Financial-Times/incident-reports/issues/534 when the data expected was not an array.

We have now fixed the type definition and fixed the typescript config to check for null types just for the `dotcom-ui-header` (it was turned off very early in this repo for everything and never turned back on). Turning on `strictNullChecks` means new type errors have been exposed for the package which this PR fixes.