### PR TITLE
fix(dotcom-ui-header): add negative tab index to sticky subscribe button

### DIFF
--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
@@ -217,6 +217,7 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as a logged in use
             data-trackable="Subscribe"
             href="/products?segmentId=#"
             role="button"
+            tabIndex={-1}
           >
             Subscribe
           </a>

--- a/packages/dotcom-ui-header/src/components/sticky/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sticky/partials.tsx
@@ -131,7 +131,7 @@ const NavListRightLoggedInSticky = (props: THeaderProps) => {
       {!props.userIsSubscribed && subscribeAction && (
         <SubscribeButton
           item={subscribeAction}
-          variant={props.variant}
+          variant="sticky"
           className="o-header__top-button--hide-m"
         />
       )}


### PR DESCRIPTION
When navigating through the navigation elements via the keyboard, the hidden sticky nav’s “subscribe“ button is in the tab index. This will element will be read highlighted to a user using assistive technologies which can cause a confusing experience.