### PR TITLE
ADSDEV-1856/Remove-references-to-smartmatch

### DIFF
--- a/examples/kitchen-sink/client/main.js
+++ b/examples/kitchen-sink/client/main.js
@@ -56,8 +56,7 @@ readyState.domready.then(async () => {
         {
           ...displayAdsOptions,
           targeting: adsData.metadata,
-          adUnit: adsData.adUnit,
-          smartmatch: flagsClient.get('adsEnableSmartmatchInTargeting') && adsData.smartmatch
+          adUnit: adsData.adUnit
         },
         flagsClient
       )

--- a/examples/kitchen-sink/server/controllers/home.js
+++ b/examples/kitchen-sink/server/controllers/home.js
@@ -22,7 +22,6 @@ const flagsStore = {
   ads: true,
   tracking: true,
   oTracking: true,
-  adsEnableSmartmatchInTargeting: true,
   AdsPermutive: true,
   moatAdsTraffic: true,
   adsEnableTestCreatives: false


### PR DESCRIPTION
[Jira Ticket](https://financialtimes.atlassian.net/jira/software/c/projects/ADSDEV/boards/803?selectedIssue=ADSDEV-1856)

As we are no longer using SmartMatch as a product, the endpoint that populates `smartmatch.creative.matches` is being decommissioned by Smartology. 

With this in mind, and given the findings from this [Spike Ticket](https://financialtimes.atlassian.net/jira/software/c/projects/ADSDEV/boards/803?selectedIssue=ADSDEV-1825) this PR removes all references to SmartMatch from `dotcom-page-kit`. 

# Description

This PR removes references to smartmatch in an example. 

# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [x] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [x] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [x] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
