### PR TITLE
fix: Remove unnecessary peer dependencies for code splitting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2594,180 +2594,6 @@
         "mathsass": "0.10.1"
       }
     },
-    "node_modules/@financial-times/n-feedback": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-feedback/-/n-feedback-9.0.4.tgz",
-      "integrity": "sha512-Xz6V2i69XQBJTRJO0SSRek2DFkgqWGOoPq0DBe0emQp9FJgLaEJF7t889heAOt2w7ofATEOs5ydlYB0u/Evs0w==",
-      "peer": true,
-      "dependencies": {
-        "@financial-times/dotcom-server-handlebars": "3.0.0",
-        "handlebars": "^4.1.2"
-      },
-      "engines": {
-        "node": "16.x || 18.x",
-        "npm": "7.x || 8.x || 9.x"
-      },
-      "peerDependencies": {
-        "@financial-times/o-buttons": "^7.2.1",
-        "@financial-times/o-forms": "^9.2.1",
-        "@financial-times/o-loading": "^5.2.0",
-        "@financial-times/o-overlay": "^4.2.2",
-        "@financial-times/o-typography": "^7.2.1"
-      }
-    },
-    "node_modules/@financial-times/n-feedback/node_modules/@financial-times/dotcom-server-handlebars": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/dotcom-server-handlebars/-/dotcom-server-handlebars-3.0.0.tgz",
-      "integrity": "sha512-cJBjlA3UaLI+UMsXIf7wusGVt/YlBXcix3eNfq24TR0QSM9uovNX5tQ5wtGcfe7NkSNUm2g2gzCYq5z1D1QrFQ==",
-      "hasInstallScript": true,
-      "peer": true,
-      "dependencies": {
-        "@types/glob": "^7.1.1",
-        "dateformat": "^3.0.3",
-        "glob": "^7.1.3",
-        "handlebars": "^4.3.1",
-        "mixin-deep": "^2.0.0",
-        "react": "^16.12.0",
-        "react-dom": "^16.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "npm": "7.x || 8.x"
-      }
-    },
-    "node_modules/@financial-times/n-feedback/node_modules/dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-      "peer": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@financial-times/n-feedback/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@financial-times/n-feedback/node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/@financial-times/n-feedback/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/@financial-times/n-syndication": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-syndication/-/n-syndication-9.0.1.tgz",
-      "integrity": "sha512-39g8Moxwq2RTnYkkbgvdNMbaM/+bs++q0IfhJScZGsj57KQxui1jxML99E0pLr9MqMovXOG5GegWwYwugEdq2A==",
-      "peer": true,
-      "dependencies": {
-        "next-session-client": "^5.0.0",
-        "superstore": "^2.1.0"
-      },
-      "engines": {
-        "node": "16.x || 18.x",
-        "npm": "7.x || 8.x || 9.x"
-      },
-      "peerDependencies": {
-        "@financial-times/o-buttons": "^7.3.0",
-        "@financial-times/o-icons": "^7.2.1",
-        "@financial-times/o-message": "^5.2.1",
-        "@financial-times/o-overlay": "^4.2.3",
-        "@financial-times/o-tracking": "^4.2.1",
-        "@financial-times/o-viewport": "^5.1.1",
-        "@financial-times/o-visual-effects": "^4.1.1",
-        "n-ui-foundations": "^9.0.0"
-      }
-    },
-    "node_modules/@financial-times/n-tracking": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-tracking/-/n-tracking-7.2.2.tgz",
-      "integrity": "sha512-WG9wvYizNicF047UbQXmTOA/XxBSU7sIv6bPjKwTxoy7er7biSC/btq15zIuW80i8Rh2a5WF98QMJYzTwWU/GA==",
-      "peer": true,
-      "dependencies": {
-        "@financial-times/ads-personalised-consent": "^5.2.8",
-        "@financial-times/o-grid": "^5.0.0",
-        "@financial-times/o-tracking": "^4.5.0",
-        "@financial-times/o-viewport": "^4.0.0",
-        "@financial-times/privacy-us-privacy": "^2.1.0",
-        "ready-state": "^2.0.5",
-        "web-vitals": "^3.4.0"
-      },
-      "engines": {
-        "node": "16.x || 18.x",
-        "npm": "7.x || 8.x || 9.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0 <19.0.0"
-      }
-    },
-    "node_modules/@financial-times/n-tracking/node_modules/@financial-times/o-grid": {
-      "version": "5.2.12",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-grid/-/o-grid-5.2.12.tgz",
-      "integrity": "sha512-j1oz7ClBvhAvlQoIj62rH0b5g3LAJcSDnWTPBV9/IYKY+xq0pewFOQ+SvK7fn4dzl7UUEVXSjy2iav8zo2OFTg==",
-      "peer": true,
-      "dependencies": {
-        "sass-mq": "^5.0.0"
-      }
-    },
-    "node_modules/@financial-times/n-tracking/node_modules/@financial-times/o-utils": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-1.1.7.tgz",
-      "integrity": "sha512-7lissruqmZfGPnkVrK8sk67Im6SJWhJnPBJ8YtbXite4NiWptNxVFXLMgHd4ixDwXxfvWWGJ3mS2CDHQHb6rog==",
-      "peer": true
-    },
-    "node_modules/@financial-times/n-tracking/node_modules/@financial-times/o-viewport": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-viewport/-/o-viewport-4.0.5.tgz",
-      "integrity": "sha512-dNB52EYnrfujG6V6B1foxCRWjgklsDc7KIEC0LOoUmXBIPXW258efzXMOKeK8ElVo3P2REjK+VOcTxJXnKuP+A==",
-      "peer": true,
-      "dependencies": {
-        "@financial-times/o-utils": "^1.0.0"
-      }
-    },
-    "node_modules/@financial-times/n-tracking/node_modules/@financial-times/privacy-legislation-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/privacy-legislation-client/-/privacy-legislation-client-2.2.0.tgz",
-      "integrity": "sha512-d0qXC6ktD1ndL94OJw5AcuqAEjjkGYJoQ0U4J4pPeXMregISkGEHtHTfT3tQKa5i4Kkvxn+/JF+I9voWHkKcaw==",
-      "peer": true
-    },
-    "node_modules/@financial-times/n-tracking/node_modules/@financial-times/privacy-us-privacy": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/privacy-us-privacy/-/privacy-us-privacy-2.2.0.tgz",
-      "integrity": "sha512-8Q/Vn467oEWGoKAwNqd1NQtfMfwSVdUGZqsbUo6xofDJJF29i4taMs5zn5CLz4K5y0uSJl/98QN6zn1pwXIepg==",
-      "peer": true,
-      "dependencies": {
-        "@financial-times/privacy-legislation-client": "^2.2.0"
-      }
-    },
     "node_modules/@financial-times/o-brand": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@financial-times/o-brand/-/o-brand-4.2.2.tgz",
