### PR TITLE
Strict type checking for dotcom-server-navigation & dotcom-ui-layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8193,9 +8193,9 @@
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.8.tgz",
-      "integrity": "sha512-nnH5lV9QCMPsbEVdTb5Y+F3GQxLSw1xQgIydrb2gSfEavRPs50FnMr+KUaa+LoPSqibm2N+ZZxH7lavZlAT4GA==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -34375,6 +34375,7 @@
       "devDependencies": {
         "@types/ft-poller": "^3.0.4",
         "@types/http-errors": "^2.0.4",
+        "@types/node-fetch": "^2.6.9",
         "check-engine": "^1.10.1",
         "dlv": "^1.1.2",
         "nock": "^12.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8057,6 +8057,12 @@
         "@types/range-parser": "*"
       }
     },
+    "node_modules/@types/ft-poller": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ft-poller/-/ft-poller-3.0.4.tgz",
+      "integrity": "sha512-cdhrCiM2AfReBydFkShheZhbY2GI52wnZxTLBXy12k55bjoHAki425aFJvl1erNCIzSb2hAx136Fhekb9e2m1A==",
+      "dev": true
+    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -34367,6 +34373,7 @@
         "node-fetch": "^2.2.1"
       },
       "devDependencies": {
+        "@types/ft-poller": "^3.0.4",
         "check-engine": "^1.10.1",
         "dlv": "^1.1.2",
         "nock": "^12.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8097,9 +8097,9 @@
       "dev": true
     },
     "node_modules/@types/http-errors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.3.tgz",
