### PR TITLE
WIP Dont Merge - Adsdev 1491

### DIFF
--- a/packages/dotcom-ui-footer/browser.js
+++ b/packages/dotcom-ui-footer/browser.js
@@ -1,4 +1,9 @@
 import Footer from '@financial-times/o-footer'
+import * as flags from '@financial-times/dotcom-ui-flags'
+import { updateFooterLinkCMP } from '@financial-times/privacy-utils'
+
+const flagsClient = flags.init()
+
 
 /**
  * @typedef FooterOptions
@@ -11,6 +16,10 @@ import Footer from '@financial-times/o-footer'
  */
 export const init = (footerOptions = {}) => {
   Footer.init(footerOptions.rootElement)
+
+  if (flagsClient.get('adsDisableInternalCMP')) {
+    updateFooterLinkCMP();
+   }
 }
 
 export { Footer as OrigamiFooter }

--- a/packages/dotcom-ui-footer/package.json
+++ b/packages/dotcom-ui-footer/package.json
@@ -25,7 +25,8 @@
   },
   "peerDependencies": {
     "react": "16.x || 17.x",
-    "@financial-times/o-footer": "^9.2.0"
+    "@financial-times/o-footer": "^9.2.0",
+    "@financial-times/privacy-utils": "1.1.1"
   },
   "engines": {
     "node": "16.x || 18.x",


### PR DESCRIPTION
This PR relates to the CMP (Consent Management Platform) integration.
We are integrating with a CMP vendor named Sourcepoint and one of the requirements is that our 'Manage Cookies' links will open the CMP popup modal where a user can manage their consent choiices.

It has been decided that we should put this functionality behind a feature-flag (`adsDisableInternalCMP`). 

This PR updates the client-side portion of the `dotcom-ui-footer` package to do the following:
 * import the `dotcom-ui-flags` package so that we can make use of feature flags 
 * imports a single function from the new `privacy-utils` package which runs client-side and updates the `Manage Cookies` link element, adding an onclick handler which calls the CMP function for loading the Consent Popup Modal.
   