### PR TITLE
CPP-1043: Define postcss implementation for loader options for dotcom-build-sass package

### DIFF
--- a/packages/dotcom-build-sass/src/index.ts
+++ b/packages/dotcom-build-sass/src/index.ts
@@ -67,7 +67,8 @@ export class PageKitSassPlugin {
           // de-duplicate rule-sets which is useful if $o-silent-mode is toggled.
           // https://github.com/cssnano/cssnano
           require('cssnano')(cssnanoOptions)
-        ]
+        ],
+        implementation: require('postcss')
       }
     }
 


### PR DESCRIPTION
Force the Webpack PostCSS loader to use the PostCSS dependency version for the package.