-      "integrity": "sha512-pP0P/9BnCj1OVvQR2lF41EkDG/lWWnDyA203b/4Fmi2eTyORnBtcDoKDwjWQthELrBvWkMOrvSOnZ8OVlW6tXA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "dev": true
     },
     "node_modules/@types/is-function": {
@@ -34374,6 +34374,7 @@
       },
       "devDependencies": {
         "@types/ft-poller": "^3.0.4",
+        "@types/http-errors": "^2.0.4",
         "check-engine": "^1.10.1",
         "dlv": "^1.1.2",
         "nock": "^12.0.0"

--- a/packages/dotcom-server-navigation/package.json
+++ b/packages/dotcom-server-navigation/package.json
@@ -28,9 +28,15 @@
   "devDependencies": {
     "@types/ft-poller": "^3.0.4",
     "@types/http-errors": "^2.0.4",
+    "@types/node-fetch": "^2.6.9",
     "check-engine": "^1.10.1",
     "dlv": "^1.1.2",
     "nock": "^12.0.0"
+  },
+  "peerDependencies": {
+    "@types/ft-poller": "^3.0.4",
+    "@types/http-errors": "^2.0.4",
+    "@types/node-fetch": "^2.6.9"
   },
   "engines": {
     "node": "16.x || 18.x",

--- a/packages/dotcom-server-navigation/package.json
+++ b/packages/dotcom-server-navigation/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@types/ft-poller": "^3.0.4",
+    "@types/http-errors": "^2.0.4",
     "check-engine": "^1.10.1",
     "dlv": "^1.1.2",
     "nock": "^12.0.0"

--- a/packages/dotcom-server-navigation/package.json
+++ b/packages/dotcom-server-navigation/package.json
@@ -26,6 +26,7 @@
     "node-fetch": "^2.2.1"
   },
   "devDependencies": {
+    "@types/ft-poller": "^3.0.4",
     "check-engine": "^1.10.1",
     "dlv": "^1.1.2",
     "nock": "^12.0.0"

--- a/packages/dotcom-server-navigation/src/decorateMenuData.ts
+++ b/packages/dotcom-server-navigation/src/decorateMenuData.ts
@@ -1,6 +1,6 @@
 import { TNavMenuItem } from '@financial-times/dotcom-types-navigation'
 
-const isSelected = (url: string, currentPath: string): boolean => {
+const isSelected = (url: string | null, currentPath: string): boolean => {
   return url === currentPath
 }
 
@@ -8,7 +8,7 @@ const isMenuItem = (item: any): boolean => {
   return item.hasOwnProperty('label') && item.hasOwnProperty('url')
 }
 
-const decorateURL = (url: string, currentPath: string): string => {
+const decorateURL = (url: string | null, currentPath: string): string | null => {
   if (url && url.includes('${currentPath}')) {
     // Don't replace the URL placeholder with a barrier or error URL so that
     // a user logging in is not redirected to a barrier or error!
@@ -32,7 +32,7 @@ function cloneMenu(value: any, currentPath: string): any {
   }
 
   if (Object(value) === value) {
-    const cloned = {}
+    const cloned: Record<string, any> = {}
 
     for (const key of Object.keys(value)) {
       cloned[key] = cloneMenu(value[key], currentPath)

--- a/packages/dotcom-server-navigation/src/navigation.ts
+++ b/packages/dotcom-server-navigation/src/navigation.ts
@@ -38,19 +38,18 @@ const defaults: TNavOptions = {
 
 export class Navigation {
   public options: TNavOptions
-  public poller: Poller
+  public poller: Poller<any, any>
   public initialPromise: Promise<void>
   private menuData: TNavMenus
 
   constructor(options: TNavOptions = {}) {
     this.options = { ...defaults, ...options }
-
+    this.menuData = {} as TNavMenus
     this.poller = new Poller({
-      url: this.options.menuUrl,
+      url: this.options.menuUrl ?? '',
       refreshInterval: this.options.interval,
       parseData
     })
-
     this.initialPromise = this.poller.start({ initialRequest: true })
   }
 
@@ -61,7 +60,6 @@ export class Navigation {
     this.menuData = this.poller.getData()
 
     return this.menuData
-
   }
 
   async getMenusFor(currentPath: string, currentEdition: string = 'uk'): Promise<TNavMenusForEdition> {

--- a/packages/dotcom-server-navigation/src/selectMenuDataForEdition.ts
+++ b/packages/dotcom-server-navigation/src/selectMenuDataForEdition.ts
@@ -1,4 +1,9 @@
-import { TNavMenuKeys, TNavMenus, TNavMenusForEdition } from '@financial-times/dotcom-types-navigation'
+import {
+  TNavMenu,
+  TNavMenuKeys,
+  TNavMenus,
+  TNavMenusForEdition
+} from '@financial-times/dotcom-types-navigation'
 
 const sharedMenuKeys: TNavMenuKeys[] = [
   'account',
@@ -10,11 +15,13 @@ const sharedMenuKeys: TNavMenuKeys[] = [
   'user'
 ]
 
+type SharedMenuKeys = (typeof sharedMenuKeys)[number]
+
 export function selectMenuDataForEdition(menuData: TNavMenus, currentEdition: string): TNavMenusForEdition {
   const output = {
-    navbar: menuData[`navbar-${currentEdition}`],
-    drawer: menuData[`drawer-${currentEdition}`]
-  }
+    navbar: menuData[`navbar-${currentEdition}` as TNavMenuKeys],
+    drawer: menuData[`drawer-${currentEdition}` as TNavMenuKeys]
+  } as { [K in SharedMenuKeys]?: TNavMenu }
 
   for (const key of sharedMenuKeys) {
     if (menuData[key]) {

--- a/packages/dotcom-server-navigation/tsconfig.json
+++ b/packages/dotcom-server-navigation/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "include": ["src/**/*"],
   "compilerOptions": {
+    "strict": true,
     "rootDir": "src",
     "outDir": "dist/node"
   }

--- a/packages/dotcom-types-navigation/index.d.ts
+++ b/packages/dotcom-types-navigation/index.d.ts
@@ -78,7 +78,7 @@ export type TNavSubNavigation = {
 }
 
 export type TNavEditions = {
-  current: TNavEdition
+  current?: TNavEdition
   others: TNavEdition[]
 }
 

--- a/packages/dotcom-ui-layout/src/components/Layout.tsx
+++ b/packages/dotcom-ui-layout/src/components/Layout.tsx
@@ -6,8 +6,10 @@ import {
   NoOutboundLinksHeader,
   Drawer,
   THeaderOptions
+  /* @ts-ignore -- importing with the correct types using TS strict checking requires more work */
 } from '@financial-times/dotcom-ui-header/component'
 import { TNavigationData } from '@financial-times/dotcom-types-navigation'
+/* @ts-ignore -- importing with the correct types using TS strict checking requires more work */
 import { Footer, LegalFooter, TFooterOptions } from '@financial-times/dotcom-ui-footer/component'
 import Template from './Template'
 
@@ -78,7 +80,8 @@ export function Layout({
       <a
         data-trackable="a11y-skip-to-help"
         className="n-layout__skip-link"
-        href="https://www.ft.com/accessibility">
+        href="https://www.ft.com/accessibility"
+      >
         Accessibility help
       </a>
 

--- a/packages/dotcom-ui-layout/tsconfig.json
+++ b/packages/dotcom-ui-layout/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "include": ["src/**/*"],
   "compilerOptions": {
+    "strict": true,
     "rootDir": "src",
     "outDir": "dist/node"
   }


### PR DESCRIPTION
## What does this change? 🔧

- Enable strict type checking for `dotcom-server-navigation` and `dotcom-ui-layout` as well as resolving follow-on type errors
- Installs required dev deps for the `dotcom-server-navigation` package and includes them as peer-deps so that projects depending on them know to use these as part of their type checking step

## Why are you making this change? 🔎

- We'd like to be able to carry out [strict type checking in `pro-central-banking`](https://github.com/Financial-Times/pro-central-banking/commit/d2763d40617e42f7b856c39cb309164ff12569ec) but are unable to due to type errors currently happening in these packages when we have `strict: true` enabled in our build step.
  - The `skipLibCheck` option doesn't do the trick for us here, because these are `.ts` files and this setting only covers `.d.ts` files

This PR should resolve the following problems that prevent our build from passing with `strict` enabled:

```
node_modules/@financial-times/dotcom-server-navigation/src/decorateMenuData.ts:24:26 - error TS2345: Argument of type 'string | null' is not assignable to parameter of type 'string'.
  Type 'null' is not assignable to type 'string'.

24   item.url = decorateURL(item.url, currentPath)
                            ~~~~~~~~

node_modules/@financial-times/dotcom-server-navigation/src/decorateMenuData.ts:38:7 - error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
  No index signature with a parameter of type 'string' was found on type '{}'.

38       cloned[key] = cloneMenu(value[key], currentPath)
         ~~~~~~~~~~~

node_modules/@financial-times/dotcom-server-navigation/src/editions.ts:24:5 - error TS2322: Type 'TNavEdition | undefined' is not assignable to type 'TNavEdition'.
  Type 'undefined' is not assignable to type 'TNavEdition'.

24     current: availableEditions.find((edition) => edition.id === currentEdition),
       ~~~~~~~

  node_modules/@financial-times/dotcom-types-navigation/index.d.ts:81:3
    81   current: TNavEdition
         ~~~~~~~
    The expected type comes from property 'current' which is declared here on type 'TNavEditions'

node_modules/@financial-times/dotcom-server-navigation/src/navigation.ts:1:20 - error TS7016: Could not find a declaration file for module 'ft-poller'. '/Users/oliver.barnwell/code/pro-central-banking/node_modules/ft-poller/src/server.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/ft-poller` if it exists or add a new declaration (.d.ts) file containing `declare module 'ft-poller';`

1 import Poller from 'ft-poller'
                     ~~~~~~~~~~~

node_modules/@financial-times/dotcom-server-navigation/src/navigation.ts:2:23 - error TS7016: Could not find a declaration file for module 'http-errors'. '/Users/oliver.barnwell/code/pro-central-banking/node_modules/@financial-times/dotcom-server-navigation/node_modules/http-errors/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/http-errors` if it exists or add a new declaration (.d.ts) file containing `declare module 'http-errors';`

2 import httpError from 'http-errors'
                        ~~~~~~~~~~~~~

node_modules/@financial-times/dotcom-server-navigation/src/navigation.ts:43:11 - error TS2564: Property 'menuData' has no initializer and is not definitely assigned in the constructor.

43   private menuData: TNavMenus
             ~~~~~~~~

node_modules/@financial-times/dotcom-server-navigation/src/selectMenuDataForEdition.ts:15:13 - error TS7053: Element implicitly has an 'any' type because expression of type '`navbar-${string}`' can't be used to index type 'TNavMenus'.

15     navbar: menuData[`navbar-${currentEdition}`],
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@financial-times/dotcom-server-navigation/src/selectMenuDataForEdition.ts:16:13 - error TS7053: Element implicitly has an 'any' type because expression of type '`drawer-${string}`' can't be used to index type 'TNavMenus'.

16     drawer: menuData[`drawer-${currentEdition}`]
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@financial-times/dotcom-server-navigation/src/selectMenuDataForEdition.ts:21:7 - error TS7053: Element implicitly has an 'any' type because expression of type 'TNavMenuKeys' can't be used to index type '{ navbar: any; drawer: any; }'.
  Property 'user' does not exist on type '{ navbar: any; drawer: any; }'.

21       output[key] = menuData[key]
         ~~~~~~~~~~~

node_modules/@financial-times/dotcom-ui-layout/src/components/Layout.tsx:9:8 - error TS7016: Could not find a declaration file for module '@financial-times/dotcom-ui-header/component'. '/Users/oliver.barnwell/code/pro-central-banking/node_modules/@financial-times/dotcom-ui-header/component.js' implicitly has an 'any' type.
  If the '@financial-times/dotcom-ui-header' package actually exposes this module, try adding a new declaration (.d.ts) file containing `declare module '@financial-times/dotcom-ui-header/component';`

9 } from '@financial-times/dotcom-ui-header/component'
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@financial-times/dotcom-ui-layout/src/components/Layout.tsx:11:53 - error TS7016: Could not find a declaration file for module '@financial-times/dotcom-ui-footer/component'. '/Users/oliver.barnwell/code/pro-central-banking/node_modules/@financial-times/dotcom-ui-footer/component.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/financial-times__dotcom-ui-footer` if it exists or add a new declaration (.d.ts) file containing `declare module '@financial-times/dotcom-ui-footer/component';`

11 import { Footer, LegalFooter, TFooterOptions } from '@financial-times/dotcom-ui-footer/component'
```