### PR TITLE
Update postcss & autoprefixer

### DIFF
--- a/packages/dotcom-build-sass/package.json
+++ b/packages/dotcom-build-sass/package.json
@@ -22,11 +22,12 @@
     "webpack": "^4.39.2"
   },
   "dependencies": {
-    "autoprefixer": "^9.6.0",
+    "autoprefixer": "^10.2.5",
+    "postcss": "^8.4.20",
     "css-loader": "^3.0.0",
     "cssnano": "^4.1.10",
     "mini-css-extract-plugin": "^0.12.0",
-    "postcss-loader": "^3.0.0",
+    "postcss-loader": "^4.0.0",
     "sass": "^1.25.0",
     "sass-loader": "^8.0.0",
     "webpack-fix-style-only-entries": "^0.5.0"

--- a/packages/dotcom-build-sass/src/index.ts
+++ b/packages/dotcom-build-sass/src/index.ts
@@ -58,15 +58,17 @@ export class PageKitSassPlugin {
     }
 
     const postcssLoaderOptions = {
-      plugins: [
-        // Add vendor prefixes automatically using data from Can I Use
-        // https://github.com/postcss/autoprefixer
-        require('autoprefixer')(autoprefixerOptions),
-        // Ensure that the final result is as small as possible. This can
-        // de-duplicate rule-sets which is useful if $o-silent-mode is toggled.
-        // https://github.com/cssnano/cssnano
-        require('cssnano')(cssnanoOptions)
-      ]
+      postcssOptions: {
+        plugins: [
+          // Add vendor prefixes automatically using data from Can I Use
+          // https://github.com/postcss/autoprefixer
+          require('autoprefixer')(autoprefixerOptions),
+          // Ensure that the final result is as small as possible. This can
+          // de-duplicate rule-sets which is useful if $o-silent-mode is toggled.
+          // https://github.com/cssnano/cssnano
+          require('cssnano')(cssnanoOptions)
+        ]
+      }
     }
 
     const cssLoaderOptions = {


### PR DESCRIPTION
There is a bug in postcss autoprefixer which throws an error when `@supports selector() {}` CSS Syntax is used. This was fixed in `autoprefixer@10.2.5`.

https://github.com/postcss/autoprefixer/issues/1391

As Origami components now use `@supports selector() {}` CSS, builds for dotcom-page-kit users have begun to fail.

Upgrading autoprefixer fixes the issue. To upgrade autoprefixer postcss and postcss-loader have also
been updated.