### PR TITLE
CPP-1317: fix missing files to publish in each package

### DIFF
--- a/packages/dotcom-build-base/package.json
+++ b/packages/dotcom-build-base/package.json
@@ -33,7 +33,7 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": ["dist/", "src/"],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-build-code-splitting/package.json
+++ b/packages/dotcom-build-code-splitting/package.json
@@ -35,7 +35,7 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": ["dist/", "src/"],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-build-images/package.json
+++ b/packages/dotcom-build-images/package.json
@@ -32,7 +32,7 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": ["dist/", "src/"],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-build-js/package.json
+++ b/packages/dotcom-build-js/package.json
@@ -39,7 +39,7 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": ["dist/", "src/"],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-build-sass/package.json
+++ b/packages/dotcom-build-sass/package.json
@@ -39,7 +39,7 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": ["dist/", "src/"],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-middleware-app-context/package.json
+++ b/packages/dotcom-middleware-app-context/package.json
@@ -30,7 +30,7 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": ["dist/", "src/"],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-middleware-asset-loader/package.json
+++ b/packages/dotcom-middleware-asset-loader/package.json
@@ -31,7 +31,7 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": ["dist/", "src/"],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-middleware-navigation/package.json
+++ b/packages/dotcom-middleware-navigation/package.json
@@ -29,7 +29,7 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": ["dist/", "src/"],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-server-app-context/package.json
+++ b/packages/dotcom-server-app-context/package.json
@@ -29,7 +29,7 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": ["dist/", "src/"],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-server-asset-loader/package.json
+++ b/packages/dotcom-server-asset-loader/package.json
@@ -21,7 +21,7 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": ["dist/", "src/"],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-server-handlebars/package.json
+++ b/packages/dotcom-server-handlebars/package.json
@@ -30,7 +30,7 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": ["dist/", "src/"],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-server-navigation/package.json
+++ b/packages/dotcom-server-navigation/package.json
@@ -34,7 +34,7 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": ["dist/", "src/"],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-server-react-jsx/package.json
+++ b/packages/dotcom-server-react-jsx/package.json
@@ -25,7 +25,7 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": ["dist/", "src/"],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-types-navigation/package.json
+++ b/packages/dotcom-types-navigation/package.json
@@ -17,7 +17,9 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": [
+    "index.d.ts"
+  ],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-ui-app-context/package.json
+++ b/packages/dotcom-ui-app-context/package.json
@@ -24,7 +24,12 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/",
+    "src/",
+    "browser.js",
+    "component.js"
+  ],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-ui-base-styles/package.json
+++ b/packages/dotcom-ui-base-styles/package.json
@@ -38,7 +38,13 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/",
+    "src/",
+    "browser.js",
+    "component.js",
+    "styles.scss"
+  ],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-ui-bootstrap/package.json
+++ b/packages/dotcom-ui-bootstrap/package.json
@@ -29,7 +29,13 @@
   "peerDependencies": {
     "react": "16.x || 17.x"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/",
+    "src/",
+    "browser.js",
+    "component.js",
+    "server.js"
+  ],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-ui-data-embed/package.json
+++ b/packages/dotcom-ui-data-embed/package.json
@@ -27,7 +27,13 @@
   "peerDependencies": {
     "react": "16.x || 17.x"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/",
+    "src/",
+    "browser.js",
+    "component.js",
+    "server.js"
+  ],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-ui-flags/package.json
+++ b/packages/dotcom-ui-flags/package.json
@@ -30,7 +30,13 @@
   "peerDependencies": {
     "react": "16.x || 17.x"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/",
+    "src/",
+    "browser.js",
+    "component.js",
+    "server.js"
+  ],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-ui-footer/package.json
+++ b/packages/dotcom-ui-footer/package.json
@@ -31,7 +31,13 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/",
+    "src/",
+    "browser.js",
+    "component.js",
+    "styles.scss"
+  ],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -43,7 +43,13 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/",
+    "src/",
+    "browser.js",
+    "component.js",
+    "styles.scss"
+  ],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-ui-layout/package.json
+++ b/packages/dotcom-ui-layout/package.json
@@ -36,7 +36,13 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/",
+    "src/",
+    "browser.js",
+    "component.js",
+    "styles.scss"
+  ],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-ui-polyfill-service/package.json
+++ b/packages/dotcom-ui-polyfill-service/package.json
@@ -23,7 +23,13 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/",
+    "src/",
+    "browser.js",
+    "component.js",
+    "styles.scss"
+  ],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-ui-shell/package.json
+++ b/packages/dotcom-ui-shell/package.json
@@ -34,7 +34,13 @@
     "node": ">= 14.0.0",
     "npm": "7.x || 8.x"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/",
+    "src/",
+    "browser.js",
+    "component.js",
+    "styles.scss"
+  ],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",


### PR DESCRIPTION
Before the migration to npm workspaces for publishing, we used to ignore a select group of files. Now we define the files to publish, we need to add the missing files that have not been defined but are required.