### PR TITLE
CPP-1802 Correctly point to declaration files instead of TypeScript source

### DIFF
--- a/packages/dotcom-build-base/package.json
+++ b/packages/dotcom-build-base/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "The Page Kit CLI",
   "main": "dist/node/index.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-build-code-splitting/package.json
+++ b/packages/dotcom-build-code-splitting/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/node/index.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-build-images/package.json
+++ b/packages/dotcom-build-images/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/node/index.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-build-js/package.json
+++ b/packages/dotcom-build-js/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/node/index.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-build-sass/package.json
+++ b/packages/dotcom-build-sass/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/node/index.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-middleware-app-context/package.json
+++ b/packages/dotcom-middleware-app-context/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/node/index.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-middleware-app-context/tsconfig.json
+++ b/packages/dotcom-middleware-app-context/tsconfig.json
@@ -4,5 +4,10 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist/node"
-  }
+  },
+  "references": [
+    {
+      "path": "../dotcom-server-app-context"
+    }
+  ]
 }

--- a/packages/dotcom-middleware-asset-loader/package.json
+++ b/packages/dotcom-middleware-asset-loader/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/node/index.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-middleware-asset-loader/tsconfig.json
+++ b/packages/dotcom-middleware-asset-loader/tsconfig.json
@@ -4,5 +4,10 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist/node"
-  }
+  },
+  "references": [
+    {
+      "path": "../dotcom-server-asset-loader"
+    }
+  ]
 }

--- a/packages/dotcom-middleware-navigation/package.json
+++ b/packages/dotcom-middleware-navigation/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/node/index.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-middleware-navigation/tsconfig.json
+++ b/packages/dotcom-middleware-navigation/tsconfig.json
@@ -4,5 +4,10 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist/node"
-  }
+  },
+  "references": [
+    {
+      "path": "../dotcom-server-navigation"
+    }
+  ]
 }

--- a/packages/dotcom-server-app-context/package.json
+++ b/packages/dotcom-server-app-context/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/node/index.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "generate-schema": "node scripts/schemaToMarkdown.js > schema.md",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/dotcom-server-asset-loader/package.json
+++ b/packages/dotcom-server-asset-loader/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/node/index.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-server-handlebars/package.json
+++ b/packages/dotcom-server-handlebars/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/node/index.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-server-navigation/package.json
+++ b/packages/dotcom-server-navigation/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/node/index.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-server-react-jsx/package.json
+++ b/packages/dotcom-server-react-jsx/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "main": "dist/node/index.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-ui-app-context/package.json
+++ b/packages/dotcom-ui-app-context/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "component.js",
   "browser": "browser.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-ui-base-styles/package.json
+++ b/packages/dotcom-ui-base-styles/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "component.js",
   "browser": "browser.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "styles": "styles.scss",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/dotcom-ui-bootstrap/package.json
+++ b/packages/dotcom-ui-bootstrap/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "component.js",
   "browser": "browser.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-ui-data-embed/package.json
+++ b/packages/dotcom-ui-data-embed/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "component.js",
   "browser": "browser.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-ui-flags/package.json
+++ b/packages/dotcom-ui-flags/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "component.js",
   "browser": "browser.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-ui-footer/package.json
+++ b/packages/dotcom-ui-footer/package.json
@@ -5,7 +5,7 @@
   "main": "component.js",
   "styles": "styles.scss",
   "browser": "browser.js",
-  "types": "src/index.tsx",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "browser": "browser.js",
   "main": "component.js",
-  "types": "src/index.tsx",
+  "types": "dist/node/index.d.ts",
   "styles": "styles.scss",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/dotcom-ui-layout/package.json
+++ b/packages/dotcom-ui-layout/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "component.js",
   "browser": "browser.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "styles": "styles.scss",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/dotcom-ui-polyfill-service/package.json
+++ b/packages/dotcom-ui-polyfill-service/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "server.js",
   "browser": "browser.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",

--- a/packages/dotcom-ui-shell/package.json
+++ b/packages/dotcom-ui-shell/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "component.js",
   "browser": "browser.js",
-  "types": "src/index.ts",
+  "types": "dist/node/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npm run clean:dist && npm run clean:node_modules",


### PR DESCRIPTION
The `types` field in `package.json` is meant to reference the declaration files that are generated by TypeScript and then can be consumed by it when installing published packages. Instead of pointing to the declaration files, we were instead pointing to the original TypeScript source code which we are (inappropriately) also publishing. This has the effect that the source code will be transpiled again by TypeScript apps that depend on the Page Kit packages, causing [issues](https://github.com/Financial-Times/dotcom-page-kit/pull/1015) when the `tsconfig.json` is different to ours.

I've updated all the packages to point to the compiled `dist/node/index.d.ts` declaration file, except `dotcom-types-navigation`, which already correctly referenced its single declaration file. I've also confirmed all the declaration files exist in the place we expect after running `tsc`.