### PR TITLE
fix: address latest QA findings

### DIFF
--- a/packages/dotcom-ui-header/browser.js
+++ b/packages/dotcom-ui-header/browser.js
@@ -24,6 +24,11 @@ export const init = (headerOptions = {}) => {
   })
 
   Header.init(headerOptions.rootElement, { searchState: headerOptions.searchState })
+
+  if (headerOptions.searchState === 'open') {
+    // Hide the sticky heder
+    document.querySelector('#o-header-search-sticky')?.setAttribute('aria-hidden', 'true')
+  }
 }
 
 export { Header as OrigamiHeader }

--- a/packages/dotcom-ui-header/src/enhanced-search/customList.js
+++ b/packages/dotcom-ui-header/src/enhanced-search/customList.js
@@ -68,7 +68,7 @@ class CustomSuggestionList extends BaseRenderer {
       data-o-component="o-message">
       <div class="o-message__container">
         <div class="o-message__content">
-          <p class="o-message__content-main">Something went wrong!</p>
+          <p class="o-message__content-main">Failed to load topics and securities results</p>
         </div>
       </div>
     </div>
@@ -135,7 +135,9 @@ class CustomSuggestionList extends BaseRenderer {
         >
           <div class="enhanced-search__wrapper">
             <h3 class="enhanced-search__title">${
-              term ? 'Get top results for...' : 'Search tip: Try using questions or phrases like...'
+              term
+                ? 'Get top results for...'
+                : 'Search tip: <span class="enhanced-search__title-no-bold">Try using questions or phrases like...</span>'
             }</h3>
             ${term ? this.renderSuggestionChip(term) : this.renderDefaultSuggestionsChips()}
             <div class="o-normalise-visually-hidden">Suggestions include</div>

--- a/packages/dotcom-ui-header/src/enhanced-search/enhancedSearch.js
+++ b/packages/dotcom-ui-header/src/enhanced-search/enhancedSearch.js
@@ -12,6 +12,8 @@ class EnhancedSearch extends TopicSearch {
           searchTerm: this.searchEl.value,
           suggestions: {}
         })
+        // const detail = { category: 'search', action: `Error: ${error.message}` }
+        // document.body.dispatchEvent(new CustomEvent('flyout-load-topics-error', { detail, bubbles: true }))
       }
     })
 

--- a/packages/dotcom-ui-header/src/enhanced-search/styles.scss
+++ b/packages/dotcom-ui-header/src/enhanced-search/styles.scss
@@ -25,6 +25,10 @@
       margin: 0 0 spacing.oSpacingByName('s3') 0;
     }
 
+    &__title-no-bold {
+      @include typography.oTypographySans($scale: 0, $style: 'normal', $weight: 'regular');
+    }
+
     &__margin-top {
       margin-top: spacing.oSpacingByName('s4');
     }


### PR DESCRIPTION
In this PR I have addressed some of the latest QA findings [here](https://financialtimes.enterprise.slack.com/files/U04B8H5442F/F05TE3GJNDT/21_sep_enhanced_search_qa_session.pdf?origin_team=T025C95MN&origin_channel=Vall_threads)

1. "Tip text shouldn’t be bold, the text after “Search tip: ...”, as per designs"
![Screenshot 2023-09-22 at 1 52 55 PM](https://github.com/Financial-Times/dotcom-page-kit/assets/139355573/46b4e6ca-1ad8-4116-82c7-f306f2a72ddb)

2. "Error message should read “failed to load topics and securities results” (The styles will be applied normally in other repos)"
![Screenshot 2023-09-22 at 1 56 18 PM](https://github.com/Financial-Times/dotcom-page-kit/assets/139355573/c9913ea8-2a31-46ef-abaa-59725081552e)

3. "Topics column is still taking up space when empty"
![Screenshot 2023-09-22 at 1 54 42 PM](https://github.com/Financial-Times/dotcom-page-kit/assets/139355573/5d8d6a90-2f7d-4fde-9240-a8b436e83d90)

4. "Can we add tracking to errors?" (Firing a custom event 'flyout-load-topics-error') when error happens
5. "Don’t show search bar on sticky header" I have set the aria-hidden property to "true" for sticky header to hide it

