### PR TITLE
Add targets for workspace menu

### DIFF
--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -131,6 +131,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
       </ul>
       <ul
         className="o-header__drawer-menu-list"
+        data-component="drawer-menu--primary__drawer-menu-list"
       >
         <li
           className="o-header__drawer-menu-item o-header__drawer-menu-item--heading"
@@ -1234,6 +1235,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
         </li>
         <li
           className="o-header__drawer-menu-item o-header__drawer-menu-item--divide"
+          data-component="drawer-menu-item--divide"
         >
           <a
             className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--secondary"
@@ -2580,6 +2582,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
         </li>
         <li
           className="o-header__drawer-menu-item o-header__drawer-menu-item--divide"
+          data-component="drawer-menu-item--divide"
         >
           <a
             className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--secondary"

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -1479,6 +1479,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
       </ul>
       <ul
         className="o-header__drawer-menu-list"
+        data-component="drawer-menu--primary__drawer-menu-list"
       >
         <li
           className="o-header__drawer-menu-item o-header__drawer-menu-item--heading"

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -34,10 +34,7 @@ const Drawer = (props: THeaderProps) => {
         <Search />
         <nav className="o-header__drawer-menu o-header__drawer-menu--primary o-header__drawer-menu--border">
           {editions && <EditionsSwitcher {...editions} />}
-          <ul
-            data-component={props.userIsLoggedIn ? 'drawer-menu--primary__drawer-menu-list' : undefined}
-            className="o-header__drawer-menu-list"
-          >
+          <ul data-component="drawer-menu--primary__drawer-menu-list" className="o-header__drawer-menu-list">
             {primary ? <SectionPrimary {...primary} /> : null}
             {secondary ? <SectionSecondary {...secondary} /> : null}
             {tertiary ? <SectionTertiary {...tertiary} /> : null}

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -34,7 +34,10 @@ const Drawer = (props: THeaderProps) => {
         <Search />
         <nav className="o-header__drawer-menu o-header__drawer-menu--primary o-header__drawer-menu--border">
           {editions && <EditionsSwitcher {...editions} />}
-          <ul className="o-header__drawer-menu-list">
+          <ul
+            data-component={props.userIsLoggedIn ? 'drawer-menu--primary__drawer-menu-list' : undefined}
+            className="o-header__drawer-menu-list"
+          >
             {primary ? <SectionPrimary {...primary} /> : null}
             {secondary ? <SectionSecondary {...secondary} /> : null}
             {tertiary ? <SectionTertiary {...tertiary} /> : null}
@@ -136,7 +139,11 @@ const SectionTertiary = (props: TNavMenuItem) => (
       const divideItem = index === 0 ? 'o-header__drawer-menu-item--divide' : ''
 
       return (
-        <li key={item.url} className={`o-header__drawer-menu-item ${divideItem}`}>
+        <li
+          data-component={divideItem ? 'drawer-menu-item--divide' : undefined}
+          key={item.url}
+          className={`o-header__drawer-menu-item ${divideItem}`}
+        >
           <DrawerSpecialItem {...item} />
         </li>
       )

--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -82,9 +82,13 @@ const NavListRight = (props: THeaderProps) => {
 
 const NavListRightLoggedIn = ({ items }: { items: TNavMenuItem[] }) => {
   return (
-    <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
+    <ul
+      data-component="nav-list--right"
+      className="o-header__nav-list o-header__nav-list--right"
+      data-trackable="user-nav"
+    >
       {items.map((item, index) => (
-        <li data-component="nav-list--right__nav-item" className="o-header__nav-item" key={`link-${index}`}>
+        <li className="o-header__nav-item" key={`link-${index}`}>
           <a className="o-header__nav-link" href={item.url ?? undefined} data-trackable={item.label}>
             {item.label}
           </a>

--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -84,7 +84,7 @@ const NavListRightLoggedIn = ({ items }: { items: TNavMenuItem[] }) => {
   return (
     <ul className="o-header__nav-list o-header__nav-list--right" data-trackable="user-nav">
       {items.map((item, index) => (
-        <li className="o-header__nav-item" key={`link-${index}`}>
+        <li data-component="nav-list--right__nav-item" className="o-header__nav-item" key={`link-${index}`}>
           <a className="o-header__nav-link" href={item.url ?? undefined} data-trackable={item.label}>
             {item.label}
           </a>


### PR DESCRIPTION
As discussed with Alex and Glynn in the conversation below I am submitting this PR to add `data-component` attributes to `NavListLoggedIn` and `Drawer` so we could target and add Workspace nav item with a tooltip.
![image](https://user-images.githubusercontent.com/110386755/197702330-20614190-21e2-4989-a349-6669cd8ee699.png)
https://financialtimes.slack.com/archives/CSH1XFM5W/p1665494436384209