### PR TITLE
CPREL-711: Remove default metadata description because it causes errors in Semrush

### DIFF
--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -29,10 +29,6 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
       Foo | Financial Times
     </title>
     <meta
-      content="News, analysis and comment from the Financial Times, the worldʼs leading global business publication"
-      name="description"
-    />
-    <meta
       content="index,follow,max-snippet:200,max-image-preview:large"
       name="robots"
     />

--- a/packages/dotcom-ui-shell/src/components/DocumentHead.tsx
+++ b/packages/dotcom-ui-shell/src/components/DocumentHead.tsx
@@ -45,7 +45,7 @@ const DocumentHead = (props: TDocumentHeadProps) => (
     <OpenGraph openGraph={props.openGraph} />
 
     {/* native apps */}
-    {props.showSmartBanner && 
+    {props.showSmartBanner &&
       (
         <meta
           name="apple-itunes-app"
@@ -86,8 +86,6 @@ const DocumentHead = (props: TDocumentHeadProps) => (
 )
 
 DocumentHead.defaultProps = {
-  description:
-    'News, analysis and comment from the Financial Times, the worldʼs leading global business publication',
   facebookPage: '8860325749',
   googleSiteVerification: '4-t8sFaPvpO5FH_Gnw1dkM28CQepjzo8UjjAkdDflTw',
   metaTags: [],


### PR DESCRIPTION
From Semrush: "Duplicate meta descriptions on different pages mean a lost opportunity to use more relevant keywords. Also, duplicate meta descriptions make it difficult for search engines and users to differentiate between different webpages. It is better to have no meta description at all than to have a duplicate one."

https://developers.google.com/search/docs/appearance/title-link?visit_id=638302770161667479-4233470687&rd=1