### PR TITLE
Include lib/ required by getBootstrapJS

### DIFF
--- a/packages/dotcom-ui-bootstrap/package.json
+++ b/packages/dotcom-ui-bootstrap/package.json
@@ -30,6 +30,7 @@
     "react": "16.x || 17.x"
   },
   "files": [
+    "lib/",
     "dist/",
     "src/",
     "browser.js",


### PR DESCRIPTION
As part of the runtime import of the `dotcom-ui-bootstrap`, it requires being able to get the script string stored in `lib/bootstrap.js` (see [server/getBootstrapJS.ts](https://github.com/Financial-Times/dotcom-page-kit/blob/76f9be1f9ff22cb5fd2bdbb599dec4d5477430c0/packages/dotcom-ui-bootstrap/src/server/getBootstrapJS.ts#L4)). However, when publishing this package, the current `package.json` doesn't include the `lib` directory as part of the published files so the code can't find it.