### PR TITLE
chore(dotcom-build-base): widen Webpack version range

### DIFF
--- a/packages/dotcom-build-base/package.json
+++ b/packages/dotcom-build-base/package.json
@@ -28,7 +28,7 @@
     "check-engine": "^1.10.1"
   },
   "peerDependencies": {
-    "webpack": "^4.39.2"
+    "webpack": "^4.39.2 || 5.x.x"
   },
   "engines": {
     "node": ">= 14.0.0",


### PR DESCRIPTION
The PR codifies that the dotcom-build-base package works with Webkit 5.x.x. The work to actually add support was completed a long time ago in [CPP-538](https://financialtimes.atlassian.net/browse/CPP-538).

I opted to keep v4 of Webkit at `^4.39.2` instead of `4.x.x` because I don't know what level of support there is for earlier versions of the 4.x branch. Let me know if you'd rather go with `4.x.x` to match `@dotcom-tool-kit/webpack`.