### PR TITLE
CPP-1242: Update o-header dependency to v11

### DIFF
--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -32,11 +32,11 @@
     "@svgr/core": "^5.0.0",
     "camelcase": "^6.0.0",
     "check-engine": "^1.10.1",
-    "@financial-times/o-header": "^10.0.0",
+    "@financial-times/o-header": "^11.0.4",
     "react": "^16.8.6"
   },
   "peerDependencies": {
-    "@financial-times/o-header": "^10.0.0",
+    "@financial-times/o-header": "^11.0.4",
     "@financial-times/logo-images": "^1.10.1",
     "react": "16.x || 17.x"
   },

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -133,7 +133,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
       </ul>
     </nav>
     <nav
-      className="o-header__drawer-menu o-header__drawer-menu--primary o-header__drawer-menu--border"
+      className="o-header__drawer-menu o-header__drawer-menu--primary"
     >
       <h2
         className="o-header__drawer-menu-item o-header__drawer-menu-item--heading"
@@ -1497,7 +1497,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
       </ul>
     </nav>
     <nav
-      className="o-header__drawer-menu o-header__drawer-menu--primary o-header__drawer-menu--border"
+      className="o-header__drawer-menu o-header__drawer-menu--primary"
     >
       <h2
         className="o-header__drawer-menu-item o-header__drawer-menu-item--heading"

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -3,13 +3,14 @@
 exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] = `
 <div
   aria-label="Drawer menu"
+  aria-modal="true"
   className="o-header__drawer"
   data-o-header-drawer={true}
   data-o-header-drawer--no-js={true}
   data-trackable="drawer"
   data-trackable-terminate={true}
   id="o-header-drawer"
-  role="navigation"
+  role="modal"
 >
   <div
     className="o-header__drawer-inner"
@@ -1351,13 +1352,14 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
 exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`] = `
 <div
   aria-label="Drawer menu"
+  aria-modal="true"
   className="o-header__drawer"
   data-o-header-drawer={true}
   data-o-header-drawer--no-js={true}
   data-trackable="drawer"
   data-trackable-terminate={true}
   id="o-header-drawer"
-  role="navigation"
+  role="modal"
 >
   <div
     className="o-header__drawer-inner"

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -110,7 +110,8 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
       </form>
     </div>
     <nav
-      className="o-header__drawer-menu o-header__drawer-menu--primary o-header__drawer-menu--border"
+      aria-label="Edition switcher"
+      className="o-header__drawer-menu"
     >
       <ul
         className="o-header__drawer-menu-list"
@@ -130,15 +131,20 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
           </a>
         </li>
       </ul>
-      <ul
-        className="o-header__drawer-menu-list"
-        data-component="drawer-menu--primary__drawer-menu-list"
+    </nav>
+    <nav
+      className="o-header__drawer-menu o-header__drawer-menu--primary o-header__drawer-menu--border"
+    >
+      <h2
+        className="o-header__drawer-menu-item o-header__drawer-menu-item--heading"
+        id="top-sections"
       >
-        <li
-          className="o-header__drawer-menu-item o-header__drawer-menu-item--heading"
-        >
-          Top sections
-        </li>
+        Top sections
+      </h2>
+      <ul
+        aria-labelledby="top-sections"
+        className="o-header__drawer-menu-list"
+      >
         <li
           className="o-header__drawer-menu-item"
         >
@@ -1069,11 +1075,17 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
             Special Reports
           </a>
         </li>
-        <li
-          className="o-header__drawer-menu-item o-header__drawer-menu-item--heading"
-        >
-          FT recommends
-        </li>
+      </ul>
+      <h2
+        className="o-header__drawer-menu-item o-header__drawer-menu-item--heading"
+        id="ft-recommends"
+      >
+        FT recommends
+      </h2>
+      <ul
+        aria-labelledby="ft-recommends"
+        className="o-header__drawer-menu-list"
+      >
         <li
           className="o-header__drawer-menu-item"
         >
@@ -1234,9 +1246,12 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
             </li>
           </ul>
         </li>
+      </ul>
+      <ul
+        className="o-header__drawer-menu-list o-header__drawer-menu-list--divide"
+      >
         <li
-          className="o-header__drawer-menu-item o-header__drawer-menu-item--divide"
-          data-component="drawer-menu-item--divide"
+          className="o-header__drawer-menu-item"
         >
           <a
             className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--secondary"
@@ -1247,7 +1262,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
           </a>
         </li>
         <li
-          className="o-header__drawer-menu-item "
+          className="o-header__drawer-menu-item"
         >
           <a
             className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--secondary"
@@ -1258,7 +1273,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
           </a>
         </li>
         <li
-          className="o-header__drawer-menu-item "
+          className="o-header__drawer-menu-item"
         >
           <a
             className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--secondary"
@@ -1269,7 +1284,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
           </a>
         </li>
         <li
-          className="o-header__drawer-menu-item "
+          className="o-header__drawer-menu-item"
         >
           <a
             className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--secondary"
@@ -1280,7 +1295,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
           </a>
         </li>
         <li
-          className="o-header__drawer-menu-item "
+          className="o-header__drawer-menu-item"
         >
           <a
             className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--secondary"
@@ -1459,7 +1474,8 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
       </form>
     </div>
     <nav
-      className="o-header__drawer-menu o-header__drawer-menu--primary o-header__drawer-menu--border"
+      aria-label="Edition switcher"
+      className="o-header__drawer-menu"
     >
       <ul
         className="o-header__drawer-menu-list"
@@ -1479,15 +1495,20 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
           </a>
         </li>
       </ul>
-      <ul
-        className="o-header__drawer-menu-list"
-        data-component="drawer-menu--primary__drawer-menu-list"
+    </nav>
+    <nav
+      className="o-header__drawer-menu o-header__drawer-menu--primary o-header__drawer-menu--border"
+    >
+      <h2
+        className="o-header__drawer-menu-item o-header__drawer-menu-item--heading"
+        id="top-sections"
       >
-        <li
-          className="o-header__drawer-menu-item o-header__drawer-menu-item--heading"
-        >
-          Top sections
-        </li>
+        Top sections
+      </h2>
+      <ul
+        aria-labelledby="top-sections"
+        className="o-header__drawer-menu-list"
+      >
         <li
           className="o-header__drawer-menu-item"
         >
@@ -2418,11 +2439,17 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
             Special Reports
           </a>
         </li>
-        <li
-          className="o-header__drawer-menu-item o-header__drawer-menu-item--heading"
-        >
-          FT recommends
-        </li>
+      </ul>
+      <h2
+        className="o-header__drawer-menu-item o-header__drawer-menu-item--heading"
+        id="ft-recommends"
+      >
+        FT recommends
+      </h2>
+      <ul
+        aria-labelledby="ft-recommends"
+        className="o-header__drawer-menu-list"
+      >
         <li
           className="o-header__drawer-menu-item"
         >
@@ -2583,9 +2610,12 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
             </li>
           </ul>
         </li>
+      </ul>
+      <ul
+        className="o-header__drawer-menu-list o-header__drawer-menu-list--divide"
+      >
         <li
-          className="o-header__drawer-menu-item o-header__drawer-menu-item--divide"
-          data-component="drawer-menu-item--divide"
+          className="o-header__drawer-menu-item"
         >
           <a
             className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--secondary"
@@ -2596,7 +2626,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
           </a>
         </li>
         <li
-          className="o-header__drawer-menu-item "
+          className="o-header__drawer-menu-item"
         >
           <a
             className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--secondary"
@@ -2607,7 +2637,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
           </a>
         </li>
         <li
-          className="o-header__drawer-menu-item "
+          className="o-header__drawer-menu-item"
         >
           <a
             className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--secondary"
@@ -2618,7 +2648,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
           </a>
         </li>
         <li
-          className="o-header__drawer-menu-item "
+          className="o-header__drawer-menu-item"
         >
           <a
             className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--secondary"
@@ -2629,7 +2659,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
           </a>
         </li>
         <li
-          className="o-header__drawer-menu-item "
+          className="o-header__drawer-menu-item"
         >
           <a
             className="o-header__drawer-menu-link o-header__drawer-menu-link--unselected o-header__drawer-menu-link--secondary"

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -22,13 +22,13 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
         aria-controls="o-header-drawer"
         className="o-header__drawer-tools-close"
         data-trackable="close"
-        title="Close drawer menu"
+        title="Close side navigation menu"
         type="button"
       >
         <span
           className="o-header__visually-hidden"
         >
-          Close drawer menu
+          Close side navigation menu
         </span>
       </button>
       <a
@@ -1371,13 +1371,13 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
         aria-controls="o-header-drawer"
         className="o-header__drawer-tools-close"
         data-trackable="close"
-        title="Close drawer menu"
+        title="Close side navigation menu"
         type="button"
       >
         <span
           className="o-header__visually-hidden"
         >
-          Close drawer menu
+          Close side navigation menu
         </span>
       </button>
       <a

--- a/packages/dotcom-ui-header/src/__test__/enzyme/drawer.spec.tsx
+++ b/packages/dotcom-ui-header/src/__test__/enzyme/drawer.spec.tsx
@@ -59,7 +59,7 @@ describe('dotcom-ui-header/src/components/drawer', () => {
     })
 
     it('renders the tertiary link section divider', () => {
-      expect(result.find('.o-header__drawer-menu-item--divide')).toHaveText('myFT')
+      expect(result.find('.o-header__drawer-menu-list--divide > li:first-child')).toHaveText('myFT')
     })
 
     it('renders primary link subsections', () => {

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -36,7 +36,7 @@ const Drawer = (props: THeaderProps) => {
         <nav className="o-header__drawer-menu" aria-label="Edition switcher">
           {editions && <EditionsSwitcher {...editions} />}
         </nav>
-        <nav className="o-header__drawer-menu o-header__drawer-menu--primary o-header__drawer-menu--border">
+        <nav className="o-header__drawer-menu o-header__drawer-menu--primary">
           {primary ? <SectionPrimary {...primary} /> : null}
           {secondary ? <SectionSecondary {...secondary} /> : null}
           {tertiary ? <SectionTertiary {...tertiary} /> : null}

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -21,8 +21,9 @@ const Drawer = (props: THeaderProps) => {
     <div
       className="o-header__drawer"
       id="o-header-drawer"
-      role="navigation"
+      role="modal"
       aria-label="Drawer menu"
+      aria-modal="true"
       data-o-header-drawer
       data-o-header-drawer--no-js
       data-trackable="drawer"

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -33,13 +33,13 @@ const Drawer = (props: THeaderProps) => {
         <DrawerTools {...editions} />
         {!props.userIsSubscribed && subscribeAction && <SubscribeButton {...subscribeAction} />}
         <Search />
-        <nav className="o-header__drawer-menu o-header__drawer-menu--primary o-header__drawer-menu--border">
+        <nav className="o-header__drawer-menu" aria-label="Edition switcher">
           {editions && <EditionsSwitcher {...editions} />}
-          <ul data-component="drawer-menu--primary__drawer-menu-list" className="o-header__drawer-menu-list">
-            {primary ? <SectionPrimary {...primary} /> : null}
-            {secondary ? <SectionSecondary {...secondary} /> : null}
-            {tertiary ? <SectionTertiary {...tertiary} /> : null}
-          </ul>
+        </nav>
+        <nav className="o-header__drawer-menu o-header__drawer-menu--primary o-header__drawer-menu--border">
+          {primary ? <SectionPrimary {...primary} /> : null}
+          {secondary ? <SectionSecondary {...secondary} /> : null}
+          {tertiary ? <SectionTertiary {...tertiary} /> : null}
         </nav>
         <UserMenu {...user} />
       </div>
@@ -100,52 +100,58 @@ const Search = () => (
 )
 
 const SectionPrimary = (props: TNavMenuItem) => {
+  const sectionId = props.label.toLowerCase().replace(' ', '-')
   return (
     <React.Fragment>
-      <li className="o-header__drawer-menu-item o-header__drawer-menu-item--heading">{props.label}</li>
-      {(props.submenu?.items as TNavMenuItem[]).map((item, index) => (
-        <li key={item.url} className="o-header__drawer-menu-item">
-          {item.submenu ? (
-            <DrawerParentItem item={item} idSuffix={`${index}`} />
-          ) : (
-            <DrawerSingleItem {...item} />
-          )}
-        </li>
-      ))}
+      <h2 id={sectionId} className="o-header__drawer-menu-item o-header__drawer-menu-item--heading">
+        {props.label}
+      </h2>
+      <ul aria-labelledby={sectionId} className="o-header__drawer-menu-list">
+        {(props.submenu?.items as TNavMenuItem[]).map((item, index) => (
+          <li key={item.url} className="o-header__drawer-menu-item">
+            {item.submenu ? (
+              <DrawerParentItem item={item} idSuffix={`${index}`} />
+            ) : (
+              <DrawerSingleItem {...item} />
+            )}
+          </li>
+        ))}
+      </ul>
     </React.Fragment>
   )
 }
 
-const SectionSecondary = (props: TNavMenuItem) => (
-  <React.Fragment>
-    <li className="o-header__drawer-menu-item o-header__drawer-menu-item--heading">{props.label}</li>
-    {(props.submenu?.items as TNavMenuItem[]).map((item, index) => (
-      <li key={item.url} className="o-header__drawer-menu-item">
-        {item.submenu ? (
-          <DrawerParentItem item={item} idSuffix={'inner' + index} />
-        ) : (
-          <DrawerSingleItem {...item} />
-        )}
-      </li>
-    ))}
-  </React.Fragment>
-)
+const SectionSecondary = (props: TNavMenuItem) => {
+  const sectionId = props.label.toLowerCase().replace(' ', '-')
+  return (
+    <React.Fragment>
+      <h2 id={sectionId} className="o-header__drawer-menu-item o-header__drawer-menu-item--heading">
+        {props.label}
+      </h2>
+      <ul aria-labelledby={sectionId} className="o-header__drawer-menu-list">
+        {(props.submenu?.items as TNavMenuItem[]).map((item, index) => (
+          <li key={item.url} className="o-header__drawer-menu-item">
+            {item.submenu ? (
+              <DrawerParentItem item={item} idSuffix={'inner' + index} />
+            ) : (
+              <DrawerSingleItem {...item} />
+            )}
+          </li>
+        ))}
+      </ul>
+    </React.Fragment>
+  )
+}
 
 const SectionTertiary = (props: TNavMenuItem) => (
   <React.Fragment>
-    {(props.submenu?.items as TNavMenuItem[]).map((item, index) => {
-      const divideItem = index === 0 ? 'o-header__drawer-menu-item--divide' : ''
-
-      return (
-        <li
-          data-component={divideItem ? 'drawer-menu-item--divide' : undefined}
-          key={item.url}
-          className={`o-header__drawer-menu-item ${divideItem}`}
-        >
+    <ul className="o-header__drawer-menu-list o-header__drawer-menu-list--divide">
+      {(props.submenu?.items as TNavMenuItem[]).map((item) => (
+        <li key={item.url} className={`o-header__drawer-menu-item`}>
           <DrawerSpecialItem {...item} />
         </li>
-      )
-    })}
+      ))}
+    </ul>
   </React.Fragment>
 )
 

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -52,11 +52,11 @@ const DrawerTools = (props: TNavEditions) => (
     <button
       type="button"
       className="o-header__drawer-tools-close"
-      title="Close drawer menu"
+      title="Close side navigation menu"
       aria-controls="o-header-drawer"
       data-trackable="close"
     >
-      <span className="o-header__visually-hidden">Close drawer menu</span>
+      <span className="o-header__visually-hidden">Close side navigation menu</span>
     </button>
     <a className="o-header__drawer-tools-logo" href="/" data-trackable="logo">
       <span className="o-header__visually-hidden">Financial Times</span>


### PR DESCRIPTION
Update the `o-header` to v11 to get the latest accessibility audit updates. Followed the [migration script](https://github.com/Financial-Times/origami/blob/o-header-v11.0.4/components/o-header/MIGRATION.md#markup-drawer-divider) to manually apply the changes.