### PR TITLE
feat: drop support for Node.js 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,14 +176,14 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
       - deploy:
           filters:
             <<: *filters_only_main
@@ -202,14 +202,14 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
 
   build-test-publish:
     jobs:
@@ -219,7 +219,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
       - test:
           filters:
             <<: *filters_release_build
@@ -228,7 +228,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
       - publish:
           context: npm-publish-token
           filters:
@@ -244,7 +244,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
       - test:
           filters:
             <<: *filters_prerelease_build
@@ -253,7 +253,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
       - prepublish:
           context: npm-publish-token
           filters:

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "typescript": "3.9.5"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "husky": {

--- a/packages/dotcom-build-base/package.json
+++ b/packages/dotcom-build-base/package.json
@@ -30,7 +30,7 @@
     "webpack": "^4.39.2"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": ["dist/", "src/"],

--- a/packages/dotcom-build-code-splitting/package.json
+++ b/packages/dotcom-build-code-splitting/package.json
@@ -32,7 +32,7 @@
     "check-engine": "^1.10.1"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": ["dist/", "src/"],

--- a/packages/dotcom-build-images/package.json
+++ b/packages/dotcom-build-images/package.json
@@ -29,7 +29,7 @@
     "check-engine": "^1.10.1"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": ["dist/", "src/"],

--- a/packages/dotcom-build-js/package.json
+++ b/packages/dotcom-build-js/package.json
@@ -36,7 +36,7 @@
     "check-engine": "^1.10.1"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": ["dist/", "src/"],

--- a/packages/dotcom-build-sass/package.json
+++ b/packages/dotcom-build-sass/package.json
@@ -36,7 +36,7 @@
     "check-engine": "^1.10.1"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": ["dist/", "src/"],

--- a/packages/dotcom-middleware-app-context/package.json
+++ b/packages/dotcom-middleware-app-context/package.json
@@ -27,7 +27,7 @@
     "@financial-times/dotcom-server-app-context": "file:../dotcom-server-app-context"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": ["dist/", "src/"],

--- a/packages/dotcom-middleware-asset-loader/package.json
+++ b/packages/dotcom-middleware-asset-loader/package.json
@@ -28,7 +28,7 @@
     "node-mocks-http": "^1.7.3"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": ["dist/", "src/"],

--- a/packages/dotcom-middleware-navigation/package.json
+++ b/packages/dotcom-middleware-navigation/package.json
@@ -26,7 +26,7 @@
     "node-mocks-http": "^1.7.3"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": ["dist/", "src/"],

--- a/packages/dotcom-server-app-context/package.json
+++ b/packages/dotcom-server-app-context/package.json
@@ -26,7 +26,7 @@
     "json-schema-to-markdown": "^1.1.0"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": ["dist/", "src/"],

--- a/packages/dotcom-server-asset-loader/package.json
+++ b/packages/dotcom-server-asset-loader/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": ["dist/", "src/"],

--- a/packages/dotcom-server-handlebars/package.json
+++ b/packages/dotcom-server-handlebars/package.json
@@ -27,7 +27,7 @@
     "react-dom": "^16.12.0"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": ["dist/", "src/"],

--- a/packages/dotcom-server-navigation/package.json
+++ b/packages/dotcom-server-navigation/package.json
@@ -31,7 +31,7 @@
     "nock": "^12.0.0"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": ["dist/", "src/"],

--- a/packages/dotcom-server-react-jsx/package.json
+++ b/packages/dotcom-server-react-jsx/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^16.8.6"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": ["dist/", "src/"],

--- a/packages/dotcom-types-navigation/package.json
+++ b/packages/dotcom-types-navigation/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": [

--- a/packages/dotcom-ui-app-context/package.json
+++ b/packages/dotcom-ui-app-context/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": [

--- a/packages/dotcom-ui-base-styles/package.json
+++ b/packages/dotcom-ui-base-styles/package.json
@@ -35,7 +35,7 @@
     "@financial-times/o-typography": "^7.2.0"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": [

--- a/packages/dotcom-ui-bootstrap/package.json
+++ b/packages/dotcom-ui-bootstrap/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "dependencies": {

--- a/packages/dotcom-ui-data-embed/package.json
+++ b/packages/dotcom-ui-data-embed/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "peerDependencies": {

--- a/packages/dotcom-ui-flags/package.json
+++ b/packages/dotcom-ui-flags/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "dependencies": {

--- a/packages/dotcom-ui-footer/package.json
+++ b/packages/dotcom-ui-footer/package.json
@@ -28,7 +28,7 @@
     "@financial-times/o-footer": "^9.2.0"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": [

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -40,7 +40,7 @@
     "react": "16.x || 17.x"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": [

--- a/packages/dotcom-ui-layout/package.json
+++ b/packages/dotcom-ui-layout/package.json
@@ -33,7 +33,7 @@
     "react": "16.x || 17.x"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": [

--- a/packages/dotcom-ui-polyfill-service/package.json
+++ b/packages/dotcom-ui-polyfill-service/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": [

--- a/packages/dotcom-ui-shell/package.json
+++ b/packages/dotcom-ui-shell/package.json
@@ -31,7 +31,7 @@
     "react": "16.x || 17.x"
   },
   "engines": {
-    "node": ">= 14.0.0",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "files": [


### PR DESCRIPTION
To be merged as part of breaking changes releases on week of 17th April

update engines field to only support Node.js 16 for now, using the agreed engines specification format - https://docs.google.com/document/d/1i1on1ZiFwQITlTDsbaQO_uOtugDxeV5bmAVaSVXe_Mo/edit#

update circle CI config to only build on Node.js 16
