### PR TITLE
WIP add support for Subresource Integrity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7836,7 +7836,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
       "integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.3",
@@ -10713,7 +10713,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
       "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "pascal-case": "^3.1.2",
         "tslib": "^2.0.3"
@@ -11092,7 +11092,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
       "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "source-map": "~0.6.0"
       },
@@ -12365,7 +12365,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
       "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.0.1",
@@ -12398,7 +12398,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 6"
       },
@@ -13186,7 +13186,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "utila": "~0.4"
       }
@@ -13195,7 +13195,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
       "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -13256,7 +13256,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
       "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "domelementtype": "^2.2.0"
       },
@@ -13271,7 +13271,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
       "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -13285,7 +13285,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -16438,7 +16438,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "he": "bin/he"
       }
@@ -16588,7 +16588,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
       "integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "camel-case": "^4.1.1",
         "clean-css": "^4.2.3",
@@ -16631,7 +16631,7 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz",
       "integrity": "sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/html-minifier-terser": "^5.0.0",
         "@types/tapable": "^1.0.5",
@@ -16654,7 +16654,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
       "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -16666,7 +16666,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
       "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -16680,7 +16680,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6"
       }
@@ -16689,7 +16689,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
       "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -22103,7 +22103,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -22344,7 +22344,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -23375,7 +23375,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -23955,7 +23955,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -24613,7 +24613,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
       "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -24743,7 +24743,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
       "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -26527,7 +26527,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz",
       "integrity": "sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "lodash": "^4.17.20",
         "renderkid": "^2.0.4"
@@ -27424,7 +27424,7 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -27650,7 +27650,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
       "integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "css-select": "^4.1.3",
         "dom-converter": "^0.2.0",
@@ -27663,7 +27663,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -27672,7 +27672,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -31008,7 +31008,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -31885,7 +31885,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -33022,6 +33022,26 @@
         "source-map": "~0.6.1"
       }
     },
+    "node_modules/webpack-subresource-integrity": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/webpack-subresource-integrity/-/webpack-subresource-integrity-1.5.2.tgz",
+      "integrity": "sha512-GBWYBoyalbo5YClwWop9qe6Zclp8CIXYGIz12OPclJhIrSplDxs1Ls1JDMH8xBPPrg1T6ISaTW9Y6zOrwEiAzw==",
+      "dependencies": {
+        "webpack-sources": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "html-webpack-plugin": ">= 2.21.0 < 5",
+        "webpack": ">= 1.12.11 < 6"
+      },
+      "peerDependenciesMeta": {
+        "html-webpack-plugin": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.2.2.tgz",
@@ -33799,7 +33819,8 @@
       "dependencies": {
         "clean-webpack-plugin": "^3.0.0",
         "compression-webpack-plugin": "^4.0.0",
-        "webpack-assets-manifest": "^3.1.1"
+        "webpack-assets-manifest": "^3.1.1",
+        "webpack-subresource-integrity": "^1.5.2"
       },
       "devDependencies": {
         "@types/webpack": "^4.41.7",

--- a/packages/dotcom-build-base/package.json
+++ b/packages/dotcom-build-base/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "clean-webpack-plugin": "^3.0.0",
     "compression-webpack-plugin": "^4.0.0",
-    "webpack-assets-manifest": "^3.1.1"
+    "webpack-assets-manifest": "^3.1.1",
+    "webpack-subresource-integrity": "^1.5.2"
   },
   "devDependencies": {
     "@types/webpack": "^4.41.7",
@@ -33,7 +34,10 @@
     "node": "16.x || 18.x || 20.x",
     "npm": "7.x || 8.x || 9.x || 10.x"
   },
-  "files": ["dist/", "src/"],
+  "files": [
+    "dist/",
+    "src/"
+  ],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",

--- a/packages/dotcom-build-base/src/index.ts
+++ b/packages/dotcom-build-base/src/index.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { CleanWebpackPlugin } from 'clean-webpack-plugin'
 import CompressionPlugin from 'compression-webpack-plugin'
 import ManifestPlugin from 'webpack-assets-manifest'
+import SubresourceIntegrityPlugin from 'webpack-subresource-integrity'
 
 export class PageKitBasePlugin {
   apply(compiler: webpack.Compiler) {
@@ -29,14 +30,20 @@ export class PageKitBasePlugin {
     }
 
     const manifestPluginOptions = {
-      entrypoints: true
+      entrypoints: true,
+      integrity: true
+    }
+
+    const subresourceIntegrityPluginOptions = {
+      hashFuncNames: ['sha256']
     }
 
     compiler.options.output = {
       ...compiler.options.output,
       filename: outputFileName,
       chunkFilename: outputFileName,
-      path: path.resolve('public')
+      path: path.resolve('public'),
+      crossOriginLoading: 'anonymous'
     }
 
     compiler.options.devtool = isDevMode ? 'cheap-module-eval-source-map' : 'source-map'
@@ -45,6 +52,7 @@ export class PageKitBasePlugin {
 
     new CleanWebpackPlugin(cleanWebpackPluginOptions).apply(compiler)
     new ManifestPlugin(manifestPluginOptions).apply(compiler)
+    new SubresourceIntegrityPlugin(subresourceIntegrityPluginOptions).apply(compiler)
 
     if (!isDevMode) {
       new CompressionPlugin(gzipCompressionPluginOptions).apply(compiler)


### PR DESCRIPTION
so far this PR just adds the `webpack-subresource-integrity` plugin to `dotcom-build-base`, and configures things to output the integrity hashes in the manifest.

we'd still need to have `dotcom-ui-bootstrap` output these hashes in the `integrity` attribute. however, the asset loader, shell and bootstrap all just expect an array of strings, and changing that all the way through was proving to be annoying.

tbh the asset loader seems unnecessarily complex, and has a lot of functionality that i'm pretty sure people aren't using. i'm tempted to rewrite it.