### PR TITLE
fix: Remove unnecessary peer dependencies (n-topic-search) for code splitting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33844,7 +33844,6 @@
         "fontfaceobserver": "^2.0.9",
         "ftdomdelegate": "^5.0.0",
         "hyperons": "2.0.0",
-        "n-topic-search": "^4.0.0",
         "preact": "^10.18.2",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "ready-state": "^2.0.5",

--- a/packages/dotcom-build-code-splitting/package.json
+++ b/packages/dotcom-build-code-splitting/package.json
@@ -18,7 +18,6 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "n-topic-search": "^4.0.0",
     "dateformat": "^3.0.0 || ^4.0.0",
     "focus-visible": "^5.0.0",
     "fontfaceobserver": "^2.0.9",


### PR DESCRIPTION

This peer dependencies were added in https://github.com/Financial-Times/dotcom-page-kit/pull/1012

However I don't believe they are needed as peer dependencies at all as the code splitting package doesn't use them.

It only references them so if they are used in a consuming app the code can be split into their own bundle as they are commonly used.

The issue with including these as a peer dependencies is that it forces apps to include these dependencies at a set version regardless.

**Note:** I think I missed this in my previous dependency clean up (https://github.com/Financial-Times/dotcom-page-kit/pull/1018) because I was looking at `@financial-times` org dependencies 