### PR TITLE
Update n topic search key event fix

### DIFF
--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
-    "n-topic-search": "^4.0.0",
+    "n-topic-search": "^6.1.0",
     "n-ui-foundations": "^9.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates the n-topic-search package to v6.1.0.

4.0.0 to 6.0.0 only updates n-topic-search's node version to 18, and updates n-express to 27.4.0.

6.1.0 makes a slight improvement to the search dropdown component, to prevent unnecessary requests to the API that provides the topics and securities data.

[See the commit log between 4.0.0 and 6.1.0 for more information](https://github.com/Financial-Times/n-topic-search/compare/v4.0.0...v6.1.0).