### PR TITLE
fix: Update o-header peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34323,7 +34323,7 @@
       },
       "peerDependencies": {
         "@financial-times/logo-images": "^1.10.1",
-        "@financial-times/o-header": "^11.0.4",
+        "@financial-times/o-header": "^12.0.0",
         "n-ui-foundations": "^9.0.0 || ^10.0.0",
         "react": "17.x || 18.x",
         "react-dom": "17.x || 18.x"

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -33,7 +33,7 @@
     "@financial-times/o-header": "^12.0.0"
   },
   "peerDependencies": {
-    "@financial-times/o-header": "^11.0.4",
+    "@financial-times/o-header": "^12.0.0",
     "@financial-times/logo-images": "^1.10.1",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x",


### PR DESCRIPTION
In v9.5.0 I managed to miss updating the peer dependency for o-header.

This ensure thats the correct version is now being used in v9.5.1 and above
