### PR TITLE
Fix failing integration tests by mirroring Navigation API change

### DIFF
--- a/examples/ft-ui/__test__/anonymous-user.test.js
+++ b/examples/ft-ui/__test__/anonymous-user.test.js
@@ -6,25 +6,22 @@ describe('examples/ft-ui', () => {
 
   describe('Header link elements', () => {
     it('renders the expected anonymous user Header link elements', async () => {
-      await expect(page).toMatchElement('a[href="/myft"]', { text: 'myFT' })
-      await expect(page).toMatchElement('.o-header__top-column--right a[href="/login?location=/"]', {
+      await expect(page).toMatchElement('a[href$="/myft"]', { text: 'myFT' })
+      await expect(page).toMatchElement('.o-header__top-column--right a[href$="/login?location=/"]', {
         text: 'Sign In'
       })
-      await expect(page).toMatchElement('.o-header__top-column--right a[href^="/products?"]', {
+      await expect(page).toMatchElement('.o-header__top-column--right a[href*="/products?"]', {
         text: 'Subscribe'
       })
-      await expect(page).toMatchElement('.o-header__drawer-actions a[href^="/products?"]', {
+      await expect(page).toMatchElement('.o-header__drawer-actions a[href*="/products?"]', {
         text: 'Subscribe for full access'
       })
     })
 
     it('does not render the logged-in user Header link elements', async () => {
-      await expect(page).not.toMatchElement(
-        '.o-header__top-column--right a[href="https://www.ft.com/myaccount"]',
-        {
-          text: 'Settings & Account'
-        }
-      )
+      await expect(page).not.toMatchElement('.o-header__top-column--right a[href$="/myaccount"]', {
+        text: 'Settings & Account'
+      })
       await expect(page).not.toMatchElement(
         `.o-header__top-column--right a[href="https://markets.ft.com/data/portfolio/dashboard"]`,
         { text: 'Portfolio' }

--- a/examples/ft-ui/__test__/logged-in-user.test.js
+++ b/examples/ft-ui/__test__/logged-in-user.test.js
@@ -6,7 +6,7 @@ describe('examples/ft-ui', () => {
 
   describe('Header link elements', () => {
     it('renders the expected loggin-in user Header link elements', async () => {
-      await expect(page).toMatchElement('.o-header__top-column--right a[href="/myft"]', { text: 'myFT' })
+      await expect(page).toMatchElement('.o-header__top-column--right a[href$="/myft"]', { text: 'myFT' })
       await expect(page).toMatchElement('.o-header__nav-list--right a[href$="/myaccount"]', {
         text: 'Settings & Account'
       })
@@ -18,14 +18,14 @@ describe('examples/ft-ui', () => {
     })
 
     it('does not render the anonymous user Header link elements', async () => {
-      await expect(page).not.toMatchElement('.o-header__top-column--right a[href="/login?location=/"]', {
+      await expect(page).not.toMatchElement('.o-header__top-column--right a[href$="/login?location=/"]', {
         text: 'Sign In'
       })
-      await expect(page).toMatchElement('.o-header__top-column--right a[href^="/products?"]', {
+      await expect(page).toMatchElement('.o-header__top-column--right a[href*="/products?"]', {
         text: 'Subscribe'
       })
       const text = await page.evaluate(() => document.body.textContent)
-      await expect(page).toMatchElement('.o-header__drawer-actions a[href^="/products?"]', {
+      await expect(page).toMatchElement('.o-header__drawer-actions a[href*="/products?"]', {
         text: 'Subscribe for full access'
       })
     })

--- a/examples/ft-ui/__test__/logged-in-user.test.js
+++ b/examples/ft-ui/__test__/logged-in-user.test.js
@@ -7,7 +7,7 @@ describe('examples/ft-ui', () => {
   describe('Header link elements', () => {
     it('renders the expected loggin-in user Header link elements', async () => {
       await expect(page).toMatchElement('.o-header__top-column--right a[href="/myft"]', { text: 'myFT' })
-      await expect(page).toMatchElement('.o-header__nav-list--right a[href="https://www.ft.com/myaccount"]', {
+      await expect(page).toMatchElement('.o-header__nav-list--right a[href$="/myaccount"]', {
         text: 'Settings & Account'
       })
 

--- a/examples/ft-ui/__test__/subscribed-user.test.js
+++ b/examples/ft-ui/__test__/subscribed-user.test.js
@@ -7,7 +7,7 @@ describe('examples/ft-ui', () => {
   describe('Header link elements', () => {
     it('renders the expected loggin-in user Header link elements', async () => {
       await expect(page).toMatchElement('.o-header__top-column--right a[href="/myft"]', { text: 'myFT' })
-      await expect(page).toMatchElement('.o-header__nav-list--right a[href="https://www.ft.com/myaccount"]', {
+      await expect(page).toMatchElement('.o-header__nav-list--right a[href$="/myaccount"]', {
         text: 'Settings & Account'
       })
 

--- a/examples/ft-ui/__test__/subscribed-user.test.js
+++ b/examples/ft-ui/__test__/subscribed-user.test.js
@@ -6,7 +6,7 @@ describe('examples/ft-ui', () => {
 
   describe('Header link elements', () => {
     it('renders the expected loggin-in user Header link elements', async () => {
-      await expect(page).toMatchElement('.o-header__top-column--right a[href="/myft"]', { text: 'myFT' })
+      await expect(page).toMatchElement('.o-header__top-column--right a[href$="/myft"]', { text: 'myFT' })
       await expect(page).toMatchElement('.o-header__nav-list--right a[href$="/myaccount"]', {
         text: 'Settings & Account'
       })
@@ -18,13 +18,13 @@ describe('examples/ft-ui', () => {
     })
 
     it('does not render the anonymous user Header link elements', async () => {
-      await expect(page).not.toMatchElement('.o-header__top-column--right a[href="/login?location=/"]', {
+      await expect(page).not.toMatchElement('.o-header__top-column--right a[href$="/login?location=/"]', {
         text: 'Sign In'
       })
-      await expect(page).not.toMatchElement('.o-header__top-column--right a[href^="/products?"]', {
+      await expect(page).not.toMatchElement('.o-header__top-column--right a[href*="/products?"]', {
         text: 'Subscribe'
       })
-      await expect(page).not.toMatchElement('.o-header__drawer-actions a[href^="/products?segmentId="]', {
+      await expect(page).not.toMatchElement('.o-header__drawer-actions a[href*="/products?segmentId="]', {
         text: 'Subscribe for full access'
       })
     })


### PR DESCRIPTION
https://github.com/Financial-Times/origami-navigation-service/pull/533 updated the `href` link for the 'Settings & Account' button in the ft.com header to be relative rather than absolute. We were testing that this element was being showing up properly when the user was signed in our integration tests, but we were selecting it by the now modified `href` attribute.

I've updated the selector to search for the new relative `href` attribute. I've also made the selector more permissive: it will find any element that _ends_ in the relative link rather than matching it exactly. It looks like Origami is planning on potentially reverting back to absolute links at some point and this more permissive selection now shouldn't break even if that change is made. Therefore, I've extended that change to all other relative links in `href` attribute selectors so that we hopefully won't have to update any of these tests in the case of switching to absolute links.