### PR TITLE
include o-loading, o-message into styles

### DIFF
--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -28,15 +28,16 @@
   },
   "devDependencies": {
     "@financial-times/logo-images": "^1.10.1",
+    "@financial-times/o-header": "^11.1.0",
     "@svgr/core": "^5.0.0",
     "camelcase": "^6.0.0",
     "check-engine": "^1.10.1",
-    "@financial-times/o-header": "^11.1.0",
     "react": "^16.8.6"
   },
   "peerDependencies": {
-    "@financial-times/o-header": "^11.1.0",
     "@financial-times/logo-images": "^1.10.1",
+    "@financial-times/o-header": "^11.1.0",
+    "@financial-times/o-message": "^5.4.3",
     "react": "16.x || 17.x"
   },
   "engines": {

--- a/packages/dotcom-ui-header/styles.scss
+++ b/packages/dotcom-ui-header/styles.scss
@@ -1,7 +1,6 @@
 // This will be overridden by dotcom-ui-layout, it's necessary here for storybook builds
 $system-code: 'page-kit-header' !default;
 
-
 @import 'n-ui-foundations/mixins';
 
 // We don't need the sub-brand or transparent header styles so disable them.
@@ -16,3 +15,9 @@ $system-code: 'page-kit-header' !default;
 
 @import './src/enhanced-search/styles';
 @include enhancedSearch;
+
+@import '@financial-times/o-loading/main';
+@include oLoading();
+
+@import '@financial-times/o-message/main';
+@include oMessage();

--- a/packages/dotcom-ui-layout/package.json
+++ b/packages/dotcom-ui-layout/package.json
@@ -30,7 +30,9 @@
     "n-ui-foundations": "^9.0.0"
   },
   "peerDependencies": {
-    "react": "16.x || 17.x"
+    "react": "16.x || 17.x",
+    "@financial-times/o-message": "^5.4.3",
+    "@financial-times/o-loading": "^5.2.2"
   },
   "engines": {
     "node": "16.x || 18.x",


### PR DESCRIPTION
In this PR I have added o-loading, o-message to the styles and peer-dependencies so we don't have to add it to all the other repos

![Screenshot 2023-09-25 at 6 45 22 PM](https://github.com/Financial-Times/dotcom-page-kit/assets/139355573/c353711f-87f2-48cb-a670-65fefde8838d)
![Screenshot 2023-09-25 at 6 45 40 PM](https://github.com/Financial-Times/dotcom-page-kit/assets/139355573/ef7ba4d1-9fb2-4be1-b142-106e845805ec)
