### PR TITLE
Revert "chore(dotcom-build-base): widen Webpack version range"

### DIFF
--- a/packages/dotcom-build-base/package.json
+++ b/packages/dotcom-build-base/package.json
@@ -28,7 +28,7 @@
     "check-engine": "^1.10.1"
   },
   "peerDependencies": {
-    "webpack": "^4.39.2 || 5.x.x"
+    "webpack": "^4.39.2"
   },
   "engines": {
     "node": ">= 14.0.0",


### PR DESCRIPTION
Reverts Financial-Times/dotcom-page-kit#959

It seems that Webpack 5 has dropped support for TypeScript 3, causing the CircleCI build to fail. Rather than rush to make a decision about how to work around this (should we update to TypeScript 4? etc...) let's discuss this within the @Financial-Times/platforms team, and revert this PR for now.