### PR TITLE
fix:  don't load polyfill.io in shell

### DIFF
--- a/examples/ft-ui/__test__/integration.test.js
+++ b/examples/ft-ui/__test__/integration.test.js
@@ -14,7 +14,6 @@ describe('examples/ft-ui', () => {
     })
 
     it('loads the configured scripts', async () => {
-      await expect(page).toMatchElement('script[src^="https://polyfill.io"]')
       await expect(page).toMatchElement('script[src="public/scripts.bundle.js"]')
     })
   })

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -100,12 +100,6 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
       rel="preconnect"
     />
     <link
-      as="script"
-      href="https://polyfill.io/v3/polyfill.min.js?features=default%2Ces5%2Ces2015%2Ces2016%2Ces2017%2CEventSource%2Cfetch%2CHTMLPictureElement%2CIntersectionObserver%2CNodeList.prototype.forEach&source=next"
-      rel="preload"
-      type={null}
-    />
-    <link
       as="font"
       crossOrigin="anonymous"
       href="https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=MetricWeb-Regular&system_code=origami&version=1.12"

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
     <script
       dangerouslySetInnerHTML={
         Object {
-          "__html": "{\\"trackErrors\\":true,\\"core\\":[\\"https://polyfill.io/v3/polyfill.min.js?features=HTMLPictureElement&source=next\\"],\\"enhanced\\":[\\"https://polyfill.io/v3/polyfill.min.js?features=default%2Ces5%2Ces2015%2Ces2016%2Ces2017%2CEventSource%2Cfetch%2CHTMLPictureElement%2CIntersectionObserver%2CNodeList.prototype.forEach&source=next\\"]}",
+          "__html": "{\\"trackErrors\\":true,\\"core\\":[],\\"enhanced\\":[]}",
         }
       }
       id="page-kit-bootstrap-config"

--- a/packages/dotcom-ui-shell/src/components/Shell.tsx
+++ b/packages/dotcom-ui-shell/src/components/Shell.tsx
@@ -12,7 +12,6 @@ import {
 } from '@financial-times/dotcom-ui-base-styles'
 import { FlagsEmbed, TFlagsEmbedProps } from '@financial-times/dotcom-ui-flags'
 import { Bootstrap, TBootstrapProps } from '@financial-times/dotcom-ui-bootstrap'
-import * as polyfillService from '@financial-times/dotcom-ui-polyfill-service'
 import formatAttributeNames, { TAttributeData } from '../lib/formatAttributeNames'
 import GTMHead from './GTMHead'
 import GTMBody from './GTMBody'
@@ -37,7 +36,6 @@ function Shell(props: TShellProps) {
   }
 
   const resourceHints = [
-    polyfillService.enhanced(),
     // There is no need to include stylesheets here as any <link rel="stylesheet" /> tags
     // should be found by the browser's speculative parser.
     ...props.scripts,

--- a/packages/dotcom-ui-shell/src/components/Shell.tsx
+++ b/packages/dotcom-ui-shell/src/components/Shell.tsx
@@ -32,8 +32,8 @@ type TShellProps = TDocumentHeadProps &
 
 function Shell(props: TShellProps) {
   const bootstrapProps: TBootstrapProps = {
-    coreScripts: [polyfillService.core()],
-    enhancedScripts: [polyfillService.enhanced(), ...props.scripts]
+    coreScripts: [],
+    enhancedScripts: props.scripts
   }
 
   const resourceHints = [


### PR DESCRIPTION
[#inc-2575-polyfill-io-is-intermittently-failing](https://financialtimes.enterprise.slack.com/archives/C06LT31R3BM)

[#polyfill-discussion-2024](https://financialtimes.enterprise.slack.com/archives/C06LNUG3C12)

although this should probably be a major change, we'll release it as a minor to make the upgrade path easier. also tbh nothing really needs polyfills any more?

there is some cleanup work to do after this to remove the `dotcom-ui-polyfill-service` package (going with the quickest fix for now)