### PR TITLE
Support n-ui-foundations v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34459,8 +34459,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "focus-visible": "^5.0.0",
-        "n-ui-foundations": "^9.0.0"
+        "focus-visible": "^5.0.0"
       },
       "devDependencies": {
         "@financial-times/o-typography": "^7.2.0",
@@ -34472,6 +34471,7 @@
       },
       "peerDependencies": {
         "@financial-times/o-typography": "^7.2.0",
+        "n-ui-foundations": "^9.0.0 || ^10.0.0",
         "react": "17.x || 18.x"
       }
     },
@@ -34616,8 +34616,7 @@
       "license": "MIT",
       "dependencies": {
         "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
-        "n-topic-search": "^4.0.0",
-        "n-ui-foundations": "^9.0.0"
+        "n-topic-search": "^4.0.0"
       },
       "devDependencies": {
         "@financial-times/logo-images": "^1.10.1",
@@ -34633,6 +34632,7 @@
       "peerDependencies": {
         "@financial-times/logo-images": "^1.10.1",
         "@financial-times/o-header": "^11.0.4",
+        "n-ui-foundations": "^9.0.0 || ^10.0.0",
         "react": "17.x || 18.x",
         "react-dom": "17.x || 18.x"
       }
@@ -34659,8 +34659,7 @@
         "@financial-times/dotcom-ui-base-styles": "file:../dotcom-ui-base-styles",
         "@financial-times/dotcom-ui-footer": "file:../dotcom-ui-footer",
         "@financial-times/dotcom-ui-header": "file:../dotcom-ui-header",
-        "focus-visible": "^5.0.0",
-        "n-ui-foundations": "^9.0.0"
+        "focus-visible": "^5.0.0"
       },
       "devDependencies": {
         "check-engine": "^1.10.1"
@@ -34670,6 +34669,7 @@
         "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
+        "n-ui-foundations": "^9.0.0 || ^10.0.0",
         "react": "17.x || 18.x",
         "react-dom": "17.x || 18.x"
       }

--- a/packages/dotcom-ui-base-styles/package.json
+++ b/packages/dotcom-ui-base-styles/package.json
@@ -22,8 +22,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "focus-visible": "^5.0.0",
-    "n-ui-foundations": "^9.0.0"
+    "focus-visible": "^5.0.0"
   },
   "devDependencies": {
     "check-engine": "^1.10.1",
@@ -31,7 +30,8 @@
   },
   "peerDependencies": {
     "react": "17.x || 18.x",
-    "@financial-times/o-typography": "^7.2.0"
+    "@financial-times/o-typography": "^7.2.0",
+    "n-ui-foundations": "^9.0.0 || ^10.0.0"
   },
   "engines": {
     "node": "16.x || 18.x",

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -23,8 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
-    "n-topic-search": "^4.0.0",
-    "n-ui-foundations": "^9.0.0"
+    "n-topic-search": "^4.0.0"
   },
   "devDependencies": {
     "@financial-times/logo-images": "^1.10.1",
@@ -37,7 +36,8 @@
     "@financial-times/o-header": "^11.0.4",
     "@financial-times/logo-images": "^1.10.1",
     "react": "17.x || 18.x",
-    "react-dom": "17.x || 18.x"
+    "react-dom": "17.x || 18.x",
+    "n-ui-foundations": "^9.0.0 || ^10.0.0"
   },
   "engines": {
     "node": "16.x || 18.x",

--- a/packages/dotcom-ui-layout/package.json
+++ b/packages/dotcom-ui-layout/package.json
@@ -26,12 +26,12 @@
     "@financial-times/dotcom-ui-base-styles": "file:../dotcom-ui-base-styles",
     "@financial-times/dotcom-ui-footer": "file:../dotcom-ui-footer",
     "@financial-times/dotcom-ui-header": "file:../dotcom-ui-header",
-    "focus-visible": "^5.0.0",
-    "n-ui-foundations": "^9.0.0"
+    "focus-visible": "^5.0.0"
   },
   "peerDependencies": {
     "react": "17.x || 18.x",
-    "react-dom": "17.x || 18.x"
+    "react-dom": "17.x || 18.x",
+    "n-ui-foundations": "^9.0.0 || ^10.0.0"
   },
   "engines": {
     "node": "16.x || 18.x",


### PR DESCRIPTION
A small PR to update to n-ui-foundations-v10.

This allows this module to be used with either v9 or v10 of this library.