### PR TITLE
fix: Update o-header peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,8 +59,8 @@
         "typescript": "4.1.6"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       }
     },
     "examples/building-sass-files": {
@@ -34143,8 +34143,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "webpack": "^4.39.2"
@@ -34167,8 +34167,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "dateformat": "^3.0.0 || ^4.0.0",
@@ -34197,8 +34197,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "webpack": "^4.39.2"
@@ -34225,8 +34225,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "webpack": "^4.39.2"
@@ -34254,8 +34254,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "webpack": "^4.39.2"
@@ -34276,8 +34276,8 @@
         "node-mocks-http": "^1.7.5"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       }
     },
     "packages/dotcom-middleware-asset-loader": {
@@ -34296,8 +34296,8 @@
         "node-mocks-http": "^1.7.3"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       }
     },
     "packages/dotcom-middleware-navigation": {
@@ -34314,8 +34314,8 @@
         "node-mocks-http": "^1.7.3"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       }
     },
     "packages/dotcom-server-app-context": {
@@ -34331,8 +34331,8 @@
         "json-schema-to-markdown": "^1.1.0"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       }
     },
     "packages/dotcom-server-asset-loader": {
@@ -34347,8 +34347,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       }
     },
     "packages/dotcom-server-handlebars": {
@@ -34367,8 +34367,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "react": "17.x || 18.x",
@@ -34402,8 +34402,8 @@
         "nock": "^12.0.0"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       }
     },
     "packages/dotcom-server-navigation/node_modules/depd": {
@@ -34446,8 +34446,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "react": "17.x || 18.x",
@@ -34463,8 +34463,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       }
     },
     "packages/dotcom-ui-app-context": {
@@ -34479,8 +34479,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       }
     },
     "packages/dotcom-ui-base-styles": {
@@ -34496,8 +34496,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "@financial-times/o-typography": "^7.2.0",
@@ -34517,8 +34517,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "react": "17.x || 18.x"
@@ -34590,8 +34590,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "react": "17.x || 18.x"
@@ -34609,8 +34609,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "react": "17.x || 18.x",
@@ -34630,8 +34630,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "@financial-times/o-footer": "^9.2.0",
@@ -34656,12 +34656,12 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "@financial-times/logo-images": "^1.10.1",
-        "@financial-times/o-header": "^11.0.4",
+        "@financial-times/o-header": "^12.0.0",
         "n-ui-foundations": "^9.0.0 || ^10.0.0",
         "react": "17.x || 18.x",
         "react-dom": "17.x || 18.x"
@@ -34695,8 +34695,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "n-ui-foundations": "^9.0.0 || ^10.0.0",
@@ -34734,8 +34734,8 @@
         "check-engine": "^1.10.1"
       },
       "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
+        "node": "18.x || 20.x",
+        "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
         "react": "17.x || 18.x",

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -33,7 +33,7 @@
     "@financial-times/o-header": "^12.0.0"
   },
   "peerDependencies": {
-    "@financial-times/o-header": "^11.0.4",
+    "@financial-times/o-header": "^12.0.0",
     "@financial-times/logo-images": "^1.10.1",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x",


### PR DESCRIPTION
In v9.5.0 I managed to miss updating the peer dependency for o-header.

This ensure thats the correct version is now being used in v10