### PR TITLE
My Account & myFT entry points rollout

### DIFF
--- a/__fixtures__/menus.json
+++ b/__fixtures__/menus.json
@@ -1217,6 +1217,28 @@
       }
     ]
   },
+  "navbar-top-right": {
+    "label": "Navigation",
+    "items": [
+      { "label": "My Account", "url": "/myaccount", "submenu": null },
+      {
+        "label": "Subscribe",
+        "url": "/products?segmentId=f860e6c2-18af-ab30-cd5e-6e3a456f9265",
+        "submenu": null
+      }
+    ]
+  },
+  "navbar-top-right-anon": {
+    "label": "Navigation",
+    "items": [
+      { "label": "Sign In", "url": "/login?location=${currentPath}", "submenu": null },
+      {
+        "label": "Subscribe",
+        "url": "/products?segmentId=f860e6c2-18af-ab30-cd5e-6e3a456f9265",
+        "submenu": null
+      }
+    ]
+  },
   "navbar-uk": {
     "label": "Navigation",
     "items": [

--- a/examples/ft-ui/__test__/anonymous-user.test.js
+++ b/examples/ft-ui/__test__/anonymous-user.test.js
@@ -6,7 +6,6 @@ describe('examples/ft-ui', () => {
 
   describe('Header link elements', () => {
     it('renders the expected anonymous user Header link elements', async () => {
-      await expect(page).toMatchElement('a[href$="/myft"]', { text: 'myFT' })
       await expect(page).toMatchElement('.o-header__top-column--right a[href$="/login?location=/"]', {
         text: 'Sign In'
       })
@@ -19,13 +18,12 @@ describe('examples/ft-ui', () => {
     })
 
     it('does not render the logged-in user Header link elements', async () => {
-      await expect(page).not.toMatchElement('.o-header__top-column--right a[href$="/myaccount"]', {
-        text: 'Settings & Account'
-      })
       await expect(page).not.toMatchElement(
         `.o-header__top-column--right a[href="https://markets.ft.com/data/portfolio/dashboard"]`,
         { text: 'Portfolio' }
       )
+
+      await expect(page).not.toMatchElement('.o-header__nav-link a[href$="/myft"]', { text: 'myFT Feed' })
     })
   })
 })

--- a/examples/ft-ui/__test__/logged-in-user.test.js
+++ b/examples/ft-ui/__test__/logged-in-user.test.js
@@ -6,9 +6,9 @@ describe('examples/ft-ui', () => {
 
   describe('Header link elements', () => {
     it('renders the expected loggin-in user Header link elements', async () => {
-      await expect(page).toMatchElement('.o-header__top-column--right a[href$="/myft"]', { text: 'myFT' })
-      await expect(page).toMatchElement('.o-header__nav-list--right a[href$="/myaccount"]', {
-        text: 'Settings & Account'
+      await expect(page).toMatchElement('.o-header__nav-item a[href$="/myft"]', { text: 'myFT Feed' })
+      await expect(page).toMatchElement('.o-header__top-column--right a[href$="/myaccount"]', {
+        text: 'My Account'
       })
 
       await expect(page).toMatchElement(

--- a/examples/ft-ui/__test__/subscribed-user.test.js
+++ b/examples/ft-ui/__test__/subscribed-user.test.js
@@ -6,9 +6,9 @@ describe('examples/ft-ui', () => {
 
   describe('Header link elements', () => {
     it('renders the expected loggin-in user Header link elements', async () => {
-      await expect(page).toMatchElement('.o-header__top-column--right a[href$="/myft"]', { text: 'myFT' })
-      await expect(page).toMatchElement('.o-header__nav-list--right a[href$="/myaccount"]', {
-        text: 'Settings & Account'
+      await expect(page).toMatchElement('.o-header__nav-item a[href$="/myft"]', { text: 'myFT Feed' })
+      await expect(page).toMatchElement('.o-header__top-column--right a[href$="/myaccount"]', {
+        text: 'My Account'
       })
 
       await expect(page).toMatchElement(

--- a/examples/kitchen-sink/__test__/integration.test.js
+++ b/examples/kitchen-sink/__test__/integration.test.js
@@ -21,7 +21,7 @@ describe('examples/kitchen-sink/integration', () => {
     expect(response.text).toContain('data-trackable="logo" href="/"')
   })
 
-  it('renders the header top components; search, menu and myFT', () => {
+  it('renders the header top components; search and menu', () => {
     expect(response.text).toContain('data-trackable="search-toggle">')
     expect(response.text).toContain('data-trackable="drawer-toggle"')
   })

--- a/packages/dotcom-server-navigation/src/__test__/selectMenuDataForEdition.spec.ts
+++ b/packages/dotcom-server-navigation/src/__test__/selectMenuDataForEdition.spec.ts
@@ -10,6 +10,8 @@ const fixture = {
   'navbar-simple': {},
   'navbar-right': {},
   'navbar-right-anon': {},
+  'navbar-top-right': {},
+  'navbar-top-right-anon': {},
   'navbar-international': {},
   'navbar-uk': {},
   user: {}

--- a/packages/dotcom-server-navigation/src/selectMenuDataForEdition.ts
+++ b/packages/dotcom-server-navigation/src/selectMenuDataForEdition.ts
@@ -7,6 +7,8 @@ const sharedMenuKeys: TNavMenuKeys[] = [
   'navbar-simple',
   'navbar-right',
   'navbar-right-anon',
+  'navbar-top-right',
+  'navbar-top-right-anon',
   'user'
 ]
 

--- a/packages/dotcom-types-navigation/index.d.ts
+++ b/packages/dotcom-types-navigation/index.d.ts
@@ -8,6 +8,8 @@ export type TNavMenuKeys =
   | 'navbar-uk'
   | 'navbar-right'
   | 'navbar-right-anon'
+  | 'navbar-top-right'
+  | 'navbar-top-right-anon'
   | 'navbar-simple'
   | 'user'
 
@@ -19,6 +21,8 @@ export type TNavMenuKeysForEdition =
   | 'navbar'
   | 'navbar-right'
   | 'navbar-right-anon'
+  | 'navbar-top-right'
+  | 'navbar-top-right-anon'
   | 'navbar-simple'
   | 'user'
 

--- a/packages/dotcom-ui-footer/src/__stories__/story-data.ts
+++ b/packages/dotcom-ui-footer/src/__stories__/story-data.ts
@@ -13,6 +13,8 @@ const fixture: TFooterProps = {
     navbar: null,
     'navbar-right': null,
     'navbar-right-anon': null,
+    'navbar-top-right': null,
+    'navbar-top-right-anon': null,
     'navbar-simple': null,
     subsections: null,
     user: null

--- a/packages/dotcom-ui-header/src/__stories__/story-data/index.ts
+++ b/packages/dotcom-ui-header/src/__stories__/story-data/index.ts
@@ -4,6 +4,8 @@ import actionsUK from './actionsUK'
 import editionsUK from './editionsUK'
 import navbarRight from './navbarRight'
 import navbarRightAnon from './navbarRightAnon'
+import navbarTopRight from './navbarTopRight'
+import navbarTopRightAnon from './navbarTopRightAnon'
 import navbarSimple from './navbarSimple'
 import navbarUK from './navbarUK'
 import subNavigation from './subNavigationUK'
@@ -31,6 +33,8 @@ const data: THeaderProps = {
     navbar: navbarUK,
     'navbar-right': navbarRight,
     'navbar-right-anon': navbarRightAnon,
+    'navbar-top-right': navbarTopRight,
+    'navbar-top-right-anon': navbarTopRightAnon,
     'navbar-simple': navbarSimple,
     subsections,
     'subsections-right': [],

--- a/packages/dotcom-ui-header/src/__stories__/story-data/navbarRight.ts
+++ b/packages/dotcom-ui-header/src/__stories__/story-data/navbarRight.ts
@@ -9,8 +9,8 @@ const data: TNavMenu = {
       submenu: null
     },
     {
-      label: 'Settings & Account',
-      url: 'https://www.ft.com/myaccount',
+      label: 'myFT Feed',
+      url: 'https://www.ft.com/myft',
       submenu: null
     }
   ]

--- a/packages/dotcom-ui-header/src/__stories__/story-data/navbarTopRight.ts
+++ b/packages/dotcom-ui-header/src/__stories__/story-data/navbarTopRight.ts
@@ -1,0 +1,19 @@
+import { TNavMenu } from '@financial-times/dotcom-types-navigation'
+
+const data: TNavMenu = {
+  label: 'Navigation',
+  items: [
+    {
+      label: 'My Account',
+      url: '/myaccount',
+      submenu: null
+    },
+    {
+      label: 'Subscribe',
+      url: '/products?segmentId=#',
+      submenu: null
+    }
+  ]
+}
+
+export default data

--- a/packages/dotcom-ui-header/src/__stories__/story-data/navbarTopRightAnon.ts
+++ b/packages/dotcom-ui-header/src/__stories__/story-data/navbarTopRightAnon.ts
@@ -1,0 +1,19 @@
+import { TNavMenu } from '@financial-times/dotcom-types-navigation'
+
+const data: TNavMenu = {
+  label: 'Navigation',
+  items: [
+    {
+      label: 'Sign In',
+      url: '/login?location=#',
+      submenu: null
+    },
+    {
+      label: 'Subscribe',
+      url: '/products?segmentId=#',
+      submenu: null
+    }
+  ]
+}
+
+export default data

--- a/packages/dotcom-ui-header/src/__stories__/story-data/profile.ts
+++ b/packages/dotcom-ui-header/src/__stories__/story-data/profile.ts
@@ -3,6 +3,8 @@ import drawerUK from './drawerUK'
 import editionsUK from './editionsUK'
 import navbarRight from './navbarRight'
 import navbarRightAnon from './navbarRightAnon'
+import navbarTopRight from './navbarTopRight'
+import navbarTopRightAnon from './navbarTopRightAnon'
 import navbarSimple from './navbarSimple'
 import navbarUK from './navbarUK'
 import subNavigation from './subNavigationProfile'
@@ -29,6 +31,8 @@ const data: THeaderProps = {
     navbar: navbarUK,
     'navbar-right': navbarRight,
     'navbar-right-anon': navbarRightAnon,
+    'navbar-top-right': navbarTopRight,
+    'navbar-top-right-anon': navbarTopRightAnon,
     'navbar-simple': navbarSimple,
     subsections,
     'subsections-right': [

--- a/packages/dotcom-ui-header/src/__stories__/story.tsx
+++ b/packages/dotcom-ui-header/src/__stories__/story.tsx
@@ -56,48 +56,6 @@ DefaultHeaderWithDrawer.args = {
   showAskButton: false
 }
 
-export const DefaultHeaderWithDrawerEntryTestAnon = (args) => (
-  <OnReady callback={onReadyCallback}>
-    <HeaderSimple {...storyData} {...args} />
-    <Drawer {...storyData} {...args} />
-  </OnReady>
-)
-
-DefaultHeaderWithDrawerEntryTestAnon.story = {
-  name: 'Default header with drawer - Account entry test [Anon]'
-}
-DefaultHeaderWithDrawerEntryTestAnon.args = {
-  showSubNavigation: true,
-  showMegaNav: true,
-  showUserNavigation: true,
-  userIsLoggedIn: false,
-  userIsSubscribed: false,
-  showLogoLink: false,
-  experimentalAccountEntryTest: true,
-  showAskButton: false
-}
-
-export const DefaultHeaderWithDrawerEntryTest = (args) => (
-  <OnReady callback={onReadyCallback}>
-    <HeaderSimple {...storyData} {...args} />
-    <Drawer {...storyData} {...args} />
-  </OnReady>
-)
-
-DefaultHeaderWithDrawerEntryTest.story = {
-  name: 'Default header with drawer - Account entry test'
-}
-DefaultHeaderWithDrawerEntryTest.args = {
-  showSubNavigation: true,
-  showMegaNav: true,
-  showUserNavigation: true,
-  userIsLoggedIn: true,
-  userIsSubscribed: false,
-  showLogoLink: false,
-  experimentalAccountEntryTest: true,
-  showAskButton: false
-}
-
 export const DefaultHeaderWithRightAlignedSubnav = (args) => (
   <OnReady callback={onReadyCallback}>
     <HeaderSimple {...profileStoryData} {...args} />

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -100,17 +100,13 @@ exports[`dotcom-ui-header/src/components/MainHeader renders ASK FT button 1`] = 
             Subscribe
           </a>
           <a
-            aria-label="My F T"
-            className="o-header__top-icon-link o-header__top-icon-link--myft "
-            data-tour-stage="myFt"
-            data-trackable="my-ft"
-            href="/myft"
-            id="o-header-top-link-myft"
+            className="o-header__top-link ft-header__top-link--myaccount"
+            data-trackable="My Account"
+            href="/myaccount"
+            id="o-header-top-link-myaccount"
           >
-            <span
-              className="o-header__visually-hidden"
-            >
-              myFT
+            <span>
+              My Account
             </span>
           </a>
         </div>
@@ -1948,17 +1944,13 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
             Subscribe
           </a>
           <a
-            aria-label="My F T"
-            className="o-header__top-icon-link o-header__top-icon-link--myft "
-            data-tour-stage="myFt"
-            data-trackable="my-ft"
-            href="/myft"
-            id="o-header-top-link-myft"
+            className="o-header__top-link ft-header__top-link--myaccount"
+            data-trackable="My Account"
+            href="/myaccount"
+            id="o-header-top-link-myaccount"
           >
-            <span
-              className="o-header__visually-hidden"
-            >
-              myFT
+            <span>
+              My Account
             </span>
           </a>
         </div>
@@ -3791,17 +3783,13 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
             Subscribe
           </a>
           <a
-            aria-label="My F T"
-            className="o-header__top-icon-link o-header__top-icon-link--myft "
-            data-tour-stage="myFt"
-            data-trackable="my-ft"
-            href="/myft"
-            id="o-header-top-link-myft"
+            className="o-header__top-link ft-header__top-link--myaccount"
+            data-trackable="My Account"
+            href="/myaccount"
+            id="o-header-top-link-myaccount"
           >
-            <span
-              className="o-header__visually-hidden"
-            >
-              myFT
+            <span>
+              My Account
             </span>
           </a>
         </div>
@@ -5639,24 +5627,13 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
             Subscribe
           </a>
           <a
-            className="o-header__top-link o-header__top-link--hide-m"
+            className="o-header__top-link ft-header__top-link--myaccount"
             data-trackable="Sign In"
             href="/login?location=#"
+            id="o-header-top-link-signin"
           >
-            Sign In
-          </a>
-          <a
-            aria-label="My F T"
-            className="o-header__top-icon-link o-header__top-icon-link--myft o-header__top-icon-link--show-m"
-            data-tour-stage="myFt"
-            data-trackable="my-ft"
-            href="/myft"
-            id="o-header-top-link-myft"
-          >
-            <span
-              className="o-header__visually-hidden"
-            >
-              myFT
+            <span>
+              Sign In
             </span>
           </a>
         </div>

--- a/packages/dotcom-ui-header/src/__test__/output/component.spec.tsx
+++ b/packages/dotcom-ui-header/src/__test__/output/component.spec.tsx
@@ -32,10 +32,6 @@ describe('dotcom-ui-header', () => {
 
     const logo = container.querySelector('div[data-trackable="header-top"] .o-header__top-logo')
     expect(logo?.hasChildNodes()).toBe(true)
-
-    const myFtLink = container.querySelector('div[data-trackable="header-top"] .o-header__top-icon-link--myft')
-    expect(myFtLink?.innerHTML).toContain('myFT')
-
   })
 
   it('renders an inlined SVG logo image', () => {
@@ -64,7 +60,8 @@ describe('dotcom-ui-header', () => {
       const { container } = render(subscribedUserHeader)
 
       expect(container.querySelector('a[data-trackable="Portfolio"]')).not.toBeNull()
-      expect(container.querySelector('a[data-trackable="Settings & Account"]')).not.toBeNull()
+      expect(container.querySelector('a[data-trackable="My Account"]')).not.toBeNull()
+      expect(container.querySelector('a[data-trackable="myFT Feed"]')).not.toBeNull()
     })
 
     it('does not render sign in link', () => {
@@ -80,7 +77,8 @@ describe('dotcom-ui-header', () => {
       const { container } = render(loggedInUserHeader)
 
       expect(container.querySelector('a[data-trackable="Portfolio"]')).not.toBeNull()
-      expect(container.querySelector('a[data-trackable="Settings & Account"]')).not.toBeNull()
+      expect(container.querySelector('a[data-trackable="My Account"]')).not.toBeNull()
+      expect(container.querySelector('a[data-trackable="myFT Feed"]')).not.toBeNull()
     })
 
     it('does not render sign in link', () => {
@@ -96,10 +94,14 @@ describe('dotcom-ui-header', () => {
       const { container } = render(anonymousUserHeader)
 
       expect(
-        container.querySelector('.o-header__top-column .o-header__top-column--right a[data-trackable="Subscribe"]')
+        container.querySelector(
+          '.o-header__top-column .o-header__top-column--right a[data-trackable="Subscribe"]'
+        )
       ).not.toBeNull()
-     expect(
-        container.querySelector('.o-header__top-column .o-header__top-column--right a[data-trackable="Sign In"]')
+      expect(
+        container.querySelector(
+          '.o-header__top-column .o-header__top-column--right a[data-trackable="Sign In"]'
+        )
       ).not.toBeNull()
     })
 
@@ -107,7 +109,8 @@ describe('dotcom-ui-header', () => {
       const { container } = render(anonymousUserHeader)
 
       expect(container.querySelector('a[data-trackable="Portfolio"]')).toBeNull()
-      expect(container.querySelector('a[data-trackable="Settings & Account"]')).toBeNull()
+      expect(container.querySelector('a[data-trackable="My Account"]')).toBeNull()
+      expect(container.querySelector('a[data-trackable="myFT Feed"]')).toBeNull()
     })
   })
 })

--- a/packages/dotcom-ui-header/src/components/navigation/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/navigation/partials.tsx
@@ -80,23 +80,15 @@ const NavListRight = (props: THeaderProps) => {
   return props.userIsLoggedIn ? (
     <NavListRightLoggedIn
       items={props.data['navbar-right'].items}
-      experimentalAccountEntryTest={props.experimentalAccountEntryTest}
     />
   ) : null
 }
 
 const NavListRightLoggedIn = ({
   items,
-  experimentalAccountEntryTest
 }: {
   items: TNavMenuItem[]
-  experimentalAccountEntryTest?: boolean
 }) => {
-  /**
-   * Accounts entry test
-   * In this rendering theres a hacky solution to replace "Settings & Account" with "MyFT Feed"
-   * Once the test is concluded the real data should be updated accordingly and the hack removed
-   */
   return (
     <ul
       data-component="nav-list--right"
@@ -105,15 +97,9 @@ const NavListRightLoggedIn = ({
     >
       {items.map((item, index) => (
         <li className="o-header__nav-item" key={`link-${index}`}>
-          {item.label === 'Settings & Account' && experimentalAccountEntryTest ? (
-            <a className="o-header__nav-link" href="/myft" data-trackable="my-ft">
-              myFT Feed
-            </a>
-          ) : (
             <a className="o-header__nav-link" href={item.url ?? undefined} data-trackable={item.label}>
               {item.label}
             </a>
-          )}
         </li>
       ))}
     </ul>

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -40,32 +40,15 @@ const SearchIcon = () => (
   </a>
 )
 
-const MyAccountLink = ({ signedIn }: { signedIn: boolean }) => {
+const MyAccountLink = ({ item, signedIn }: { item: TNavMenuItem; signedIn: boolean }) => {
   const classNames = 'o-header__top-link ft-header__top-link--myaccount'
+  const id = signedIn ? 'o-header-top-link-myaccount' : 'o-header-top-link-signin'
 
-  if (signedIn) {
-    return (
-      <a
-        className={classNames}
-        id="o-header-top-link-myaccount"
-        href="/myaccount"
-        data-trackable="my-account"
-      >
-        <span>My Account</span>
-      </a>
-    )
-  } else {
-    return (
-      <a
-        className={classNames}
-        id="o-header-top-link-signin"
-        href="/login?location=/"
-        data-trackable="Sign In"
-      >
-        <span>Sign In</span>
-      </a>
-    )
-  }
+  return (
+    <a className={classNames} id={id} href={item.url || undefined} data-trackable={item.label}>
+      <span>{item.label}</span>
+    </a>
+  )
 }
 
 const TopWrapper = (props) => (
@@ -109,7 +92,8 @@ const TopColumnCenterNoLink = () => (
 )
 
 const TopColumnRightLoggedIn = (props: THeaderProps) => {
-  const subscribeAction = props.data['navbar-right-anon']?.items?.[1]
+  const signInAction = props.data['navbar-top-right']?.items?.[0]
+  const subscribeAction = props.data['navbar-top-right']?.items?.[1]
   return (
     <div className="o-header__top-column o-header__top-column--right">
       {!props.userIsSubscribed && subscribeAction && (
@@ -119,7 +103,7 @@ const TopColumnRightLoggedIn = (props: THeaderProps) => {
           className="o-header__top-button--hide-m"
         />
       )}
-      <MyAccountLink signedIn={true} />
+      {signInAction && <MyAccountLink item={signInAction} signedIn={true} />}
     </div>
   )
 }
@@ -170,13 +154,7 @@ const SubscribeButton = ({
   )
 }
 
-const TopColumnRightAnon = ({
-  items,
-  variant,
-}: {
-  items: TNavMenuItem[]
-  variant?: string
-}) => {
+const TopColumnRightAnon = ({ items, variant }: { items: TNavMenuItem[]; variant?: string }) => {
   // If user is anonymous the second list item is styled as a button
   const [signInAction, subscribeAction] = items
 
@@ -185,7 +163,7 @@ const TopColumnRightAnon = ({
       {subscribeAction && (
         <SubscribeButton item={subscribeAction} variant={variant} className="o-header__top-button--hide-m" />
       )}
-      <MyAccountLink signedIn={false} />
+      {signInAction && <MyAccountLink item={signInAction} signedIn={false} />}
     </div>
   )
 }
@@ -194,13 +172,8 @@ const TopColumnRight = (props: THeaderProps) => {
   if (props.userIsLoggedIn) {
     return <TopColumnRightLoggedIn {...props} />
   } else {
-    const userNavAnonItems = props.data['navbar-right-anon'].items
-    return (
-      <TopColumnRightAnon
-        items={userNavAnonItems}
-        variant={props.variant}
-      />
-    )
+    const userNavAnonItems = props.data['navbar-top-right-anon'].items
+    return <TopColumnRightAnon items={userNavAnonItems} variant={props.variant} />
   }
 }
 

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -40,35 +40,6 @@ const SearchIcon = () => (
   </a>
 )
 
-const TopRightAccountEntry = ({
-  className,
-  signedIn,
-  experimentalAccountEntryTest
-}: {
-  className?: string
-  signedIn: boolean
-  experimentalAccountEntryTest?: boolean
-}) => {
-  if (experimentalAccountEntryTest) {
-    return <MyAccountLink signedIn={signedIn} />
-  } else {
-    return <MyFtLogoLink className={className} />
-  }
-}
-
-const MyFtLogoLink = ({ className }: { className?: string }) => (
-  <a
-    className={`o-header__top-icon-link o-header__top-icon-link--myft ${className}`}
-    id="o-header-top-link-myft"
-    href="/myft"
-    data-trackable="my-ft"
-    data-tour-stage="myFt"
-    aria-label="My F T"
-  >
-    <span className="o-header__visually-hidden">myFT</span>
-  </a>
-)
-
 const MyAccountLink = ({ signedIn }: { signedIn: boolean }) => {
   const classNames = 'o-header__top-link ft-header__top-link--myaccount'
 
@@ -148,11 +119,7 @@ const TopColumnRightLoggedIn = (props: THeaderProps) => {
           className="o-header__top-button--hide-m"
         />
       )}
-      <TopRightAccountEntry
-        className=""
-        signedIn={true}
-        experimentalAccountEntryTest={props.experimentalAccountEntryTest}
-      />
+      <MyAccountLink signedIn={true} />
     </div>
   )
 }
@@ -206,11 +173,9 @@ const SubscribeButton = ({
 const TopColumnRightAnon = ({
   items,
   variant,
-  experimentalAccountEntryTest
 }: {
   items: TNavMenuItem[]
   variant?: string
-  experimentalAccountEntryTest?: boolean
 }) => {
   // If user is anonymous the second list item is styled as a button
   const [signInAction, subscribeAction] = items
@@ -220,14 +185,7 @@ const TopColumnRightAnon = ({
       {subscribeAction && (
         <SubscribeButton item={subscribeAction} variant={variant} className="o-header__top-button--hide-m" />
       )}
-      {signInAction && !experimentalAccountEntryTest && (
-        <SignInLink item={signInAction} variant={variant} className="o-header__top-link--hide-m" />
-      )}
-      <TopRightAccountEntry
-        className="o-header__top-icon-link--show-m"
-        signedIn={false}
-        experimentalAccountEntryTest={experimentalAccountEntryTest}
-      />
+      <MyAccountLink signedIn={false} />
     </div>
   )
 }
@@ -241,7 +199,6 @@ const TopColumnRight = (props: THeaderProps) => {
       <TopColumnRightAnon
         items={userNavAnonItems}
         variant={props.variant}
-        experimentalAccountEntryTest={props.experimentalAccountEntryTest}
       />
     )
   }

--- a/packages/dotcom-ui-header/src/interfaces.d.ts
+++ b/packages/dotcom-ui-header/src/interfaces.d.ts
@@ -11,12 +11,6 @@ export type THeaderOptions = {
   showMegaNav?: boolean
   showLogoLink?: boolean
   showAskButton?: boolean
-  /*
-   * experimentalAccountEntryTest is an experimental feature switch
-   * This is being run as an AB test and should be removed afterwards
-   * This option shouldn't be used by anyone without consulting the CP Retention team first
-   */
-  experimentalAccountEntryTest?: boolean
 }
 
 export type THeaderProps = THeaderOptions & {


### PR DESCRIPTION
# Description

Roll out the variant of the `experimentalAccountEntryTest` AB test as the default permanent behaviour

### Justification

In early 2024 the Retention team ran an AB test to try and improve the user experience of the header by trying to reduce confusion of the difference between Settings & Account and myFT. This test was successful so we are now rolling these changes out to all users. The changes that are relevant to this PR are

1. Rename `Settings & Account` to `My Account`
2. Rename `myFT` to `myFT Feed`
3. Move My Account to the top right slot, replacing the myFT logo
4. Move myFT to the bottom right slot, replacing the old Settings & Account link


### Screenshots
 
 **Anonymous user - Previous layout**

![Screenshot of the FT header as seen by an anonymous user in the test control](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/e4400267-c55c-4ad1-8ba7-d21db826423b)
 
  **Anonymous user - New layout**  
  
![Screenshot of the FT header as seen by an anonymous user in the test variant](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/70e9aa8b-6228-480f-97b2-37eba0ef1ab6)

  **Signed in user - Previous layout**
  
  
![Screenshot of the FT header as seen by an registered user in the test control](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/210f0b4d-c815-4339-a436-a197fb6aa783)

  **Signed in user - New layout**
  
![Screenshot of the FT header as seen by an regustered user in the test variant](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/b24475f5-6c76-4e72-8499-ecb3d85ca6dc)


### Reviewer considerations

1. This relates to the following PRs
a.[ Original AB Test PR](https://github.com/Financial-Times/dotcom-page-kit/pull/1017)
b. [Origami navigation service data changes](https://github.com/Financial-Times/origami-navigation-service/pull/922)
2. In this PR I am focusing on the data and markup changes, moving any css into origami will going to come in a follow up PR to keep changes as small as possible
3. You can see the data changes on https://next-navigation.ft.com/v2/menus


### Ticket
https://financialtimes.atlassian.net/browse/ACC-3083