@@ -2840,32 +2666,6 @@
         "@financial-times/o-viewport": "^5.0.0"
       }
     },
-    "node_modules/@financial-times/o-forms": {
-      "version": "9.12.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.12.1.tgz",
-      "integrity": "sha512-qnlLZYwdysDt7HNRZjy890gQZ+bWRBAAIGra/qm5MjXO2D23R1+3L+WUZLQ62Xo5kEmp0k2e2wjoj2oANNLXFg==",
-      "peer": true,
-      "dependencies": {
-        "@types/lodash.uniqueid": "^4.0.7",
-        "lodash.uniqueid": "^4.0.1"
-      },
-      "engines": {
-        "npm": ">7"
-      },
-      "peerDependencies": {
-        "@financial-times/math": "^1.0.0",
-        "@financial-times/o-brand": "^4.1.0",
-        "@financial-times/o-buttons": "^7.2.0",
-        "@financial-times/o-colors": "^6.5.0",
-        "@financial-times/o-grid": "^6.0.0",
-        "@financial-times/o-icons": "^7.0.0",
-        "@financial-times/o-loading": "^5.0.0",
-        "@financial-times/o-normalise": "^3.3.0",
-        "@financial-times/o-spacing": "^3.0.0",
-        "@financial-times/o-typography": "^7.4.1",
-        "@financial-times/o-utils": "^2.2.0"
-      }
-    },
     "node_modules/@financial-times/o-grid": {
       "version": "6.1.8",
       "resolved": "https://registry.npmjs.org/@financial-times/o-grid/-/o-grid-6.1.8.tgz",
@@ -2915,6 +2715,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@financial-times/o-loading/-/o-loading-5.2.3.tgz",
       "integrity": "sha512-rVK6WVCnf2VIDKdA2upIDLmYSSy49qxuEQOxuH1XhagvagYximCNE04F3ZXdQAUyKbdsR+BqFKr3SUp+N/5v0w==",
+      "dev": true,
       "peer": true,
       "engines": {
         "npm": ">7"
@@ -2923,25 +2724,6 @@
         "@financial-times/o-brand": "^4.1.0",
         "@financial-times/o-colors": "^6.5.0",
         "@financial-times/sass-mq": "^5.0.2"
-      }
-    },
-    "node_modules/@financial-times/o-message": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-message/-/o-message-5.4.4.tgz",
-      "integrity": "sha512-ZbipElvDgsYy+FYZ5lyfdFvhQPwFbrd3rfGbSckItHS983SUD6v8wCvdUGkXEBXzu5U0VN9DP0N9xdshosZklA==",
-      "peer": true,
-      "engines": {
-        "npm": ">7"
-      },
-      "peerDependencies": {
-        "@financial-times/math": "^1.0.0",
-        "@financial-times/o-brand": "^4.1.0",
-        "@financial-times/o-buttons": "^7.8.0",
-        "@financial-times/o-colors": "^6.5.0",
-        "@financial-times/o-grid": "^6.0.0",
-        "@financial-times/o-icons": "^7.0.1",
-        "@financial-times/o-spacing": "^3.0.0",
-        "@financial-times/o-typography": "^7.4.1"
       }
     },
     "node_modules/@financial-times/o-normalise": {
@@ -2956,35 +2738,6 @@
         "@financial-times/o-colors": "^6.0.1",
         "@financial-times/sass-mq": "^5.0.2"
       }
