### PR TITLE
Account and myFT entry points test

### DIFF
--- a/packages/dotcom-ui-header/src/__stories__/story.tsx
+++ b/packages/dotcom-ui-header/src/__stories__/story.tsx
@@ -55,6 +55,46 @@ DefaultHeaderWithDrawer.args = {
   showLogoLink: false
 }
 
+export const DefaultHeaderWithDrawerEntryTestAnon = (args) => (
+  <OnReady callback={onReadyCallback}>
+    <HeaderSimple {...storyData} {...args} />
+    <Drawer {...storyData} {...args} />
+  </OnReady>
+)
+
+DefaultHeaderWithDrawerEntryTestAnon.story = {
+  name: 'Default header with drawer - Account entry test [Anon]'
+}
+DefaultHeaderWithDrawerEntryTestAnon.args = {
+  showSubNavigation: true,
+  showMegaNav: true,
+  showUserNavigation: true,
+  userIsLoggedIn: false,
+  userIsSubscribed: false,
+  showLogoLink: false,
+  accountEntryTest: true
+}
+
+export const DefaultHeaderWithDrawerEntryTest = (args) => (
+  <OnReady callback={onReadyCallback}>
+    <HeaderSimple {...storyData} {...args} />
+    <Drawer {...storyData} {...args} />
+  </OnReady>
+)
+
+DefaultHeaderWithDrawerEntryTest.story = {
+  name: 'Default header with drawer - Account entry test'
+}
+DefaultHeaderWithDrawerEntryTest.args = {
+  showSubNavigation: true,
+  showMegaNav: true,
+  showUserNavigation: true,
+  userIsLoggedIn: true,
+  userIsSubscribed: false,
+  showLogoLink: false,
+  accountEntryTest: true
+}
+
 export const DefaultHeaderWithRightAlignedSubnav = (args) => (
   <OnReady callback={onReadyCallback}>
     <HeaderSimple {...profileStoryData} {...args} />

--- a/packages/dotcom-ui-header/src/__stories__/story.tsx
+++ b/packages/dotcom-ui-header/src/__stories__/story.tsx
@@ -72,7 +72,7 @@ DefaultHeaderWithDrawerEntryTestAnon.args = {
   userIsLoggedIn: false,
   userIsSubscribed: false,
   showLogoLink: false,
-  accountEntryTest: true
+  experimentalAccountEntryTest: true
 }
 
 export const DefaultHeaderWithDrawerEntryTest = (args) => (
@@ -92,7 +92,7 @@ DefaultHeaderWithDrawerEntryTest.args = {
   userIsLoggedIn: true,
   userIsSubscribed: false,
   showLogoLink: false,
-  accountEntryTest: true
+  experimentalAccountEntryTest: true
 }
 
 export const DefaultHeaderWithRightAlignedSubnav = (args) => (

--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -80,17 +80,17 @@ const NavListRight = (props: THeaderProps) => {
   return props.userIsLoggedIn ? (
     <NavListRightLoggedIn
       items={props.data['navbar-right'].items}
-      accountEntryTest={props.accountEntryTest}
+      experimentalAccountEntryTest={props.experimentalAccountEntryTest}
     />
   ) : null
 }
 
 const NavListRightLoggedIn = ({
   items,
-  accountEntryTest
+  experimentalAccountEntryTest
 }: {
   items: TNavMenuItem[]
-  accountEntryTest?: boolean
+  experimentalAccountEntryTest?: boolean
 }) => {
   /**
    * Accounts entry test
@@ -105,7 +105,7 @@ const NavListRightLoggedIn = ({
     >
       {items.map((item, index) => (
         <li className="o-header__nav-item" key={`link-${index}`}>
-          {item.label === 'Settings & Account' && accountEntryTest ? (
+          {item.label === 'Settings & Account' && experimentalAccountEntryTest ? (
             <a className="o-header__nav-link" href="/myft" data-trackable="my-ft">
               myFT Feed
             </a>

--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -77,10 +77,26 @@ const NavListLeft = (props: THeaderProps) => (
 )
 
 const NavListRight = (props: THeaderProps) => {
-  return props.userIsLoggedIn ? <NavListRightLoggedIn items={props.data['navbar-right'].items} /> : null
+  return props.userIsLoggedIn ? (
+    <NavListRightLoggedIn
+      items={props.data['navbar-right'].items}
+      accountEntryTest={props.accountEntryTest}
+    />
+  ) : null
 }
 
-const NavListRightLoggedIn = ({ items }: { items: TNavMenuItem[] }) => {
+const NavListRightLoggedIn = ({
+  items,
+  accountEntryTest
+}: {
+  items: TNavMenuItem[]
+  accountEntryTest?: boolean
+}) => {
+  /**
+   * Accounts entry test
+   * In this rendering theres a hacky solution to replace "Settings & Account" with "MyFT Feed"
+   * Once the test is concluded the real data should be updated accordingly and the hack removed
+   */
   return (
     <ul
       data-component="nav-list--right"
@@ -89,9 +105,15 @@ const NavListRightLoggedIn = ({ items }: { items: TNavMenuItem[] }) => {
     >
       {items.map((item, index) => (
         <li className="o-header__nav-item" key={`link-${index}`}>
-          <a className="o-header__nav-link" href={item.url ?? undefined} data-trackable={item.label}>
-            {item.label}
-          </a>
+          {item.label === 'Settings & Account' && accountEntryTest ? (
+            <a className="o-header__nav-link" href="/myft" data-trackable="my-ft">
+              myFT Feed
+            </a>
+          ) : (
+            <a className="o-header__nav-link" href={item.url ?? undefined} data-trackable={item.label}>
+              {item.label}
+            </a>
+          )}
         </li>
       ))}
     </ul>

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -39,7 +39,23 @@ const SearchIcon = () => (
   </a>
 )
 
-const MyFt = ({ className }: { className?: string }) => (
+const TopRightAccountEntry = ({
+  className,
+  signedIn,
+  accountEntryTest
+}: {
+  className?: string
+  signedIn: boolean
+  accountEntryTest?: boolean
+}) => {
+  if (accountEntryTest) {
+    return <MyAccountLink signedIn={signedIn} />
+  } else {
+    return <MyFtLogoLink className={className} />
+  }
+}
+
+const MyFtLogoLink = ({ className }: { className?: string }) => (
   <a
     className={`o-header__top-icon-link o-header__top-icon-link--myft ${className}`}
     id="o-header-top-link-myft"
@@ -51,6 +67,29 @@ const MyFt = ({ className }: { className?: string }) => (
     <span className="o-header__visually-hidden">myFT</span>
   </a>
 )
+
+const MyAccountLink = ({ signedIn }: { signedIn: boolean }) => {
+  const classNames = 'o-header__top-link ft-header__top-link--myaccount'
+
+  if (signedIn) {
+    return (
+      <a
+        className={classNames}
+        id="o-header-top-link-myaccount"
+        href="/myaccount"
+        data-trackable="my-account"
+      >
+        <span>My Account</span>
+      </a>
+    )
+  } else {
+    return (
+      <a className={classNames} id="o-header-top-link-signin" href="/login?location=/" data-trackable="Sign In">
+        <span>Sign In</span>
+      </a>
+    )
+  }
+}
 
 const TopWrapper = (props) => (
   <div className="o-header__row o-header__top" data-trackable="header-top">
@@ -100,7 +139,7 @@ const TopColumnRightLoggedIn = (props: THeaderProps) => {
           className="o-header__top-button--hide-m"
         />
       )}
-      <MyFt className="" />
+      <TopRightAccountEntry className="" signedIn={true} accountEntryTest={props.accountEntryTest} />
     </div>
   )
 }
@@ -151,18 +190,31 @@ const SubscribeButton = ({
   )
 }
 
-const TopColumnRightAnon = ({ items, variant }: { items: TNavMenuItem[]; variant?: string }) => {
+const TopColumnRightAnon = ({
+  items,
+  variant,
+  accountEntryTest
+}: {
+  items: TNavMenuItem[]
+  variant?: string
+  accountEntryTest?: boolean
+}) => {
   // If user is anonymous the second list item is styled as a button
   const [signInAction, subscribeAction] = items
+
   return (
     <div className="o-header__top-column o-header__top-column--right">
       {subscribeAction && (
         <SubscribeButton item={subscribeAction} variant={variant} className="o-header__top-button--hide-m" />
       )}
-      {signInAction && (
+      {signInAction && !accountEntryTest && (
         <SignInLink item={signInAction} variant={variant} className="o-header__top-link--hide-m" />
       )}
-      <MyFt className="o-header__top-icon-link--show-m" />
+      <TopRightAccountEntry
+        className="o-header__top-icon-link--show-m"
+        signedIn={false}
+        accountEntryTest={accountEntryTest}
+      />
     </div>
   )
 }
@@ -172,7 +224,13 @@ const TopColumnRight = (props: THeaderProps) => {
     return <TopColumnRightLoggedIn {...props} />
   } else {
     const userNavAnonItems = props.data['navbar-right-anon'].items
-    return <TopColumnRightAnon items={userNavAnonItems} variant={props.variant} />
+    return (
+      <TopColumnRightAnon
+        items={userNavAnonItems}
+        variant={props.variant}
+        accountEntryTest={props.accountEntryTest}
+      />
+    )
   }
 }
 

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -42,13 +42,13 @@ const SearchIcon = () => (
 const TopRightAccountEntry = ({
   className,
   signedIn,
-  accountEntryTest
+  experimentalAccountEntryTest
 }: {
   className?: string
   signedIn: boolean
-  accountEntryTest?: boolean
+  experimentalAccountEntryTest?: boolean
 }) => {
-  if (accountEntryTest) {
+  if (experimentalAccountEntryTest) {
     return <MyAccountLink signedIn={signedIn} />
   } else {
     return <MyFtLogoLink className={className} />
@@ -84,7 +84,12 @@ const MyAccountLink = ({ signedIn }: { signedIn: boolean }) => {
     )
   } else {
     return (
-      <a className={classNames} id="o-header-top-link-signin" href="/login?location=/" data-trackable="Sign In">
+      <a
+        className={classNames}
+        id="o-header-top-link-signin"
+        href="/login?location=/"
+        data-trackable="Sign In"
+      >
         <span>Sign In</span>
       </a>
     )
@@ -139,7 +144,11 @@ const TopColumnRightLoggedIn = (props: THeaderProps) => {
           className="o-header__top-button--hide-m"
         />
       )}
-      <TopRightAccountEntry className="" signedIn={true} accountEntryTest={props.accountEntryTest} />
+      <TopRightAccountEntry
+        className=""
+        signedIn={true}
+        experimentalAccountEntryTest={props.experimentalAccountEntryTest}
+      />
     </div>
   )
 }
@@ -193,11 +202,11 @@ const SubscribeButton = ({
 const TopColumnRightAnon = ({
   items,
   variant,
-  accountEntryTest
+  experimentalAccountEntryTest
 }: {
   items: TNavMenuItem[]
   variant?: string
-  accountEntryTest?: boolean
+  experimentalAccountEntryTest?: boolean
 }) => {
   // If user is anonymous the second list item is styled as a button
   const [signInAction, subscribeAction] = items
@@ -207,13 +216,13 @@ const TopColumnRightAnon = ({
       {subscribeAction && (
         <SubscribeButton item={subscribeAction} variant={variant} className="o-header__top-button--hide-m" />
       )}
-      {signInAction && !accountEntryTest && (
+      {signInAction && !experimentalAccountEntryTest && (
         <SignInLink item={signInAction} variant={variant} className="o-header__top-link--hide-m" />
       )}
       <TopRightAccountEntry
         className="o-header__top-icon-link--show-m"
         signedIn={false}
-        accountEntryTest={accountEntryTest}
+        experimentalAccountEntryTest={experimentalAccountEntryTest}
       />
     </div>
   )
@@ -228,7 +237,7 @@ const TopColumnRight = (props: THeaderProps) => {
       <TopColumnRightAnon
         items={userNavAnonItems}
         variant={props.variant}
-        accountEntryTest={props.accountEntryTest}
+        experimentalAccountEntryTest={props.experimentalAccountEntryTest}
       />
     )
   }

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -34,15 +34,26 @@
   @include oTypographySans(0);
 }
 
+
 .ft-header__top-link--myaccount span {
   vertical-align: middle;
-
+  // Hide the myaccount/sign in text on smaller screens leaving the icon only
   @include oGridRespondTo($until: 'M') {
     @include oNormaliseVisuallyHidden;
   }
 }
 
-.ft-header__top-link--myaccount:before {
+// Override the hover styles so the underline
+// Is only under the text and not the icon
+// And is closer to the text
+.ft-header__top-link--myaccount::after {
+  width: calc(100% - 32px);
+  left: unset;
+  right: 0;
+  bottom: 8px;
+}
+
+.ft-header__top-link--myaccount::before {
   content: '';
   display: block;
   @include oIconsContent(

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -3,7 +3,7 @@
 // Once for a core experience, once for an enhanced experience.
 // The enhanced version is hidden until toggled with JavaScript.
 // Instead since we can rely on the `core` class we can use the
-// one enhanced experience search block and reveal for the core 
+// one enhanced experience search block and reveal for the core
 // experience if needed.
 .core [data-o-header-search] {
   display: block;
@@ -26,4 +26,29 @@
 // Search typeahead
 .n-typeahead {
   display: none;
+}
+
+// The styles below are part of an AB test
+// If the test is successful these should be incorporated into o-header
+.ft-header__top-link--myaccount {
+  @include oTypographySans(0);
+}
+
+.ft-header__top-link--myaccount span {
+  vertical-align: middle;
+
+  @include oGridRespondTo($until: 'M') {
+    @include oNormaliseVisuallyHidden;
+  }
+}
+
+.ft-header__top-link--myaccount:before {
+  content: '';
+  display: block;
+  @include oIconsContent(
+		$icon-name: 'user',
+		$color: oColorsByName('black'),
+		$size: 32
+	);
+  vertical-align: middle;
 }

--- a/packages/dotcom-ui-header/src/interfaces.d.ts
+++ b/packages/dotcom-ui-header/src/interfaces.d.ts
@@ -10,7 +10,7 @@ export type THeaderOptions = {
   showStickyHeader?: boolean
   showMegaNav?: boolean
   showLogoLink?: boolean
-  accountEntryTest?: boolean
+  experimentalAccountEntryTest?: boolean
 }
 
 export type THeaderProps = THeaderOptions & {

--- a/packages/dotcom-ui-header/src/interfaces.d.ts
+++ b/packages/dotcom-ui-header/src/interfaces.d.ts
@@ -10,6 +10,11 @@ export type THeaderOptions = {
   showStickyHeader?: boolean
   showMegaNav?: boolean
   showLogoLink?: boolean
+  /*
+   * experimentalAccountEntryTest is an experimental feature switch
+   * This is being run as an AB test and should be removed afterwards
+   * This option shouldn't be used by anyone without consulting the CP Retention team first
+   */
   experimentalAccountEntryTest?: boolean
 }
 

--- a/packages/dotcom-ui-header/src/interfaces.d.ts
+++ b/packages/dotcom-ui-header/src/interfaces.d.ts
@@ -10,6 +10,7 @@ export type THeaderOptions = {
   showStickyHeader?: boolean
   showMegaNav?: boolean
   showLogoLink?: boolean
+  accountEntryTest?: boolean
 }
 
 export type THeaderProps = THeaderOptions & {


### PR DESCRIPTION
### Description

The Retention team aim to run an AB test with the hope of improving the confusion regarding entry points to myFT and Settings & Account.

The changes include

1. Swapping the position of myFT and Settings & Account entry points, so Setting & Account is at the top and MyFT is below
2. Changing the name of "Settings & Account" to "My Account"
3. Adding a "user" icon next to the My Account and Sign in links
4. Adding "Feed" to the myFT link

 These changes are related to user research that discovered
 
 1. Users think the myFT logo is just branding and not a link
 2. Settings and Account was not obvious place to go as the main hub for your Account
 3. My Account was a more common term for that hub
 4. The user icon help to distinguish this as your space
 
 These changes have also been couples with other changes else where including
 
 1. Adding sign posting to myFT features from within Settings & Account (My Account) so users can still find their way to those features from a central hub
 2. Removing the login barrier from Settings & Account (My Account) landing page so that sign posting is visible without being prompted to login again
 
 ### Screenshots
 
 **Anonymous user - test control**

![Screenshot of the FT header as seen by an anonymous user in the test control](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/e4400267-c55c-4ad1-8ba7-d21db826423b)
 
  **Anonymous user - test variant**  
  
![Screenshot of the FT header as seen by an anonymous user in the test variant](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/70e9aa8b-6228-480f-97b2-37eba0ef1ab6)

  **Signed in user - test control**
  
  
![Screenshot of the FT header as seen by an registered user in the test control](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/210f0b4d-c815-4339-a436-a197fb6aa783)

  **Signed in user - test variant**
  
![Screenshot of the FT header as seen by an regustered user in the test variant](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/b24475f5-6c76-4e72-8499-ecb3d85ca6dc)


**Mobile view**
This is the same regardless if you are logged in or not

![Screenshot of the FT header as seen by a user in the test variant](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/144098be-3908-435c-8525-8a357c1348c5)

### Interface changes

A new property has been added to the header components interface, that property is called `accountEntryTest` and it can be a `boolean` or `undefined` to allow for apps where this change doesn't need to be rolled out. That new property is temporary and will be cleaned up based on the outcome of the test.

Most (probably all) apps this is relevant to use the `dotcom-ui-layout` component to render pages so the new property will be passed into `dotcom-ui-layout` in the `headerOptions` object. For example in next-profile it will be added [here](https://github.com/Financial-Times/next-profile/blob/main/server/controllers/concerns/page-kit.js#L151)


### Ticket

https://financialtimes.atlassian.net/browse/ACC-2757

### Discussion points

As the interface change is optional and the output is unchanged without the new property then I would propose this change is released as a new minor, does anyone disagree with that?