### PR TITLE
CPP-1330: fix publish versions of each package Page Kit dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
             ${HOME}/.npmrc
       - run:
           name: Bump version
-          command: npx --yes @financial-times/athloi@2.0.1 version ${CIRCLE_TAG} --filter "dotcom-*"
+          command: npx athloi version ${CIRCLE_TAG} --filter "dotcom-*"
       - run:
           name: NPM publish
           command: npm publish --workspace=packages/ --access=public --tag=latest
@@ -151,7 +151,7 @@ jobs:
             ${HOME}/.npmrc
       - run:
           name: Bump version
-          command: npx --yes @financial-times/athloi@2.0.1 version ${CIRCLE_TAG} --filter "dotcom-*"
+          command: npx athloi version ${CIRCLE_TAG} --filter "dotcom-*"
       - run:
           name: NPM publish
           command: npm publish --workspace=packages/ --access=public --tag=pre-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
             ${HOME}/.npmrc
       - run:
           name: Bump version
-          command: npm version ${CIRCLE_TAG} --workspace=packages/
+          command: npx --yes @financial-times/athloi@2.0.1 version ${CIRCLE_TAG} --filter "dotcom-*"
       - run:
           name: NPM publish
           command: npm publish --workspace=packages/ --access=public --tag=latest
@@ -151,7 +151,7 @@ jobs:
             ${HOME}/.npmrc
       - run:
           name: Bump version
-          command: npm version ${CIRCLE_TAG} --workspace=packages/
+          command: npx --yes @financial-times/athloi@2.0.1 version ${CIRCLE_TAG} --filter "dotcom-*"
       - run:
           name: NPM publish
           command: npm publish --workspace=packages/ --access=public --tag=pre-release

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
     "@storybook/addon-essentials": "^6.0.27",
     "@storybook/react": "^6.0.27",
     "@storybook/storybook-deployer": "^2.8.7",
+    "@types/babel__traverse": "7.11.1",
     "@types/jest": "^26.0.0",
     "@types/node": "^10.12.26",
     "@types/react": "^16.8.20",
-    "@types/babel__traverse": "7.11.1",
     "@typescript-eslint/parser": "^3.0.0",
     "babel-loader": "^8.0.4",
     "check-engine": "^1.10.1",
@@ -96,5 +96,8 @@
   "volta": {
     "node": "16.14.0",
     "npm": "8.5.3"
+  },
+  "dependencies": {
+    "@financial-times/athloi": "^2.0.1"
   }
 }


### PR DESCRIPTION
When publishing to the npm registry, we set the version in each Page Kit package dependency. Athloi used to then update each Page Kit package Page Kit dependency to the latest version number. This is missing in the migration to npm workspaces (CPP-1249).

We can use athloi just for the version step. We should then replace this with release-please.

https://financialtimes.atlassian.net/browse/CPP-1330