### PR TITLE
Add sass build time monitoring [OR-483]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 * @financial-times/platforms
 
 # The Origami team are responsible for sass-loader modifications.
-/packages/dotcom-build-sass/src/monitored-sass-loader.ts @financial-times/origami-core
+packages/dotcom-build-sass/ @Financial-Times/origami-core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,6 @@
 # See https://help.github.com/articles/about-codeowners/ for more information about this file.
 
 * @financial-times/platforms
+
+# The Origami team are responsible for sass-loader modifications.
+/packages/dotcom-build-sass/src/monitored-sass-loader.ts @financial-times/origami-core

--- a/packages/dotcom-build-sass/README.md
+++ b/packages/dotcom-build-sass/README.md
@@ -71,3 +71,20 @@ The CSS loader has `@import` and `url()` resolution disabled as these should be 
 | `webpackImporter` | Boolean  | `false` | See https://github.com/webpack-contrib/sass-loader#webpackimporter |
 | `prependData`     | String   | `''`    | See https://webpack.js.org/loaders/sass-loader/#prependdata        |
 | `includePaths`    | String[] | `[]`    | See https://sass-lang.com/documentation/js-api#includepaths        |
+
+## Sass build monitoring
+
+Sass build times are stored locally and remotely, where your project sets relevant API keys. Alternatively, you may turn both these features off using environment variable.
+
+- Local reporting: A running total of your local Sass build times are stored in a temporary file on your machine. This statistic is reported periodically for your interest, along with a prompt to support FT efforts to move away from Sass.
+- Alongside this, your local Sass build times are sent to the [biz-ops metrics api](https://github.com/Financial-Times/biz-ops-metrics-api), provided the below environment variables are set.
+
+
+| Environment Variable                       | Required   | Default    | Description                                                                                                                                                                                           |
+|--------------------------------------------|------------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `FT_SASS_STATS_NOTICE`                     | no         | `throttle` | How often to log Sass statistics out to terminal. One of `throttle`, `never`, `always`                                                                                                                |
+| `FT_SASS_STATS_NOTICE_THROTTLE_SECONDS`    | no         | `1800`     | How many seconds to wait between logging Sass statistics out to terminal.                                                                                                                             |
+| `FT_SASS_STATS_NOTICE_THROTTLE_PERCENTAGE` | no         | `30`       | A percentage increase in total Sass build time in which to log out statistics to the terminal regardless of time.                                                                                     |
+| `FT_SASS_STATS_MONITOR`                    | no         | `off`      | Set to `on` to send Sass build time statistics to [biz-ops metrics api](https://github.com/Financial-Times/biz-ops-metrics-api) Requires `FT_SASS_BIZ_OPS_API_KEY` and `FT_SASS_BIZ_OPS_SYSTEM_CODE`. |
+| `FT_SASS_BIZ_OPS_API_KEY`                  | no         | ``         | A [Biz-Ops Metrics API Key](https://github.com/Financial-Times/biz-ops-metrics-api/blob/main/docs/API_DEFINITION.md#authentication) for your system.                                                  |
+| `FT_SASS_BIZ_OPS_SYSTEM_CODE`              | no         | ``         | The [biz-ops](https://biz-ops.in.ft.com/) system code of your project. Use `page-kit` if your system does not have a biz-ops code yet.                                                                |

--- a/packages/dotcom-build-sass/src/index.ts
+++ b/packages/dotcom-build-sass/src/index.ts
@@ -115,7 +115,7 @@ export class PageKitSassPlugin {
         // Enable use of Sass for CSS preprocessing
         // https://github.com/webpack-contrib/sass-loader
         {
-          loader: require.resolve('sass-loader'),
+          loader: require.resolve('./monitored-sass-loader'),
           options: sassLoaderOptions
         }
       ]

--- a/packages/dotcom-build-sass/src/monitored-sass-loader.ts
+++ b/packages/dotcom-build-sass/src/monitored-sass-loader.ts
@@ -4,8 +4,19 @@ import os from 'os'
 import sassLoader from 'sass-loader'
 
 class SassStats {
-  #noticeThrottle = 10 * 1000
-  #stats = { totalTime: 0, notice: null }
+  #noticeStrategies = ['throttle', 'never', 'always']
+  #noticeStrategy = this.#noticeStrategies.includes(process.env.FT_SASS_STATS_NOTICE)
+    ? process.env.FT_SASS_STATS_NOTICE
+    : 'throttle'
+  #noticeThrottleSeconds =
+    typeof process.env.FT_SASS_STATS_NOTICE_THROTTLE_SECONDS === 'number'
+      ? process.env.FT_SASS_STATS_NOTICE_THROTTLE_SECONDS
+      : 60 * 60 * 0.5 // show throttled notice given 30 mins since last notice
+  #noticeThrottlePercentage =
+    typeof process.env.FT_SASS_STATS_NOTICE_THROTTLE_PERCENTAGE === 'number'
+      ? process.env.FT_SASS_STATS_NOTICE_THROTTLE_PERCENTAGE
+      : 30 // show throttled notice given a 30% increase
+  #stats = { totalTime: 0, noticeDate: null, totalTimeAtLastNotice: 0 }
   #directory = path.join(os.tmpdir(), 'dotcom-build-sass')
   #file = path.join(this.#directory, 'sass-stats.json')
   #startTime
@@ -40,24 +51,60 @@ class SassStats {
     fs.writeFileSync(this.#file, JSON.stringify(this.#stats))
   }
 
-  throttledReport = () => {
-    if (!this.#stats.notice || this.#stats.notice < Date.now() - this.#noticeThrottle) {
-      this.#write({ notice: Date.now() })
+  reportAccordingToNoticeStrategy = () => {
+    let shouldReport
+
+    switch (this.#noticeStrategy) {
+      case 'never':
+        shouldReport = false
+        break
+
+      case 'always':
+        shouldReport = true
+        break
+
+      case 'throttle':
+        // Throttle notices to show a limited number per hour, or if the total sass build time
+        // has increased by a significant percentage. This favours more frequent reports to begin with.
+        const noticeTimeThrottle = Date.now() >= this.#stats.noticeDate + this.#noticeThrottleSeconds * 1000
+        const percentageTotalTimeThrottle =
+          this.#stats.totalTime > 0 &&
+          (this.#stats.totalTime / this.#stats.totalTimeAtLastNotice - 1) * 100 >=
+            this.#noticeThrottlePercentage // % increase
+        shouldReport = !this.#stats.noticeDate || noticeTimeThrottle || percentageTotalTimeThrottle
+        break
+
+      default:
+        break
+    }
+
+    if (shouldReport) {
       this.#report()
     }
   }
 
   #report = () => {
-    const seconds = Math.floor(this.#stats.totalTime / 1000)
-    const minutes = Math.floor(seconds / 60)
-    const hours = Math.floor(seconds / 3600)
-    const time = hours > 2 ? `${hours} hours` : minutes > 2 ? `${minutes} minutes` : `${seconds} seconds`
+    const seconds = this.#stats.totalTime / 1000
+    const minutes = seconds / 60
+    const hours = seconds / 3600
+    const time =
+      hours > 1
+        ? `${hours.toFixed(1)} hours`
+        : minutes > 1
+        ? `${minutes.toFixed(0)} minutes`
+        : `${seconds.toFixed(0)} seconds`
+    const emoji =
+      hours > 2 ? ['🔥', '😭', '😱'] : hours >= 1 ? ['🔥', '😱'] : minutes > 10 ? ['⏱️', '😬'] : ['⏱️']
 
     // eslint-disable-next-line no-console
     console.log(
-      `\n\nYou have spent at least 🔥😱 ${time} 😱🔥 waiting on FT Sass to compile.` +
-        `\nLet's fix that! 🎉 [link to support to optimise / remove Sass]\n\n`
+      `\n\nYou have spent at least ${emoji.join(' ')} ${time} ${emoji
+        .reverse()
+        .join(' ')} waiting on FT Sass to compile.` +
+        `\nLet's fix that! 🎉 https://origami.ft.com/blog/2024/01/24/sass-build-times/\n\n`
     )
+
+    this.#write({ noticeDate: Date.now(), totalTimeAtLastNotice: this.#stats.totalTime })
   }
 }
 
@@ -71,7 +118,10 @@ const forgivingProxy = (target, task) => {
       } catch (error) {
         Reflect.apply(...args)
         // eslint-disable-next-line no-console
-        console.log('dotcom-build-sass: Failed to monitor Sass build.', error)
+        console.log(
+          'dotcom-build-sass: Failed to monitor Sass build. Please report to #origami-support',
+          error
+        )
       }
     }
   })
@@ -93,7 +143,7 @@ const monitoredSassLoaderProxy = forgivingProxy(sassLoader, (target, sassLoaderT
       // sass-loader's callback has been... called.
       // Either we have sass, or the build failed.
       localStats.end()
-      localStats.throttledReport()
+      localStats.reportAccordingToNoticeStrategy()
       return Reflect.apply(target, thisArg, argumentsList)
     })
   })

--- a/packages/dotcom-build-sass/src/monitored-sass-loader.ts
+++ b/packages/dotcom-build-sass/src/monitored-sass-loader.ts
@@ -1,0 +1,105 @@
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import sassLoader from 'sass-loader'
+
+class SassStats {
+  #noticeThrottle = 10 * 1000
+  #stats = { totalTime: 0, notice: null }
+  #directory = path.join(os.tmpdir(), 'dotcom-build-sass')
+  #file = path.join(this.#directory, 'sass-stats.json')
+  #startTime
+
+  constructor() {
+    fs.mkdirSync(path.dirname(this.#directory), { recursive: true })
+  }
+
+  start = () => {
+    this.#read()
+    this.#startTime = performance.now()
+  }
+
+  end = () => {
+    const endTime = performance.now()
+    const updatedTotal = (this.#stats.totalTime += endTime - this.#startTime)
+    this.#write({ totalTime: updatedTotal })
+  }
+
+  #read = () => {
+    try {
+      // Restore stats from a temporary file if it exists.
+      // Reading from disk ensures that we can track stats across builds.
+      const statsFile = fs.readFileSync(this.#file, 'utf-8')
+      this.#stats = JSON.parse(statsFile)
+    } catch {}
+    return this.#stats
+  }
+
+  #write = (stats) => {
+    this.#stats = Object.assign(this.#stats, stats)
+    fs.writeFileSync(this.#file, JSON.stringify(this.#stats))
+  }
+
+  throttledReport = () => {
+    if (!this.#stats.notice || this.#stats.notice < Date.now() - this.#noticeThrottle) {
+      this.#write({ notice: Date.now() })
+      this.#report()
+    }
+  }
+
+  #report = () => {
+    const seconds = Math.floor(this.#stats.totalTime / 1000)
+    const minutes = Math.floor(seconds / 60)
+    const hours = Math.floor(seconds / 3600)
+    const time = hours > 2 ? `${hours} hours` : minutes > 2 ? `${minutes} minutes` : `${seconds} seconds`
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n\nYou have spent at least 🔥😱 ${time} 😱🔥 waiting on FT Sass to compile.` +
+        `\nLet's fix that! 🎉 [link to support to optimise / remove Sass]\n\n`
+    )
+  }
+}
+
+// We're proxying a few functions for monitoring purposes,
+// we want to catch any monitoring errors silently.
+const forgivingProxy = (target, task) => {
+  return new Proxy(target, {
+    apply(...args) {
+      try {
+        return task(...args)
+      } catch (error) {
+        Reflect.apply(...args)
+        // eslint-disable-next-line no-console
+        console.log('dotcom-build-sass: Failed to monitor Sass build.', error)
+      }
+    }
+  })
+}
+
+const localStats = new SassStats()
+const monitoredSassLoaderProxy = forgivingProxy(sassLoader, (target, sassLoaderThis, argumentsList) => {
+  // Start the timer, sass-loader has been called with Sass content.
+  // https://github.com/webpack-contrib/sass-loader/blob/03773152760434a2dd845008c504a09c0eb3fd91/src/index.js#L19
+  localStats.start()
+  // Assign our proxy to sass-loaders async function.
+  // https://github.com/webpack-contrib/sass-loader/blob/03773152760434a2dd845008c504a09c0eb3fd91/src/index.js#L29
+  const sassLoaderAsyncProxy = forgivingProxy(sassLoaderThis.async, (target, thisArg, argumentsList) => {
+    // Run sass-loader's async function as normal.
+    // Proxy the callback it returns.
+    // https://github.com/webpack-contrib/sass-loader/blob/03773152760434a2dd845008c504a09c0eb3fd91/src/index.js#L113
+    const sassLoaderCallback = Reflect.apply(target, thisArg, argumentsList)
+    return forgivingProxy(sassLoaderCallback, (target, thisArg, argumentsList) => {
+      // sass-loader's callback has been... called.
+      // Either we have sass, or the build failed.
+      localStats.end()
+      localStats.throttledReport()
+      return Reflect.apply(target, thisArg, argumentsList)
+    })
+  })
+  sassLoaderThis.async = sassLoaderAsyncProxy
+  // Run sass-loader as normal.
+  return Reflect.apply(target, sassLoaderThis, argumentsList)
+})
+
+export default monitoredSassLoaderProxy

--- a/packages/dotcom-build-sass/src/monitored-sass-loader.ts
+++ b/packages/dotcom-build-sass/src/monitored-sass-loader.ts
@@ -159,8 +159,9 @@ class SassStats {
     console.log(
       `\n\nYou have spent at least ${emoji.join(' ')} ${time} ${emoji
         .reverse()
-        .join(' ')} waiting on FT Sass to compile.` +
-        `\nLet's fix that! 🎉 https://origami.ft.com/blog/2024/01/24/sass-build-times/\n\n`
+        .join(' ')} waiting on FT Sass to compile.\n` +
+        `Share your pain in Slack #sass-to-css, and help fix that! 🎉\n` +
+        `https://origami.ft.com/blog/2024/01/24/sass-build-times/\n\n`
     )
 
     this.#write({ noticeDate: Date.now(), totalTimeAtLastNotice: this.#stats.totalTime })

--- a/packages/dotcom-build-sass/src/monitored-sass-loader.ts
+++ b/packages/dotcom-build-sass/src/monitored-sass-loader.ts
@@ -54,14 +54,14 @@ class SassStats {
   }
 
   sendMetric = () => {
-    if (process.env.FT_SASS_STATS_MONITOR === 'off') {
+    if (process.env.FT_SASS_STATS_MONITOR !== 'on') {
       return
     }
 
     if (!process.env.FT_SASS_BIZ_OPS_API_KEY) {
       // eslint-disable-next-line no-console
       console.log(
-        'dotcom-build-sass: Could not monitor Sass your build time. Please help us improve build times by including a FT_SASS_BIZ_OPS_API_KEY. Please contact #origami-support with any questions.'
+        'dotcom-build-sass: Could not monitor your Sass build time. Please help us improve build times by including a FT_SASS_BIZ_OPS_API_KEY. Please contact #origami-support with any questions.'
       )
     }
 


### PR DESCRIPTION
Let's build a case to invest in our Sass and its tooling. Or, better, to [proactively move away from sass](https://docs.google.com/document/d/1RuGduWdX0zGsgsp9C7lIhXgqEia6sWK900_3XVwYDIM/edit#heading=h.1f3yolavobef)!

Completed todo:

1. Do the Platforms team think this is a good idea? 💚 
2. Option to turn off 🟢 
3. [Helpful link](https://github.com/Financial-Times/origami/pull/1407) on why this is here, and what we'll do about it 🟢 – will release when this is approved
4. Capture [number of sass compilation errors](https://github.com/webpack-contrib/sass-loader/blob/03773152760434a2dd845008c504a09c0eb3fd91/src/index.js#L68) 🟠  – this is a big enough PR, we can add this later if we want
5. Remote, aggregate monitoring through [biz-ops metrics api](https://github.com/Financial-Times/biz-ops-metrics-api)  🟢  - [example](https://biz-ops.in.ft.com/api-explorer?loggedInUser=kiya.gurmesa&query=%7B%0A++teams%28where%3A+%7B+code%3A+%22platforms-customer-products%22+%7D%29+%7B%0A++++delivers%28where%3A+%7B+code%3A+%22page-kit%22+%7D%29+%7B%0A++++++code%0A++++++metric%28name%3A+%22sass-build-time%22%29+%7B%0A++++++++value%0A++++++++timestamp%0A++++++%7D%0A++++%7D%0A++++metricRollup%28path%3A+%22delivers.metric%22%2C+method%3A+sum%29+%7B%0A++++++value%0A++++++timestamp%0A++++%7D%0A++%7D%0A%7D&title=Custom+Biz+Ops+report)