### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/jest": "^26.0.0",
     "@types/node": "^10.12.26",
     "@types/react": "^16.8.20",
+    "@types/babel__traverse": "7.11.1",
     "@typescript-eslint/parser": "^3.0.0",
     "babel-loader": "^8.0.4",
     "check-engine": "^1.10.1",

--- a/packages/dotcom-build-sass/package.json
+++ b/packages/dotcom-build-sass/package.json
@@ -22,11 +22,12 @@
     "webpack": "^4.39.2"
   },
   "dependencies": {
-    "autoprefixer": "^9.6.0",
+    "autoprefixer": "^10.2.5",
+    "postcss": "^8.4.20",
     "css-loader": "^3.0.0",
     "cssnano": "^4.1.10",
     "mini-css-extract-plugin": "^0.12.0",
-    "postcss-loader": "^3.0.0",
+    "postcss-loader": "^4.0.0",
     "sass": "^1.25.0",
     "sass-loader": "^8.0.0",
     "webpack-fix-style-only-entries": "^0.5.0"

--- a/packages/dotcom-build-sass/src/index.ts
+++ b/packages/dotcom-build-sass/src/index.ts
@@ -58,15 +58,17 @@ export class PageKitSassPlugin {
     }
 
     const postcssLoaderOptions = {
-      plugins: [
-        // Add vendor prefixes automatically using data from Can I Use
-        // https://github.com/postcss/autoprefixer
-        require('autoprefixer')(autoprefixerOptions),
-        // Ensure that the final result is as small as possible. This can
-        // de-duplicate rule-sets which is useful if $o-silent-mode is toggled.
-        // https://github.com/cssnano/cssnano
-        require('cssnano')(cssnanoOptions)
-      ]
+      postcssOptions: {
+        plugins: [
+          // Add vendor prefixes automatically using data from Can I Use
+          // https://github.com/postcss/autoprefixer
+          require('autoprefixer')(autoprefixerOptions),
+          // Ensure that the final result is as small as possible. This can
+          // de-duplicate rule-sets which is useful if $o-silent-mode is toggled.
+          // https://github.com/cssnano/cssnano
+          require('cssnano')(cssnanoOptions)
+        ]
+      }
     }
 
     const cssLoaderOptions = {

--- a/packages/dotcom-middleware-app-context/package.json
+++ b/packages/dotcom-middleware-app-context/package.json
@@ -19,13 +19,13 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@types/express": "4.17.12",
     "@types/express-serve-static-core": "4.17.20",
     "check-engine": "^1.10.1",
     "node-mocks-http": "^1.7.5"
   },
   "dependencies": {
-    "@financial-times/dotcom-server-app-context": "file:../dotcom-server-app-context",
-    "@types/express": "^4.16.1"
+    "@financial-times/dotcom-server-app-context": "file:../dotcom-server-app-context"
   },
   "engines": {
     "node": ">= 14.0.0",

--- a/packages/dotcom-middleware-asset-loader/package.json
+++ b/packages/dotcom-middleware-asset-loader/package.json
@@ -20,10 +20,10 @@
   "license": "MIT",
   "dependencies": {
     "@financial-times/dotcom-server-asset-loader": "file:../../packages/dotcom-server-asset-loader",
-    "@types/express": "^4.16.0",
     "express": "^4.16.4"
   },
   "devDependencies": {
+    "@types/express": "4.17.12",
     "@types/express-serve-static-core": "4.17.20",
     "check-engine": "^1.10.1",
     "node-mocks-http": "^1.7.3"


### PR DESCRIPTION
Seeing as we still aren't using a lockfile for this repository we're occasionally bumping into `@types` definitions which are doing minor version updates that are breaking TypeScript 3.x support. We need to pin the version of `@types/babel__traverse` that Jest uses in order to avoid one such compatibility issue.