### PR TITLE
fix: link myFt & FT logo to navigation Options

### DIFF
--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -54,7 +54,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
           <a
             className="o-header__top-logo"
             data-trackable="logo"
-            href="/"
+            href="#"
             style={
               Object {
                 "backgroundImage": "none",
@@ -1897,7 +1897,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
           <a
             className="o-header__top-logo"
             data-trackable="logo"
-            href="/"
+            href="#"
             style={
               Object {
                 "backgroundImage": "none",
@@ -3745,7 +3745,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
           <a
             className="o-header__top-logo"
             data-trackable="logo"
-            href="/"
+            href="#"
             style={
               Object {
                 "backgroundImage": "none",

--- a/packages/dotcom-ui-header/src/components/sticky/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sticky/partials.tsx
@@ -4,6 +4,7 @@
 import React from 'react'
 import { SubscribeButton, SignInLink } from '../top/partials'
 import { THeaderProps } from '../../interfaces'
+import { TNavMenuItem } from '@financial-times/dotcom-types-navigation'
 
 const StickyHeaderWrapper = (props: THeaderProps & { children: React.ReactNode }) => (
   <header
@@ -88,16 +89,19 @@ const NavListRightAnonSticky = (props: THeaderProps) => {
   )
 }
 
-const MyFtSticky = ({ className }: { className?: string }) => (
-  <a
-    className={`o-header__top-icon-link o-header__top-icon-link--myft ${className}`}
-    href="/myft"
-    data-trackable="my-ft"
-    tabIndex={-1}
-  >
-    <span className="o-header__visually-hidden">myFT</span>
-  </a>
-)
+const MyFtSticky = ({ className, items }: { className?: string; items?: TNavMenuItem[] }) => {
+  const ftUrl = items?.find((el) => el.label === 'myFT')?.url
+  return (
+    <a
+      className={`o-header__top-icon-link o-header__top-icon-link--myft ${className}`}
+      href={ftUrl ?? '/myft'}
+      data-trackable="my-ft"
+      tabIndex={-1}
+    >
+      <span className="o-header__visually-hidden">myFT</span>
+    </a>
+  )
+}
 
 const TopWrapperSticky = (props) => (
   <div className="o-header__row o-header__top" data-trackable="header-sticky">
@@ -129,13 +133,9 @@ const NavListRightLoggedInSticky = (props: THeaderProps) => {
   return (
     <React.Fragment>
       {!props.userIsSubscribed && subscribeAction && (
-        <SubscribeButton
-          item={subscribeAction}
-          variant="sticky"
-          className="o-header__top-button--hide-m"
-        />
+        <SubscribeButton item={subscribeAction} variant="sticky" className="o-header__top-button--hide-m" />
       )}
-      <MyFtSticky className="" />
+      <MyFtSticky className="" items={props.data.account?.items} />
     </React.Fragment>
   )
 }

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -39,18 +39,21 @@ const SearchIcon = () => (
   </a>
 )
 
-const MyFt = ({ className }: { className?: string }) => (
-  <a
-    className={`o-header__top-icon-link o-header__top-icon-link--myft ${className}`}
-    id="o-header-top-link-myft"
-    href="/myft"
-    data-trackable="my-ft"
-    data-tour-stage="myFt"
-    aria-label="My F T"
-  >
-    <span className="o-header__visually-hidden">myFT</span>
-  </a>
-)
+const MyFt = ({ className, items }: { className?: string; items?: TNavMenuItem[] }) => {
+  const ftUrl = items?.find((el) => el.label === 'myFT')?.url
+  return (
+    <a
+      className={`o-header__top-icon-link o-header__top-icon-link--myft ${className}`}
+      id="o-header-top-link-myft"
+      href={ftUrl ?? '/myft'}
+      data-trackable="my-ft"
+      data-tour-stage="myFt"
+      aria-label="My F T"
+    >
+      <span className="o-header__visually-hidden">myFT</span>
+    </a>
+  )
+}
 
 const TopWrapper = (props) => (
   <div className="o-header__row o-header__top" data-trackable="header-top">
@@ -67,13 +70,13 @@ const TopColumnLeft = () => (
   </div>
 )
 
-const TopColumnCenter = () => (
+const TopColumnCenter = ({ url }: { url?: string }) => (
   <div className="o-header__top-column o-header__top-column--center">
     <a
       className="o-header__top-logo"
       style={{ backgroundImage: 'none' }}
       data-trackable="logo"
-      href="/"
+      href={url ?? '/'}
       title="Go to Financial Times homepage"
     >
       <BrandFtMastheadSvg title="Financial Times" />
@@ -100,7 +103,7 @@ const TopColumnRightLoggedIn = (props: THeaderProps) => {
           className="o-header__top-button--hide-m"
         />
       )}
-      <MyFt className="" />
+      <MyFt className="" items={props.data?.account?.items} />
     </div>
   )
 }
@@ -162,7 +165,7 @@ const TopColumnRightAnon = ({ items, variant }: { items: TNavMenuItem[]; variant
       {signInAction && (
         <SignInLink item={signInAction} variant={variant} className="o-header__top-link--hide-m" />
       )}
-      <MyFt className="o-header__top-icon-link--show-m" />
+      <MyFt className="o-header__top-icon-link--show-m" items={items} />
     </div>
   )
 }
@@ -172,7 +175,8 @@ const TopColumnRight = (props: THeaderProps) => {
     return <TopColumnRightLoggedIn {...props} />
   } else {
     const userNavAnonItems = props.data['navbar-right-anon'].items
-    return <TopColumnRightAnon items={userNavAnonItems} variant={props.variant} />
+    const userNavAccountItems = props.data.account?.items ?? []
+    return <TopColumnRightAnon items={userNavAnonItems.concat(userNavAccountItems)} variant={props.variant} />
   }
 }
 

--- a/packages/dotcom-ui-header/src/index.tsx
+++ b/packages/dotcom-ui-header/src/index.tsx
@@ -45,7 +45,11 @@ function MainHeader(props: THeaderProps) {
       {includeUserActionsNav ? <UserActionsNav {...props} /> : null}
       <TopWrapper>
         <TopColumnLeft />
-        {props.showLogoLink ? <TopColumnCenter /> : <TopColumnCenterNoLink />}
+        {props.showLogoLink ? (
+          <TopColumnCenter url={props.data.editions.current.url} />
+        ) : (
+          <TopColumnCenterNoLink />
+        )}
         <TopColumnRight {...props} />
       </TopWrapper>
 
@@ -112,7 +116,13 @@ function NoOutboundLinksHeader(props: THeaderProps) {
   return (
     <HeaderWrapper {...props}>
       {includeUserActionsNav ? <UserActionsNav {...props} /> : null}
-      <TopWrapper>{props.showLogoLink ? <TopColumnCenter /> : <TopColumnCenterNoLink />}</TopWrapper>
+      <TopWrapper>
+        {props.showLogoLink ? (
+          <TopColumnCenter url={props.data.editions.current.url} />
+        ) : (
+          <TopColumnCenterNoLink />
+        )}
+      </TopWrapper>
       <NavDesktop>{props.showUserNavigation ? <NavListRight {...props} /> : null}</NavDesktop>
       {includeSubNavigation ? <SubNavigation {...props} /> : null}
     </HeaderWrapper>


### PR DESCRIPTION
In this PR I have fixed the myft and Logo links as they were not linked to the navigation props (myFt link is linked to the accounts myFt link, and the logo is linked to the editions.current.url)