-    },
-    "node_modules/@financial-times/o-overlay": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-overlay/-/o-overlay-4.2.11.tgz",
-      "integrity": "sha512-wbnKFqglN4jUn0FqtOHd6ZANrfnS6CpGaVHhAVGxReb/jk17g5dhlMbaqKw2QXqzfsaY02AwoKKckWTxTSPEqw==",
-      "peer": true,
-      "dependencies": {
-        "focusable": "^2.3.0",
-        "ftdomdelegate": "^4.0.0"
-      },
-      "engines": {
-        "npm": ">7"
-      },
-      "peerDependencies": {
-        "@financial-times/o-brand": "^4.1.0",
-        "@financial-times/o-colors": "^6.5.0",
-        "@financial-times/o-icons": "^7.0.0",
-        "@financial-times/o-normalise": "^3.3.0",
-        "@financial-times/o-spacing": "^3.0.0",
-        "@financial-times/o-typography": "^7.4.1",
-        "@financial-times/o-viewport": "^5.0.0",
-        "@financial-times/o-visual-effects": "^4.0.1"
-      }
-    },
-    "node_modules/@financial-times/o-overlay/node_modules/ftdomdelegate": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ftdomdelegate/-/ftdomdelegate-4.0.6.tgz",
-      "integrity": "sha512-M1d0WNPkXngQlNuD5eWaxNsbigRkJE6qlgRyPSWXfpyq+H7DMF7EB1GC2VYZZtKH3ZIZf97Db8N3Qn7xU1MzPw==",
-      "peer": true
     },
     "node_modules/@financial-times/o-spacing": {
       "version": "3.2.5",
@@ -8150,16 +7903,8 @@
     "node_modules/@types/lodash": {
       "version": "4.14.200",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q=="
-    },
-    "node_modules/@types/lodash.uniqueid": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/lodash.uniqueid/-/lodash.uniqueid-4.0.8.tgz",
-      "integrity": "sha512-5/CZBvFikfLPSlnjm4WJ5DnTwk6FMVDdjIuE9/Uy/KzJCniZe/9Sn2zXK5PTEl5iVCUfRC5072FLaUXOHUSgSw==",
-      "peer": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
+      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
+      "dev": true
     },
     "node_modules/@types/mdast": {
       "version": "3.0.14",
@@ -15521,12 +15266,6 @@
       "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
       "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
     },
