### PR TITLE
CPP-1757: loosen appContext.contentType schema

### DIFF
--- a/packages/dotcom-server-app-context/schema.md
+++ b/packages/dotcom-server-app-context/schema.md
@@ -56,7 +56,7 @@ The type or sub-type of the content on the current page
 
 Additional restrictions:
 
-* Regex pattern: `^(article|video|audio|podcast|package|live-blog)$`
+* Regex pattern: `^.+$`
 
 ## `edition` (string)
 
@@ -91,6 +91,14 @@ Additional restrictions:
 ## `publishReference` (string)
 
 The publish reference of the content on the current page
+
+Additional restrictions:
+
+* Regex pattern: `^.+$`
+
+## `pageKitVersion` (string)
+
+The version of Page Kit powering the app
 
 Additional restrictions:
 

--- a/packages/dotcom-server-app-context/src/__test__/__fixtures__/contextData.ts
+++ b/packages/dotcom-server-app-context/src/__test__/__fixtures__/contextData.ts
@@ -5,7 +5,7 @@ export const validAppContext = Object.freeze({
   product: 'next',
   abTestState: 'subscriberCohort:on,premiumCohort:on,topicTracker_UIDemo:100-percent',
   contentId: 'c5935758-7730-11e9-bbad-7c18c0ea0201',
-  contentType: 'article',
+  contentType: 'Article',
   conceptId: 'c5935738-7730-11e9-bbad-7c18c0ea8201',
   conceptType: 'http://www.ft.com/ontology/Location',
   isProduction: true,

--- a/packages/dotcom-server-app-context/src/schema.json
+++ b/packages/dotcom-server-app-context/src/schema.json
@@ -6,49 +6,71 @@
     "abTestState": {
       "type": "string",
       "description": "The A/B test flags data as a comma delimited string",
-      "examples": ["subscriberCohort:on,premiumCohort:on,nonUSACohort:on"],
+      "examples": [
+        "subscriberCohort:on,premiumCohort:on,nonUSACohort:on"
+      ],
       "pattern": "^,*([0-9A-Za-z-_]+:[0-9A-Za-z-_]+,*)+$"
     },
     "appName": {
       "type": "string",
       "description": "The name of the application",
-      "examples": ["front-page", "stream-page", "article-page"],
+      "examples": [
+        "front-page",
+        "stream-page",
+        "article-page"
+      ],
       "pattern": "^.+$"
     },
     "appVersion": {
       "type": "string",
       "description": "The running version of the app (usually a Git commit hash)",
-      "examples": ["882797258625531f20d604f6441ef8cfcb2d772b"],
+      "examples": [
+        "882797258625531f20d604f6441ef8cfcb2d772b"
+      ],
       "pattern": "^.+$"
     },
     "conceptId": {
       "type": "string",
       "description": "The UUID of the concept on the current page",
-      "examples": ["c5935758-7730-11e9-bbad-7c18c0ea0201"],
+      "examples": [
+        "c5935758-7730-11e9-bbad-7c18c0ea0201"
+      ],
       "pattern": "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$"
     },
     "conceptType": {
       "type": "string",
       "description": "The type of concept on the current page",
-      "examples": ["http://www.ft.com/ontology/product/Brand", "http://www.ft.com/ontology/Location"],
+      "examples": [
+        "http://www.ft.com/ontology/product/Brand",
+        "http://www.ft.com/ontology/Location"
+      ],
       "pattern": "^http://www.ft.com/ontology/.+$"
     },
     "contentId": {
       "type": "string",
       "description": "The UUID of the content on the current page",
-      "examples": ["c5935758-7730-11e9-bbad-7c18c0ea0201"],
+      "examples": [
+        "c5935758-7730-11e9-bbad-7c18c0ea0201"
+      ],
       "pattern": "^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$"
     },
     "contentType": {
       "type": "string",
       "description": "The type or sub-type of the content on the current page",
-      "examples": ["article", "video", "audio", "podcast", "package", "live-blog"],
-      "pattern": "^(article|video|audio|podcast|package|live-blog)$"
+      "examples": [
+        "Article",
+        "LiveBlogPost",
+        "Video"
+      ],
+      "pattern": "^.+$"
     },
     "edition": {
       "type": "string",
       "description": "The selected FT edition",
-      "examples": ["uk", "international"],
+      "examples": [
+        "uk",
+        "international"
+      ],
       "pattern": "^(uk|international)$"
     },
     "isProduction": {
@@ -80,7 +102,9 @@
     "pageKitVersion": {
       "type": "string",
       "description": "The version of Page Kit powering the app",
-      "examples": ["1.0.0"],
+      "examples": [
+        "1.0.0"
+      ],
       "pattern": "^.+$"
     }
   },


### PR DESCRIPTION
loosens the schema for `appContext.contentType` to accept any string. this allows us to use both the current (CAPI-style, PascalCase) values and the old (ES-style, kebab-case) values, and prevents implicitly coupling this schema to the list of possible content types that CAPI can return.

i don't like that the schema validator can throw an error if the app context is invalid, when some of it is provided by data we don't control. but i'm not about to rewrite how this works 😅 