### PR TITLE
Update My Account header styles to latest o-header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2675,9 +2675,9 @@
       }
     },
     "node_modules/@financial-times/o-header": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-11.1.1.tgz",
-      "integrity": "sha512-5qjwoywMjLrKE7RqaCqPduAF4TcnMT7Uz+Cm72nFBsdkuHWC0d1pWvYCAPSdRupnqutzxzXFb4mu5SP0LRK/7Q==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-12.0.0.tgz",
+      "integrity": "sha512-FRYJlaJvmJukO1yH1KnNETxT3RK5l+4lKUXtzvwT2N5Qr7PfqvtFKbALjlFZb35EfaA45bSVE9BOZF3DwazO3Q==",
       "dev": true,
       "engines": {
         "npm": ">7"
@@ -34312,7 +34312,7 @@
       },
       "devDependencies": {
         "@financial-times/logo-images": "^1.10.1",
-        "@financial-times/o-header": "^11.0.4",
+        "@financial-times/o-header": "^12.0.0",
         "@svgr/core": "^5.0.0",
         "camelcase": "^6.0.0",
         "check-engine": "^1.10.1"

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -30,7 +30,7 @@
     "@svgr/core": "^5.0.0",
     "camelcase": "^6.0.0",
     "check-engine": "^1.10.1",
-    "@financial-times/o-header": "^11.0.4"
+    "@financial-times/o-header": "^12.0.0"
   },
   "peerDependencies": {
     "@financial-times/o-header": "^11.0.4",

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -101,7 +101,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders ASK FT button 1`] = 
             Subscribe
           </a>
           <a
-            className="o-header__top-link ft-header__top-link--myaccount"
+            className="o-header__top-myaccount"
             data-trackable="My Account"
             href="/myaccount"
             id="o-header-top-link-myaccount"
@@ -1945,7 +1945,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
             Subscribe
           </a>
           <a
-            className="o-header__top-link ft-header__top-link--myaccount"
+            className="o-header__top-myaccount"
             data-trackable="My Account"
             href="/myaccount"
             id="o-header-top-link-myaccount"
@@ -3784,7 +3784,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
             Subscribe
           </a>
           <a
-            className="o-header__top-link ft-header__top-link--myaccount"
+            className="o-header__top-myaccount"
             data-trackable="My Account"
             href="/myaccount"
             id="o-header-top-link-myaccount"
@@ -5628,7 +5628,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
             Subscribe
           </a>
           <a
-            className="o-header__top-link ft-header__top-link--myaccount"
+            className="o-header__top-myaccount"
             data-trackable="Sign In"
             href="/login?location=#"
             id="o-header-top-link-signin"

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -41,7 +41,7 @@ const SearchIcon = () => (
 )
 
 const MyAccountLink = ({ item, signedIn }: { item: TNavMenuItem; signedIn: boolean }) => {
-  const classNames = 'o-header__top-link ft-header__top-link--myaccount'
+  const classNames = 'o-header__top-myaccount'
   const id = signedIn ? 'o-header-top-link-myaccount' : 'o-header-top-link-signin'
 
   return (

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -28,42 +28,6 @@
   display: none;
 }
 
-// The styles below are part of an AB test
-// If the test is successful these should be incorporated into o-header
-.ft-header__top-link--myaccount {
-  @include oTypographySans(0);
-}
-
-
-.ft-header__top-link--myaccount span {
-  vertical-align: middle;
-  // Hide the myaccount/sign in text on smaller screens leaving the icon only
-  @include oGridRespondTo($until: 'M') {
-    @include oNormaliseVisuallyHidden;
-  }
-}
-
-// Override the hover styles so the underline
-// Is only under the text and not the icon
-// And is closer to the text
-.ft-header__top-link--myaccount::after {
-  width: calc(100% - 32px);
-  left: unset;
-  right: 0;
-  bottom: 8px;
-}
-
-.ft-header__top-link--myaccount::before {
-  content: '';
-  display: block;
-  @include oIconsContent(
-		$icon-name: 'user',
-		$color: oColorsByName('black'),
-		$size: 32
-	);
-  vertical-align: middle;
-}
-
 .o-header__drawer-search-term {
   width: 100%;
 }


### PR DESCRIPTION
## Description

Use o-header to style the new My Account & Sign in links

### Justification

These new links were added as part of an AB test. At that stage we hardcoded the styles within this repo but now that the test has proven successful we have moved the styles into o-header

### Extra notes

This is a follow up PR to https://github.com/Financial-Times/dotcom-page-kit/pull/1035 which contains additional details about this change and rollout

### Ticket

https://financialtimes.atlassian.net/browse/ACC-3083