-    "node_modules/focusable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/focusable/-/focusable-2.3.0.tgz",
-      "integrity": "sha512-e63a4CAb5yLbn4Scn0wG9F+rEq4ZcbggRc9pD3hufAWf8y8dpZImdIES8YNUufRpKB+p0JS+BRd8RBU+sLAeIw==",
-      "peer": true
-    },
     "node_modules/follow-redirects": {
       "version": "1.15.3",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
@@ -22413,12 +22152,6 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
-    "node_modules/lodash.uniqueid": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
-      "integrity": "sha512-GQQWaIeGlL6DIIr06kj1j6sSmBxyNMwI8kaX9aKpHR/XsMTiaXDVPNPAkiboOTK9OJpTJF/dXT3xYoFQnj386Q==",
-      "peer": true
-    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -23636,17 +23369,6 @@
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.1.tgz",
       "integrity": "sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==",
       "dev": true
-    },
-    "node_modules/next-session-client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/next-session-client/-/next-session-client-5.0.0.tgz",
-      "integrity": "sha512-xkXekXRDB2k8OWj/7WHh37mV6PdAfLAdFd8f5usWaZtq+0LKHyx6mvO79/JdFvvJUod8IHOkQ+An64TpokBCFw==",
-      "hasInstallScript": true,
-      "peer": true,
-      "engines": {
-        "node": "16.x",
-        "npm": "7.x || 8.x"
-      }
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -29992,27 +29714,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/superstore": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/superstore/-/superstore-2.1.0.tgz",
-      "integrity": "sha512-S27KsusQpKsYYsNMa9Onom6nzVkxBN5azEI9mSs9lSNotvlG9SVK0KbT13+5j3ifVff1XxudzwPAEZmk9xKMPg==",
-      "peer": true,
-      "dependencies": {
-        "superstore-sync": "^2.1.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/superstore-sync": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/superstore-sync/-/superstore-sync-2.1.1.tgz",
-      "integrity": "sha512-p9UZQkOR0JKr4rJFwQubHff8+ktFg8LuIvwR3fYtjra2+m6dTA3LPkf6VQApZaRgaCkYzcDDgAIshM1Ejq0wxQ==",
-      "peer": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/supertest": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-4.0.2.tgz",
@@ -34138,9 +33839,6 @@
         "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {
-        "@financial-times/n-feedback": "^9.0.4",
-        "@financial-times/n-syndication": "^9.0.1",
-        "@financial-times/n-tracking": "^7.2.2",
         "dateformat": "^3.0.0 || ^4.0.0",
         "focus-visible": "^5.0.0",
         "fontfaceobserver": "^2.0.9",

--- a/packages/dotcom-build-code-splitting/package.json
+++ b/packages/dotcom-build-code-splitting/package.json
@@ -18,9 +18,6 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "@financial-times/n-tracking": "^7.2.2",
-    "@financial-times/n-feedback": "^9.0.4",
-    "@financial-times/n-syndication": "^9.0.1",
     "n-topic-search": "^4.0.0",
     "dateformat": "^3.0.0 || ^4.0.0",
     "focus-visible": "^5.0.0",


### PR DESCRIPTION
_**Theres no big urgency to this so it can wait until the new year if we think theres any risk to it**_

### Description

These peer dependencies were added in https://github.com/Financial-Times/dotcom-page-kit/pull/1012

However I don't believe they are needed as peer dependencies at all as the code splitting package doesn't use them.

It only references them so if they are used in a consuming app the code can be split into their own bundle as they are commonly used.

The issue with including these as a peer dependencies is that it forces apps to include these dependencies at a set version regardless, therefore potentially increasing the work to upgrade an app to the latest page-kit version

Maybe I am missing something here about needing to ensure the bundle we create is based on a certain version? but I cannot find any evidence of this being the case and this package work prior to these being included as a peer dependency.
