### PR TITLE
Eles 800 adjust alignment and padding of flyout menu toms tweak

### DIFF
--- a/packages/dotcom-ui-header/src/enhanced-search/customList.js
+++ b/packages/dotcom-ui-header/src/enhanced-search/customList.js
@@ -107,7 +107,7 @@ class CustomSuggestionList extends BaseRenderer {
             : ''
         }
         <div
-          class="n-topic-search n-topic-search__suggestions"
+          class="n-topic-search n-topic-search__suggestions enhanced-search enhanced-search__suggestions"
           data-trackable="typeahead"
         >
           <div class="enhanced-search__wrapper">

--- a/packages/dotcom-ui-header/src/enhanced-search/styles.scss
+++ b/packages/dotcom-ui-header/src/enhanced-search/styles.scss
@@ -4,6 +4,11 @@
 
 @mixin enhancedSearch {
   .enhanced-search {
+    &__suggestions {
+      max-width: 540px;
+      left: - spacing.oSpacingByName('s3');
+    }
+
     &__wrapper {
       display: flex;
       flex-direction: column;
@@ -20,7 +25,7 @@
     &__suggestions {
       display: flex;
       gap: spacing.oSpacingByName('m16');
-      padding-top: spacing.oSpacingByName('s6');
+      padding-top: spacing.oSpacingByName('s4');
       flex-direction: column;
 
       @include oGridRespondTo('L') {


### PR DESCRIPTION
In this PR I have updated the UI for the enhanced-search-flyout by updating max-width, and paddings
## Ticket
[JIRA ELES-800](https://financialtimes.atlassian.net/browse/ELES-800)

## Design
[figma](https://www.figma.com/file/Hjz28uiQqs8pxUm6X7fCG5/FT.com_Search_Test?type=design&node-id=1652-1663&mode=design&t=rLW08eQlkduo7XPI-4)

## Screeshots

| Before    | After |
| -------- | ------- |
|  <img width="1169" alt="Screenshot 2023-09-07 at 5 25 19 PM" src="https://github.com/Financial-Times/dotcom-page-kit/assets/139355573/6201bf85-b1d0-41bc-9a67-a0aefbf1cfbf">|<img width="1169" alt="Screenshot 2023-09-07 at 5 24 52 PM" src="https://github.com/Financial-Times/dotcom-page-kit/assets/139355573/91d8c61e-e191-4caf-9cf5-5ae12190b061"> |
