### PR TITLE
CON-3426: design changes ask button, edition switcher, subscribe button

### DIFF
--- a/examples/ft-ui/__test__/integration.test.js
+++ b/examples/ft-ui/__test__/integration.test.js
@@ -61,7 +61,7 @@ describe('examples/ft-ui', () => {
     })
 
     it('renders the drawer menu', async () => {
-      await expect(page).toMatchElement('#o-header-drawer', { text: 'Switch to International Edition' })
+      await expect(page).toMatchElement('#o-header-drawer', { text: 'International' })
       await expect(page).toMatchElement(
         '#o-header-drawer',
         { text: 'Top sections' },

--- a/examples/kitchen-sink/__test__/integration.test.js
+++ b/examples/kitchen-sink/__test__/integration.test.js
@@ -1,5 +1,6 @@
 const app = require('../server/app')
 const request = require('supertest')
+const React = require("react");
 
 describe('examples/kitchen-sink/integration', () => {
   let response
@@ -47,7 +48,7 @@ describe('examples/kitchen-sink/integration', () => {
   })
 
   it('renders edition with current edition selected', () => {
-    expect(response.text).toContain('<p class="o-header__drawer-current-edition">International Edition</p>')
+    expect(response.text).toContain('<span class="current-edition">International Edition</span>')
   })
 
   it('renders app context data as embedded JSON', () => {

--- a/examples/kitchen-sink/__test__/integration.test.js
+++ b/examples/kitchen-sink/__test__/integration.test.js
@@ -47,7 +47,7 @@ describe('examples/kitchen-sink/integration', () => {
   })
 
   it('renders edition with current edition selected', () => {
-    expect(response.text).toContain('<span class="current-edition">International Edition</span>')
+    expect(response.text).toContain('<span class="o-header__drawer-menu-item o-header__drawer-current-edition">International</span>')
   })
 
   it('renders app context data as embedded JSON', () => {

--- a/examples/kitchen-sink/__test__/integration.test.js
+++ b/examples/kitchen-sink/__test__/integration.test.js
@@ -1,6 +1,5 @@
 const app = require('../server/app')
 const request = require('supertest')
-const React = require("react");
 
 describe('examples/kitchen-sink/integration', () => {
   let response

--- a/package-lock.json
+++ b/package-lock.json
@@ -2667,6 +2667,33 @@
         "@financial-times/o-viewport": "^5.0.0"
       }
     },
+    "node_modules/@financial-times/o-forms": {
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.12.1.tgz",
+      "integrity": "sha512-qnlLZYwdysDt7HNRZjy890gQZ+bWRBAAIGra/qm5MjXO2D23R1+3L+WUZLQ62Xo5kEmp0k2e2wjoj2oANNLXFg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/lodash.uniqueid": "^4.0.7",
+        "lodash.uniqueid": "^4.0.1"
+      },
+      "engines": {
+        "npm": ">7"
+      },
+      "peerDependencies": {
+        "@financial-times/math": "^1.0.0",
+        "@financial-times/o-brand": "^4.1.0",
+        "@financial-times/o-buttons": "^7.2.0",
+        "@financial-times/o-colors": "^6.5.0",
+        "@financial-times/o-grid": "^6.0.0",
+        "@financial-times/o-icons": "^7.0.0",
+        "@financial-times/o-loading": "^5.0.0",
+        "@financial-times/o-normalise": "^3.3.0",
+        "@financial-times/o-spacing": "^3.0.0",
+        "@financial-times/o-typography": "^7.4.1",
+        "@financial-times/o-utils": "^2.2.0"
+      }
+    },
     "node_modules/@financial-times/o-grid": {
       "version": "6.1.8",
       "resolved": "https://registry.npmjs.org/@financial-times/o-grid/-/o-grid-6.1.8.tgz",
@@ -2681,9 +2708,9 @@
       }
     },
     "node_modules/@financial-times/o-header": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-12.0.0.tgz",
-      "integrity": "sha512-FRYJlaJvmJukO1yH1KnNETxT3RK5l+4lKUXtzvwT2N5Qr7PfqvtFKbALjlFZb35EfaA45bSVE9BOZF3DwazO3Q==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-13.0.0.tgz",
+      "integrity": "sha512-z+DhtvGNxj5X2lZXIzXdZfE3LKc6pJNr3SBfWdyF/yCaCR/ynG+VKCUhD/nAzQ0yOA1PUUMyGcZ4tnb6TLhM1Q==",
       "dev": true,
       "engines": {
         "npm": ">7"
@@ -2693,6 +2720,7 @@
         "@financial-times/o-brand": "^4.1.0",
         "@financial-times/o-buttons": "^7.8.0",
         "@financial-times/o-colors": "^6.5.0",
+        "@financial-times/o-forms": "^9.12.1",
         "@financial-times/o-grid": "^6.1.1",
         "@financial-times/o-icons": "^7.0.1",
         "@financial-times/o-normalise": "^3.3.0",
@@ -7906,6 +7934,16 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
       "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
       "dev": true
+    },
+    "node_modules/@types/lodash.uniqueid": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.uniqueid/-/lodash.uniqueid-4.0.9.tgz",
+      "integrity": "sha512-SEzkJBS8t+tqAUnSmyqbuWqxKU+Z/Xu2cgPtD+Ik0l+M7L2q7So9VoN2rQ8H0mmL87lJ00ykxal8oB54QRet6g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mdast": {
       "version": "3.0.14",
@@ -22159,6 +22197,13 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
+    "node_modules/lodash.uniqueid": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
+      "integrity": "sha512-GQQWaIeGlL6DIIr06kj1j6sSmBxyNMwI8kaX9aKpHR/XsMTiaXDVPNPAkiboOTK9OJpTJF/dXT3xYoFQnj386Q==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -34683,7 +34728,7 @@
       },
       "devDependencies": {
         "@financial-times/logo-images": "^1.10.1",
-        "@financial-times/o-header": "^12.0.0",
+        "@financial-times/o-header": "^13.0.0",
         "@svgr/core": "^5.0.0",
         "camelcase": "^6.0.0",
         "check-engine": "^1.10.1"
@@ -34694,7 +34739,7 @@
       },
       "peerDependencies": {
         "@financial-times/logo-images": "^1.10.1",
-        "@financial-times/o-header": "^12.0.0",
+        "@financial-times/o-header": "^13.0.0",
         "n-ui-foundations": "^9.0.0 || ^10.0.0",
         "react": "17.x || 18.x",
         "react-dom": "17.x || 18.x"

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -30,10 +30,10 @@
     "@svgr/core": "^5.0.0",
     "camelcase": "^6.0.0",
     "check-engine": "^1.10.1",
-    "@financial-times/o-header": "^12.0.0"
+    "@financial-times/o-header": "^13.0.0"
   },
   "peerDependencies": {
-    "@financial-times/o-header": "^12.0.0",
+    "@financial-times/o-header": "^13.0.0",
     "@financial-times/logo-images": "^1.10.1",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x",

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -110,7 +110,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders ASK FT button 1`] = `
              Edition
           </span>
           <span
-            className="divider"
+            aria-hidden="true"
           >
             |
           </span>
@@ -1497,7 +1497,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
              Edition
           </span>
           <span
-            className="divider"
+            aria-hidden="true"
           >
             |
           </span>
@@ -2867,7 +2867,7 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
              Edition
           </span>
           <span
-            className="divider"
+            aria-hidden="true"
           >
             |
           </span>

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -42,23 +42,6 @@ exports[`dotcom-ui-header/src/components/Drawer renders ASK FT button 1`] = `
           Financial Times
         </span>
       </a>
-      <p
-        className="o-header__drawer-current-edition"
-      >
-        UK Edition
-      </p>
-    </div>
-    <div
-      className="o-header__drawer-actions"
-    >
-      <a
-        className="o-header__drawer-button"
-        data-trackable="subscribe-button"
-        href="#"
-        role="button"
-      >
-        Subscribe for full access
-      </a>
     </div>
     <div
       className="o-header__drawer-search"
@@ -107,19 +90,6 @@ exports[`dotcom-ui-header/src/components/Drawer renders ASK FT button 1`] = `
             Search
           </span>
         </button>
-        <a
-          className="ft-header__ask-ft-button ft-header__drawer-ask-ft-button"
-          data-trackable="ask-ft-button-drawer"
-          href="https://ask.ft.com"
-          id="ask-ft-button-drawer"
-          title="ASK FT"
-        >
-          <span
-            className="ft-header__ask-ft-button-label"
-          >
-            Ask FT
-          </span>
-        </a>
       </form>
     </div>
     <nav
@@ -130,9 +100,20 @@ exports[`dotcom-ui-header/src/components/Drawer renders ASK FT button 1`] = `
         className="o-header__drawer-menu-list"
       >
         <li
-          className="o-header__drawer-menu-item"
+          className="o-header__drawer-menu-item edition-switcher"
           data-trackable="edition-switcher"
         >
+          <span
+            className="current-edition"
+          >
+            UK
+             Edition
+          </span>
+          <span
+            className="divider"
+          >
+            |
+          </span>
           <a
             className="o-header__drawer-menu-link"
             data-trackable="international"
@@ -145,6 +126,35 @@ exports[`dotcom-ui-header/src/components/Drawer renders ASK FT button 1`] = `
         </li>
       </ul>
     </nav>
+    <div
+      className="o-header__drawer-actions"
+    >
+      <a
+        className="ft-header__ask-ft-button ft-header__drawer-ask-ft-button"
+        data-trackable="ask-ft-button-drawer"
+        href="https://ask.ft.com"
+        id="ask-ft-button-drawer"
+        title="ASK FT"
+      >
+        <span
+          className="ft-header__ask-ft-button-label"
+        >
+          Ask FT
+        </span>
+      </a>
+    </div>
+    <div
+      className="o-header__drawer-actions"
+    >
+      <a
+        className="o-header__drawer-button"
+        data-trackable="subscribe-button"
+        href="#"
+        role="button"
+      >
+        Subscribe for full access
+      </a>
+    </div>
     <nav
       className="o-header__drawer-menu o-header__drawer-menu--primary"
     >
@@ -1419,23 +1429,6 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
           Financial Times
         </span>
       </a>
-      <p
-        className="o-header__drawer-current-edition"
-      >
-        UK Edition
-      </p>
-    </div>
-    <div
-      className="o-header__drawer-actions"
-    >
-      <a
-        className="o-header__drawer-button"
-        data-trackable="subscribe-button"
-        href="#"
-        role="button"
-      >
-        Subscribe for full access
-      </a>
     </div>
     <div
       className="o-header__drawer-search"
@@ -1494,9 +1487,20 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
         className="o-header__drawer-menu-list"
       >
         <li
-          className="o-header__drawer-menu-item"
+          className="o-header__drawer-menu-item edition-switcher"
           data-trackable="edition-switcher"
         >
+          <span
+            className="current-edition"
+          >
+            UK
+             Edition
+          </span>
+          <span
+            className="divider"
+          >
+            |
+          </span>
           <a
             className="o-header__drawer-menu-link"
             data-trackable="international"
@@ -1509,6 +1513,18 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
         </li>
       </ul>
     </nav>
+    <div
+      className="o-header__drawer-actions"
+    >
+      <a
+        className="o-header__drawer-button"
+        data-trackable="subscribe-button"
+        href="#"
+        role="button"
+      >
+        Subscribe for full access
+      </a>
+    </div>
     <nav
       className="o-header__drawer-menu o-header__drawer-menu--primary"
     >
@@ -2783,23 +2799,6 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
           Financial Times
         </span>
       </a>
-      <p
-        className="o-header__drawer-current-edition"
-      >
-        UK Edition
-      </p>
-    </div>
-    <div
-      className="o-header__drawer-actions"
-    >
-      <a
-        className="o-header__drawer-button"
-        data-trackable="subscribe-button"
-        href="#"
-        role="button"
-      >
-        Subscribe for full access
-      </a>
     </div>
     <div
       className="o-header__drawer-search"
@@ -2858,9 +2857,20 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
         className="o-header__drawer-menu-list"
       >
         <li
-          className="o-header__drawer-menu-item"
+          className="o-header__drawer-menu-item edition-switcher"
           data-trackable="edition-switcher"
         >
+          <span
+            className="current-edition"
+          >
+            UK
+             Edition
+          </span>
+          <span
+            className="divider"
+          >
+            |
+          </span>
           <a
             className="o-header__drawer-menu-link"
             data-trackable="international"
@@ -2873,6 +2883,18 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
         </li>
       </ul>
     </nav>
+    <div
+      className="o-header__drawer-actions"
+    >
+      <a
+        className="o-header__drawer-button"
+        data-trackable="subscribe-button"
+        href="#"
+        role="button"
+      >
+        Subscribe for full access
+      </a>
+    </div>
     <nav
       className="o-header__drawer-menu o-header__drawer-menu--primary"
     >

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -42,6 +42,30 @@ exports[`dotcom-ui-header/src/components/Drawer renders ASK FT button 1`] = `
           Financial Times
         </span>
       </a>
+      <nav
+        aria-label="Edition switcher"
+        className="o-header__drawer-menu o-header__drawer-edition-switcher"
+      >
+        <span
+          className="o-header__drawer-menu-item"
+        >
+          Edition:
+        </span>
+        <span
+          className="o-header__drawer-menu-item o-header__drawer-current-edition"
+        >
+          UK
+        </span>
+        <div
+          className="o-header__drawer-divider"
+        />
+        <a
+          className="o-header__drawer-menu-link"
+          href="#?edition=international"
+        >
+          International
+        </a>
+      </nav>
     </div>
     <div
       className="o-header__drawer-search"
@@ -56,76 +80,53 @@ exports[`dotcom-ui-header/src/components/Drawer renders ASK FT button 1`] = `
         role="search"
       >
         <label
-          className="o-header__visually-hidden"
+          className="o-forms-field o-forms-field--optional"
           htmlFor="o-header-drawer-search-term"
         >
-          Search the 
-          <abbr
-            title="Financial Times"
-          >
-            FT
-          </abbr>
-        </label>
-        <input
-          autoCapitalize="off"
-          autoComplete="off"
-          autoCorrect="off"
-          className="o-header__drawer-search-term"
-          data-n-topic-search-input={true}
-          data-trackable="search-term"
-          id="o-header-drawer-search-term"
-          name="q"
-          placeholder="Search the FT"
-          spellCheck={false}
-          type="text"
-        />
-        <button
-          className="o-header__drawer-search-submit"
-          data-trackable="search-submit"
-          type="submit"
-        >
           <span
-            className="o-header__visually-hidden"
+            className="o-forms-title o-header__visually-hidden"
           >
-            Search
+            <span
+              className="o-forms-title__main"
+            >
+              Search the 
+              <abbr
+                title="Financial Times"
+              >
+                FT
+              </abbr>
+            </span>
           </span>
-        </button>
+          <span
+            className="o-forms-input o-forms-input--text o-forms-input--suffix"
+          >
+            <input
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              data-n-topic-search-input={true}
+              data-trackable="search-term"
+              id="o-header-drawer-search-term"
+              name="q"
+              placeholder="Search for stories, topics or securities"
+              spellCheck={false}
+              type="text"
+            />
+            <button
+              className="o-header__drawer-search-submit"
+              data-trackable="search-submit"
+              type="submit"
+            >
+              <span
+                className="o-header__visually-hidden"
+              >
+                Search
+              </span>
+            </button>
+          </span>
+        </label>
       </form>
     </div>
-    <nav
-      aria-label="Edition switcher"
-      className="o-header__drawer-menu"
-    >
-      <ul
-        className="o-header__drawer-menu-list"
-      >
-        <li
-          className="o-header__drawer-menu-item edition-switcher"
-          data-trackable="edition-switcher"
-        >
-          <span
-            className="current-edition"
-          >
-            UK
-             Edition
-          </span>
-          <span
-            aria-hidden="true"
-          >
-            |
-          </span>
-          <a
-            className="o-header__drawer-menu-link"
-            data-trackable="international"
-            href="#?edition=international"
-          >
-            Switch to 
-            International
-             Edition
-          </a>
-        </li>
-      </ul>
-    </nav>
     <div
       className="o-header__drawer-actions"
     >
@@ -1429,6 +1430,30 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
           Financial Times
         </span>
       </a>
+      <nav
+        aria-label="Edition switcher"
+        className="o-header__drawer-menu o-header__drawer-edition-switcher"
+      >
+        <span
+          className="o-header__drawer-menu-item"
+        >
+          Edition:
+        </span>
+        <span
+          className="o-header__drawer-menu-item o-header__drawer-current-edition"
+        >
+          UK
+        </span>
+        <div
+          className="o-header__drawer-divider"
+        />
+        <a
+          className="o-header__drawer-menu-link"
+          href="#?edition=international"
+        >
+          International
+        </a>
+      </nav>
     </div>
     <div
       className="o-header__drawer-search"
@@ -1443,76 +1468,53 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
         role="search"
       >
         <label
-          className="o-header__visually-hidden"
+          className="o-forms-field o-forms-field--optional"
           htmlFor="o-header-drawer-search-term"
         >
-          Search the 
-          <abbr
-            title="Financial Times"
-          >
-            FT
-          </abbr>
-        </label>
-        <input
-          autoCapitalize="off"
-          autoComplete="off"
-          autoCorrect="off"
-          className="o-header__drawer-search-term"
-          data-n-topic-search-input={true}
-          data-trackable="search-term"
-          id="o-header-drawer-search-term"
-          name="q"
-          placeholder="Search the FT"
-          spellCheck={false}
-          type="text"
-        />
-        <button
-          className="o-header__drawer-search-submit"
-          data-trackable="search-submit"
-          type="submit"
-        >
           <span
-            className="o-header__visually-hidden"
+            className="o-forms-title o-header__visually-hidden"
           >
-            Search
+            <span
+              className="o-forms-title__main"
+            >
+              Search the 
+              <abbr
+                title="Financial Times"
+              >
+                FT
+              </abbr>
+            </span>
           </span>
-        </button>
+          <span
+            className="o-forms-input o-forms-input--text o-forms-input--suffix"
+          >
+            <input
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              data-n-topic-search-input={true}
+              data-trackable="search-term"
+              id="o-header-drawer-search-term"
+              name="q"
+              placeholder="Search for stories, topics or securities"
+              spellCheck={false}
+              type="text"
+            />
+            <button
+              className="o-header__drawer-search-submit"
+              data-trackable="search-submit"
+              type="submit"
+            >
+              <span
+                className="o-header__visually-hidden"
+              >
+                Search
+              </span>
+            </button>
+          </span>
+        </label>
       </form>
     </div>
-    <nav
-      aria-label="Edition switcher"
-      className="o-header__drawer-menu"
-    >
-      <ul
-        className="o-header__drawer-menu-list"
-      >
-        <li
-          className="o-header__drawer-menu-item edition-switcher"
-          data-trackable="edition-switcher"
-        >
-          <span
-            className="current-edition"
-          >
-            UK
-             Edition
-          </span>
-          <span
-            aria-hidden="true"
-          >
-            |
-          </span>
-          <a
-            className="o-header__drawer-menu-link"
-            data-trackable="international"
-            href="#?edition=international"
-          >
-            Switch to 
-            International
-             Edition
-          </a>
-        </li>
-      </ul>
-    </nav>
     <div
       className="o-header__drawer-actions"
     >
@@ -2799,6 +2801,30 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
           Financial Times
         </span>
       </a>
+      <nav
+        aria-label="Edition switcher"
+        className="o-header__drawer-menu o-header__drawer-edition-switcher"
+      >
+        <span
+          className="o-header__drawer-menu-item"
+        >
+          Edition:
+        </span>
+        <span
+          className="o-header__drawer-menu-item o-header__drawer-current-edition"
+        >
+          UK
+        </span>
+        <div
+          className="o-header__drawer-divider"
+        />
+        <a
+          className="o-header__drawer-menu-link"
+          href="#?edition=international"
+        >
+          International
+        </a>
+      </nav>
     </div>
     <div
       className="o-header__drawer-search"
@@ -2813,76 +2839,53 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
         role="search"
       >
         <label
-          className="o-header__visually-hidden"
+          className="o-forms-field o-forms-field--optional"
           htmlFor="o-header-drawer-search-term"
         >
-          Search the 
-          <abbr
-            title="Financial Times"
-          >
-            FT
-          </abbr>
-        </label>
-        <input
-          autoCapitalize="off"
-          autoComplete="off"
-          autoCorrect="off"
-          className="o-header__drawer-search-term"
-          data-n-topic-search-input={true}
-          data-trackable="search-term"
-          id="o-header-drawer-search-term"
-          name="q"
-          placeholder="Search the FT"
-          spellCheck={false}
-          type="text"
-        />
-        <button
-          className="o-header__drawer-search-submit"
-          data-trackable="search-submit"
-          type="submit"
-        >
           <span
-            className="o-header__visually-hidden"
+            className="o-forms-title o-header__visually-hidden"
           >
-            Search
+            <span
+              className="o-forms-title__main"
+            >
+              Search the 
+              <abbr
+                title="Financial Times"
+              >
+                FT
+              </abbr>
+            </span>
           </span>
-        </button>
+          <span
+            className="o-forms-input o-forms-input--text o-forms-input--suffix"
+          >
+            <input
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              data-n-topic-search-input={true}
+              data-trackable="search-term"
+              id="o-header-drawer-search-term"
+              name="q"
+              placeholder="Search for stories, topics or securities"
+              spellCheck={false}
+              type="text"
+            />
+            <button
+              className="o-header__drawer-search-submit"
+              data-trackable="search-submit"
+              type="submit"
+            >
+              <span
+                className="o-header__visually-hidden"
+              >
+                Search
+              </span>
+            </button>
+          </span>
+        </label>
       </form>
     </div>
-    <nav
-      aria-label="Edition switcher"
-      className="o-header__drawer-menu"
-    >
-      <ul
-        className="o-header__drawer-menu-list"
-      >
-        <li
-          className="o-header__drawer-menu-item edition-switcher"
-          data-trackable="edition-switcher"
-        >
-          <span
-            className="current-edition"
-          >
-            UK
-             Edition
-          </span>
-          <span
-            aria-hidden="true"
-          >
-            |
-          </span>
-          <a
-            className="o-header__drawer-menu-link"
-            data-trackable="international"
-            href="#?edition=international"
-          >
-            Switch to 
-            International
-             Edition
-          </a>
-        </li>
-      </ul>
-    </nav>
     <div
       className="o-header__drawer-actions"
     >

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -31,17 +31,6 @@ exports[`dotcom-ui-header/src/components/Drawer renders ASK FT button 1`] = `
           Close side navigation menu
         </span>
       </button>
-      <a
-        className="o-header__drawer-tools-logo"
-        data-trackable="logo"
-        href="/"
-      >
-        <span
-          className="o-header__visually-hidden"
-        >
-          Financial Times
-        </span>
-      </a>
       <nav
         aria-label="Edition switcher"
         className="o-header__drawer-menu o-header__drawer-edition-switcher"
@@ -1419,17 +1408,6 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
           Close side navigation menu
         </span>
       </button>
-      <a
-        className="o-header__drawer-tools-logo"
-        data-trackable="logo"
-        href="/"
-      >
-        <span
-          className="o-header__visually-hidden"
-        >
-          Financial Times
-        </span>
-      </a>
       <nav
         aria-label="Edition switcher"
         className="o-header__drawer-menu o-header__drawer-edition-switcher"
@@ -2790,17 +2768,6 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
           Close side navigation menu
         </span>
       </button>
-      <a
-        className="o-header__drawer-tools-logo"
-        data-trackable="logo"
-        href="/"
-      >
-        <span
-          className="o-header__visually-hidden"
-        >
-          Financial Times
-        </span>
-      </a>
       <nav
         aria-label="Edition switcher"
         className="o-header__drawer-menu o-header__drawer-edition-switcher"

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -137,49 +137,60 @@ exports[`dotcom-ui-header/src/components/MainHeader renders ASK FT button 1`] = 
         role="search"
       >
         <label
-          className="o-header__visually-hidden"
+          className="o-header__search-term o-forms-field o-forms-field--optional"
           htmlFor="o-header-search-term-primary"
         >
-          Search the 
-          <abbr
-            title="Financial Times"
-          >
-            FT
-          </abbr>
-        </label>
-        <input
-          autoCapitalize="off"
-          autoComplete="off"
-          autoCorrect="off"
-          className="o-header__search-term"
-          data-n-topic-search-input={true}
-          data-trackable="search-term"
-          id="o-header-search-term-primary"
-          name="q"
-          placeholder="Search the FT"
-          spellCheck={false}
-          type="text"
-        />
-        <button
-          className="o-header__search-submit"
-          data-trackable="search-submit"
-          type="submit"
-        >
-          Search
-        </button>
-        <button
-          aria-controls="o-header-search-primary"
-          className="o-header__search-close o--if-js"
-          data-trackable="close"
-          title="Close search bar"
-          type="button"
-        >
           <span
-            className="o-header__visually-hidden"
+            className="o-forms-title o-header__visually-hidden"
           >
-            Close search bar
+            <span
+              className="o-forms-title__main"
+            >
+              Search the 
+              <abbr
+                title="Financial Times"
+              >
+                FT
+              </abbr>
+            </span>
           </span>
-        </button>
+          <span
+            className="o-forms-input o-forms-input--text o-forms-input--suffix"
+          >
+            <input
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              className="o-header__search-term"
+              data-n-topic-search-input={true}
+              data-trackable="search-term"
+              id="o-header-search-term-primary"
+              name="q"
+              placeholder="Search for stories, topics or securities"
+              spellCheck={false}
+              type="text"
+            />
+            <button
+              className="o-header__search-submit"
+              type="submit"
+            >
+              Search
+            </button>
+            <button
+              aria-controls="o-header-search-primary"
+              className="o-header__search-close o--if-js"
+              data-trackable="close"
+              title="Close search bar"
+              type="button"
+            >
+              <span
+                className="o-header__visually-hidden"
+              >
+                Close search bar
+              </span>
+            </button>
+          </span>
+        </label>
       </form>
     </div>
   </div>
@@ -1981,49 +1992,60 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
         role="search"
       >
         <label
-          className="o-header__visually-hidden"
+          className="o-header__search-term o-forms-field o-forms-field--optional"
           htmlFor="o-header-search-term-primary"
         >
-          Search the 
-          <abbr
-            title="Financial Times"
-          >
-            FT
-          </abbr>
-        </label>
-        <input
-          autoCapitalize="off"
-          autoComplete="off"
-          autoCorrect="off"
-          className="o-header__search-term"
-          data-n-topic-search-input={true}
-          data-trackable="search-term"
-          id="o-header-search-term-primary"
-          name="q"
-          placeholder="Search the FT"
-          spellCheck={false}
-          type="text"
-        />
-        <button
-          className="o-header__search-submit"
-          data-trackable="search-submit"
-          type="submit"
-        >
-          Search
-        </button>
-        <button
-          aria-controls="o-header-search-primary"
-          className="o-header__search-close o--if-js"
-          data-trackable="close"
-          title="Close search bar"
-          type="button"
-        >
           <span
-            className="o-header__visually-hidden"
+            className="o-forms-title o-header__visually-hidden"
           >
-            Close search bar
+            <span
+              className="o-forms-title__main"
+            >
+              Search the 
+              <abbr
+                title="Financial Times"
+              >
+                FT
+              </abbr>
+            </span>
           </span>
-        </button>
+          <span
+            className="o-forms-input o-forms-input--text o-forms-input--suffix"
+          >
+            <input
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              className="o-header__search-term"
+              data-n-topic-search-input={true}
+              data-trackable="search-term"
+              id="o-header-search-term-primary"
+              name="q"
+              placeholder="Search for stories, topics or securities"
+              spellCheck={false}
+              type="text"
+            />
+            <button
+              className="o-header__search-submit"
+              type="submit"
+            >
+              Search
+            </button>
+            <button
+              aria-controls="o-header-search-primary"
+              className="o-header__search-close o--if-js"
+              data-trackable="close"
+              title="Close search bar"
+              type="button"
+            >
+              <span
+                className="o-header__visually-hidden"
+              >
+                Close search bar
+              </span>
+            </button>
+          </span>
+        </label>
       </form>
     </div>
   </div>
@@ -3820,49 +3842,60 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
         role="search"
       >
         <label
-          className="o-header__visually-hidden"
+          className="o-header__search-term o-forms-field o-forms-field--optional"
           htmlFor="o-header-search-term-primary"
         >
-          Search the 
-          <abbr
-            title="Financial Times"
-          >
-            FT
-          </abbr>
-        </label>
-        <input
-          autoCapitalize="off"
-          autoComplete="off"
-          autoCorrect="off"
-          className="o-header__search-term"
-          data-n-topic-search-input={true}
-          data-trackable="search-term"
-          id="o-header-search-term-primary"
-          name="q"
-          placeholder="Search the FT"
-          spellCheck={false}
-          type="text"
-        />
-        <button
-          className="o-header__search-submit"
-          data-trackable="search-submit"
-          type="submit"
-        >
-          Search
-        </button>
-        <button
-          aria-controls="o-header-search-primary"
-          className="o-header__search-close o--if-js"
-          data-trackable="close"
-          title="Close search bar"
-          type="button"
-        >
           <span
-            className="o-header__visually-hidden"
+            className="o-forms-title o-header__visually-hidden"
           >
-            Close search bar
+            <span
+              className="o-forms-title__main"
+            >
+              Search the 
+              <abbr
+                title="Financial Times"
+              >
+                FT
+              </abbr>
+            </span>
           </span>
-        </button>
+          <span
+            className="o-forms-input o-forms-input--text o-forms-input--suffix"
+          >
+            <input
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              className="o-header__search-term"
+              data-n-topic-search-input={true}
+              data-trackable="search-term"
+              id="o-header-search-term-primary"
+              name="q"
+              placeholder="Search for stories, topics or securities"
+              spellCheck={false}
+              type="text"
+            />
+            <button
+              className="o-header__search-submit"
+              type="submit"
+            >
+              Search
+            </button>
+            <button
+              aria-controls="o-header-search-primary"
+              className="o-header__search-close o--if-js"
+              data-trackable="close"
+              title="Close search bar"
+              type="button"
+            >
+              <span
+                className="o-header__visually-hidden"
+              >
+                Close search bar
+              </span>
+            </button>
+          </span>
+        </label>
       </form>
     </div>
   </div>
@@ -5664,49 +5697,60 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
         role="search"
       >
         <label
-          className="o-header__visually-hidden"
+          className="o-header__search-term o-forms-field o-forms-field--optional"
           htmlFor="o-header-search-term-primary"
         >
-          Search the 
-          <abbr
-            title="Financial Times"
-          >
-            FT
-          </abbr>
-        </label>
-        <input
-          autoCapitalize="off"
-          autoComplete="off"
-          autoCorrect="off"
-          className="o-header__search-term"
-          data-n-topic-search-input={true}
-          data-trackable="search-term"
-          id="o-header-search-term-primary"
-          name="q"
-          placeholder="Search the FT"
-          spellCheck={false}
-          type="text"
-        />
-        <button
-          className="o-header__search-submit"
-          data-trackable="search-submit"
-          type="submit"
-        >
-          Search
-        </button>
-        <button
-          aria-controls="o-header-search-primary"
-          className="o-header__search-close o--if-js"
-          data-trackable="close"
-          title="Close search bar"
-          type="button"
-        >
           <span
-            className="o-header__visually-hidden"
+            className="o-forms-title o-header__visually-hidden"
           >
-            Close search bar
+            <span
+              className="o-forms-title__main"
+            >
+              Search the 
+              <abbr
+                title="Financial Times"
+              >
+                FT
+              </abbr>
+            </span>
           </span>
-        </button>
+          <span
+            className="o-forms-input o-forms-input--text o-forms-input--suffix"
+          >
+            <input
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              className="o-header__search-term"
+              data-n-topic-search-input={true}
+              data-trackable="search-term"
+              id="o-header-search-term-primary"
+              name="q"
+              placeholder="Search for stories, topics or securities"
+              spellCheck={false}
+              type="text"
+            />
+            <button
+              className="o-header__search-submit"
+              type="submit"
+            >
+              Search
+            </button>
+            <button
+              aria-controls="o-header-search-primary"
+              className="o-header__search-close o--if-js"
+              data-trackable="close"
+              title="Close search bar"
+              type="button"
+            >
+              <span
+                className="o-header__visually-hidden"
+              >
+                Close search bar
+              </span>
+            </button>
+          </span>
+        </label>
       </form>
     </div>
   </div>

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -47,19 +47,23 @@ exports[`dotcom-ui-header/src/components/MainHeader renders ASK FT button 1`] = 
               Open search bar
             </span>
           </a>
-          <a
-            className="ft-header__ask-ft-button ft-header__top-ask-ft-button"
-            data-trackable="ask-ft-button-header"
-            href="https://ask.ft.com"
-            id="ask-ft-button-header"
-            title="ASK FT"
+          <div
+            className="o-header__drawer-actions"
           >
-            <span
-              className="ft-header__ask-ft-button-label"
+            <a
+              className="ft-header__ask-ft-button ft-header__top-ask-ft-button"
+              data-trackable="ask-ft-button-header"
+              href="https://ask.ft.com"
+              id="ask-ft-button-header"
+              title="ASK FT"
             >
-              Ask FT
-            </span>
-          </a>
+              <span
+                className="ft-header__ask-ft-button-label"
+              >
+                Ask FT
+              </span>
+            </a>
+          </div>
         </div>
         <div
           className="o-header__top-column o-header__top-column--center"

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
@@ -46,19 +46,23 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders ASK FT button 1`] 
               Search
             </span>
           </a>
-          <a
-            className="ft-header__ask-ft-button ft-header__top-ask-ft-button"
-            data-trackable="ask-ft-button-sticky"
-            href="https://ask.ft.com"
-            id="ask-ft-button-sticky"
-            title="ASK FT"
+          <div
+            className="o-header__drawer-actions"
           >
-            <span
-              className="ft-header__ask-ft-button-label"
+            <a
+              className="ft-header__ask-ft-button ft-header__top-ask-ft-button"
+              data-trackable="ask-ft-button-sticky"
+              href="https://ask.ft.com"
+              id="ask-ft-button-sticky"
+              title="ASK FT"
             >
-              Ask FT
-            </span>
-          </a>
+              <span
+                className="ft-header__ask-ft-button-label"
+              >
+                Ask FT
+              </span>
+            </a>
+          </div>
         </div>
         <div
           className="o-header__top-column o-header__top-column--center"

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
@@ -272,49 +272,60 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders ASK FT button 1`] 
         role="search"
       >
         <label
-          className="o-header__visually-hidden"
+          className="o-header__search-term o-forms-field o-forms-field--optional"
           htmlFor="o-header-search-term-sticky"
         >
-          Search the 
-          <abbr
-            title="Financial Times"
-          >
-            FT
-          </abbr>
-        </label>
-        <input
-          autoCapitalize="off"
-          autoComplete="off"
-          autoCorrect="off"
-          className="o-header__search-term"
-          data-n-topic-search-input={true}
-          data-trackable="search-term"
-          id="o-header-search-term-sticky"
-          name="q"
-          placeholder="Search the FT"
-          spellCheck={false}
-          type="text"
-        />
-        <button
-          className="o-header__search-submit"
-          data-trackable="search-submit"
-          type="submit"
-        >
-          Search
-        </button>
-        <button
-          aria-controls="o-header-search-sticky"
-          className="o-header__search-close o--if-js"
-          data-trackable="close"
-          title="Close search bar"
-          type="button"
-        >
           <span
-            className="o-header__visually-hidden"
+            className="o-forms-title o-header__visually-hidden"
           >
-            Close search bar
+            <span
+              className="o-forms-title__main"
+            >
+              Search the 
+              <abbr
+                title="Financial Times"
+              >
+                FT
+              </abbr>
+            </span>
           </span>
-        </button>
+          <span
+            className="o-forms-input o-forms-input--text o-forms-input--suffix"
+          >
+            <input
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              className="o-header__search-term"
+              data-n-topic-search-input={true}
+              data-trackable="search-term"
+              id="o-header-search-term-sticky"
+              name="q"
+              placeholder="Search for stories, topics or securities"
+              spellCheck={false}
+              type="text"
+            />
+            <button
+              className="o-header__search-submit"
+              type="submit"
+            >
+              Search
+            </button>
+            <button
+              aria-controls="o-header-search-sticky"
+              className="o-header__search-close o--if-js"
+              data-trackable="close"
+              title="Close search bar"
+              type="button"
+            >
+              <span
+                className="o-header__visually-hidden"
+              >
+                Close search bar
+              </span>
+            </button>
+          </span>
+        </label>
       </form>
     </div>
   </div>
@@ -576,49 +587,60 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as a logged in use
         role="search"
       >
         <label
-          className="o-header__visually-hidden"
+          className="o-header__search-term o-forms-field o-forms-field--optional"
           htmlFor="o-header-search-term-sticky"
         >
-          Search the 
-          <abbr
-            title="Financial Times"
-          >
-            FT
-          </abbr>
-        </label>
-        <input
-          autoCapitalize="off"
-          autoComplete="off"
-          autoCorrect="off"
-          className="o-header__search-term"
-          data-n-topic-search-input={true}
-          data-trackable="search-term"
-          id="o-header-search-term-sticky"
-          name="q"
-          placeholder="Search the FT"
-          spellCheck={false}
-          type="text"
-        />
-        <button
-          className="o-header__search-submit"
-          data-trackable="search-submit"
-          type="submit"
-        >
-          Search
-        </button>
-        <button
-          aria-controls="o-header-search-sticky"
-          className="o-header__search-close o--if-js"
-          data-trackable="close"
-          title="Close search bar"
-          type="button"
-        >
           <span
-            className="o-header__visually-hidden"
+            className="o-forms-title o-header__visually-hidden"
           >
-            Close search bar
+            <span
+              className="o-forms-title__main"
+            >
+              Search the 
+              <abbr
+                title="Financial Times"
+              >
+                FT
+              </abbr>
+            </span>
           </span>
-        </button>
+          <span
+            className="o-forms-input o-forms-input--text o-forms-input--suffix"
+          >
+            <input
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              className="o-header__search-term"
+              data-n-topic-search-input={true}
+              data-trackable="search-term"
+              id="o-header-search-term-sticky"
+              name="q"
+              placeholder="Search for stories, topics or securities"
+              spellCheck={false}
+              type="text"
+            />
+            <button
+              className="o-header__search-submit"
+              type="submit"
+            >
+              Search
+            </button>
+            <button
+              aria-controls="o-header-search-sticky"
+              className="o-header__search-close o--if-js"
+              data-trackable="close"
+              title="Close search bar"
+              type="button"
+            >
+              <span
+                className="o-header__visually-hidden"
+              >
+                Close search bar
+              </span>
+            </button>
+          </span>
+        </label>
       </form>
     </div>
   </div>
@@ -879,49 +901,60 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as an anonymous us
         role="search"
       >
         <label
-          className="o-header__visually-hidden"
+          className="o-header__search-term o-forms-field o-forms-field--optional"
           htmlFor="o-header-search-term-sticky"
         >
-          Search the 
-          <abbr
-            title="Financial Times"
-          >
-            FT
-          </abbr>
-        </label>
-        <input
-          autoCapitalize="off"
-          autoComplete="off"
-          autoCorrect="off"
-          className="o-header__search-term"
-          data-n-topic-search-input={true}
-          data-trackable="search-term"
-          id="o-header-search-term-sticky"
-          name="q"
-          placeholder="Search the FT"
-          spellCheck={false}
-          type="text"
-        />
-        <button
-          className="o-header__search-submit"
-          data-trackable="search-submit"
-          type="submit"
-        >
-          Search
-        </button>
-        <button
-          aria-controls="o-header-search-sticky"
-          className="o-header__search-close o--if-js"
-          data-trackable="close"
-          title="Close search bar"
-          type="button"
-        >
           <span
-            className="o-header__visually-hidden"
+            className="o-forms-title o-header__visually-hidden"
           >
-            Close search bar
+            <span
+              className="o-forms-title__main"
+            >
+              Search the 
+              <abbr
+                title="Financial Times"
+              >
+                FT
+              </abbr>
+            </span>
           </span>
-        </button>
+          <span
+            className="o-forms-input o-forms-input--text o-forms-input--suffix"
+          >
+            <input
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              className="o-header__search-term"
+              data-n-topic-search-input={true}
+              data-trackable="search-term"
+              id="o-header-search-term-sticky"
+              name="q"
+              placeholder="Search for stories, topics or securities"
+              spellCheck={false}
+              type="text"
+            />
+            <button
+              className="o-header__search-submit"
+              type="submit"
+            >
+              Search
+            </button>
+            <button
+              aria-controls="o-header-search-sticky"
+              className="o-header__search-close o--if-js"
+              data-trackable="close"
+              title="Close search bar"
+              type="button"
+            >
+              <span
+                className="o-header__visually-hidden"
+              >
+                Close search bar
+              </span>
+            </button>
+          </span>
+        </label>
       </form>
     </div>
   </div>

--- a/packages/dotcom-ui-header/src/__test__/output/drawer.spec.tsx
+++ b/packages/dotcom-ui-header/src/__test__/output/drawer.spec.tsx
@@ -28,8 +28,8 @@ describe('dotcom-ui-header/src/components/drawer', () => {
     it('renders the current edition text', () => {
       const { container } = render(<Subject {...fixture} />)
 
-      expect(container.getElementsByClassName('current-edition')[0].innerHTML).toContain(
-        'UK Edition'
+      expect(container.getElementsByClassName('o-header__drawer-current-edition')[0].innerHTML).toContain(
+        'UK'
       )
     })
 
@@ -37,7 +37,7 @@ describe('dotcom-ui-header/src/components/drawer', () => {
       const { container } = render(<Subject {...fixture} />)
 
       const [firstLink] = Array.from(container.getElementsByClassName('o-header__drawer-menu-link'))
-      expect(firstLink.innerHTML).toContain('Switch to International Edition')
+      expect(firstLink.innerHTML).toContain('International')
     })
   })
 

--- a/packages/dotcom-ui-header/src/__test__/output/drawer.spec.tsx
+++ b/packages/dotcom-ui-header/src/__test__/output/drawer.spec.tsx
@@ -28,7 +28,7 @@ describe('dotcom-ui-header/src/components/drawer', () => {
     it('renders the current edition text', () => {
       const { container } = render(<Subject {...fixture} />)
 
-      expect(container.getElementsByClassName('o-header__drawer-current-edition')[0].innerHTML).toContain(
+      expect(container.getElementsByClassName('current-edition')[0].innerHTML).toContain(
         'UK Edition'
       )
     })

--- a/packages/dotcom-ui-header/src/components/ask-ft/askFtButton.tsx
+++ b/packages/dotcom-ui-header/src/components/ask-ft/askFtButton.tsx
@@ -7,13 +7,14 @@ export interface AskFtButtonProps {
 }
 
 export const AskFtButton = ({ id, className, dataTrackable }: AskFtButtonProps) => (
-  <a
-    id={id}
-    className={`ft-header__ask-ft-button ${className}`}
-    data-trackable={dataTrackable}
-    href="https://ask.ft.com"
-    title="ASK FT"
-  >
-    <span className="ft-header__ask-ft-button-label">Ask FT</span>
-  </a>
+  <div className="o-header__drawer-actions">
+    <a
+      id={id}
+      className={`ft-header__ask-ft-button ${className}`}
+      data-trackable={dataTrackable}
+      href="https://ask.ft.com"
+      title="ASK FT">
+      <span className="ft-header__ask-ft-button-label">Ask FT</span>
+    </a>
+  </div>
 )

--- a/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
@@ -85,7 +85,7 @@ export const EditionsSwitcher = (editions: TNavEditions) => (
           className="o-header__drawer-menu-item edition-switcher"
           data-trackable="edition-switcher">
           <span className="current-edition">{editions.current.name} Edition</span>
-          <span className="divider">|</span>
+          <span aria-hidden="true">|</span>
           <a className="o-header__drawer-menu-link" href={href} data-trackable={id}>
             Switch to {name} Edition
           </a>

--- a/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
@@ -16,23 +16,20 @@ export const DrawerParentItem = ({ item, idSuffix }: TDrawerParentItemProps) => 
           className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected} o-header__drawer-menu-link--parent`}
           href={item.url ?? undefined}
           {...ariaSelected(item)}
-          data-trackable={item.label}
-        >
+          data-trackable={item.label}>
           {item.label}
         </a>
         <button
           className={`o-header__drawer-menu-toggle o-header__drawer-menu-toggle--${selected}`}
           aria-controls={`o-header-drawer-child-${idSuffix}`}
-          data-trackable={`sub-level-toggle | ${item.label}`}
-        >
+          data-trackable={`sub-level-toggle | ${item.label}`}>
           {`Show more ${item.label}`}
         </button>
       </div>
       <ul
         className="o-header__drawer-menu-list o-header__drawer-menu-list--child"
         id={`o-header-drawer-child-${idSuffix}`}
-        data-trackable="sub-level"
-      >
+        data-trackable="sub-level">
         {(item.submenu?.items as TNavMenuItem[]).map((item) => {
           const selected = item.selected ? 'selected' : 'unselected'
           return (
@@ -41,8 +38,7 @@ export const DrawerParentItem = ({ item, idSuffix }: TDrawerParentItemProps) => 
                 className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected} o-header__drawer-menu-link--child`}
                 href={item.url ?? undefined}
                 data-trackable={item.label}
-                {...ariaSelected(item)}
-              >
+                {...ariaSelected(item)}>
                 {item.label}
               </a>
             </li>
@@ -60,8 +56,7 @@ export const DrawerSingleItem = (item: TNavMenuItem) => {
       className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected}`}
       href={item.url ?? undefined}
       data-trackable={item.label}
-      {...ariaSelected(item)}
-    >
+      {...ariaSelected(item)}>
       {item.label}
     </a>
   )
@@ -74,8 +69,7 @@ export const DrawerSpecialItem = (item: TNavMenuItem) => {
       className={`o-header__drawer-menu-link o-header__drawer-menu-link--${selected} o-header__drawer-menu-link--secondary`}
       href={item.url ?? undefined}
       data-trackable={item.label}
-      {...ariaSelected(item)}
-    >
+      {...ariaSelected(item)}>
       {item.label}
     </a>
   )
@@ -86,7 +80,12 @@ export const EditionsSwitcher = (editions: TNavEditions) => (
     {editions.others.map(({ id, name, url }) => {
       const href = `${url}?edition=${id}`
       return (
-        <li key={id} className="o-header__drawer-menu-item" data-trackable="edition-switcher">
+        <li
+          key={id}
+          className="o-header__drawer-menu-item edition-switcher"
+          data-trackable="edition-switcher">
+          <span className="current-edition">{editions.current.name} Edition</span>
+          <span className="divider">|</span>
           <a className="o-header__drawer-menu-link" href={href} data-trackable={id}>
             Switch to {name} Edition
           </a>

--- a/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
@@ -76,24 +76,22 @@ export const DrawerSpecialItem = (item: TNavMenuItem) => {
 }
 
 export const EditionsSwitcher = (editions: TNavEditions) => (
-  <ul className="o-header__drawer-menu-list">
-    {editions.others.map(({ id, name, url }) => {
-      const href = `${url}?edition=${id}`
-      return (
-        <li
-          key={id}
-          className="o-header__drawer-menu-item edition-switcher"
-          data-trackable="edition-switcher">
-          <span className="current-edition">{editions.current.name} Edition</span>
-          <span aria-hidden="true">|</span>
-          <a className="o-header__drawer-menu-link" href={href} data-trackable={id}>
-            Switch to {name} Edition
-          </a>
-        </li>
-      )
-    })}
-  </ul>
-)
+  <nav
+    className="o-header__drawer-menu o-header__drawer-edition-switcher"
+    aria-label="Edition switcher">
+    <span className="o-header__drawer-menu-item">Edition:</span>
+    <span className="o-header__drawer-menu-item o-header__drawer-current-edition">
+      {editions.current?.name}
+    </span>
+    <div className="o-header__drawer-divider"></div>
+    {editions.others?.map(({name, id, url}) => ( // Asegúrate de que `items` sea el nombre correcto de la propiedad del array
+      <a key={id} className="o-header__drawer-menu-link" href={`${url}?edition=${id}`}>
+        {name}
+      </a>
+    ))}
+  </nav>
+);
+
 
 export const SubscribeButton = (action: TNavAction) => (
   <div className="o-header__drawer-actions">

--- a/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/additionalPartials.tsx
@@ -84,7 +84,7 @@ export const EditionsSwitcher = (editions: TNavEditions) => (
       {editions.current?.name}
     </span>
     <div className="o-header__drawer-divider"></div>
-    {editions.others?.map(({name, id, url}) => ( // Asegúrate de que `items` sea el nombre correcto de la propiedad del array
+    {editions.others?.map(({name, id, url}) => (
       <a key={id} className="o-header__drawer-menu-link" href={`${url}?edition=${id}`}>
         {name}
       </a>

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -61,9 +61,6 @@ const DrawerTools = (editions: TNavEditions) => (
       data-trackable="close">
       <span className="o-header__visually-hidden">Close side navigation menu</span>
     </button>
-    <a className="o-header__drawer-tools-logo" href="/" data-trackable="logo">
-      <span className="o-header__visually-hidden">Financial Times</span>
-    </a>
     {editions && <EditionsSwitcher {...editions} />}
   </div>
 )

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -7,7 +7,7 @@ import {
   SubscribeButton
 } from './additionalPartials'
 import { THeaderProps } from '../../interfaces'
-import {TNavMenuItem, TNavMenu, TNavEditions} from '@financial-times/dotcom-types-navigation'
+import { TNavMenuItem, TNavMenu, TNavEditions } from '@financial-times/dotcom-types-navigation'
 import { AskFtButton } from '../ask-ft/askFtButton'
 
 const IncludeDrawer = (props) => <Drawer {...props} />
@@ -30,7 +30,7 @@ const Drawer = (props: THeaderProps) => {
       data-trackable="drawer"
       data-trackable-terminate>
       <div className="o-header__drawer-inner">
-        <DrawerTools {...editions}/>
+        <DrawerTools {...editions} />
         <Search />
         {props.showAskButton && (
           <AskFtButton

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -7,7 +7,7 @@ import {
   SubscribeButton
 } from './additionalPartials'
 import { THeaderProps } from '../../interfaces'
-import { TNavMenuItem, TNavMenu } from '@financial-times/dotcom-types-navigation'
+import {TNavMenuItem, TNavMenu, TNavEditions} from '@financial-times/dotcom-types-navigation'
 import { AskFtButton } from '../ask-ft/askFtButton'
 
 const IncludeDrawer = (props) => <Drawer {...props} />
@@ -30,12 +30,8 @@ const Drawer = (props: THeaderProps) => {
       data-trackable="drawer"
       data-trackable-terminate>
       <div className="o-header__drawer-inner">
-        <DrawerTools />
+        <DrawerTools {...editions}/>
         <Search />
-
-        <nav className="o-header__drawer-menu" aria-label="Edition switcher">
-          {editions && <EditionsSwitcher {...editions} />}
-        </nav>
         {props.showAskButton && (
           <AskFtButton
             className="ft-header__drawer-ask-ft-button"
@@ -55,7 +51,7 @@ const Drawer = (props: THeaderProps) => {
   )
 }
 
-const DrawerTools = () => (
+const DrawerTools = (editions: TNavEditions) => (
   <div className="o-header__drawer-tools">
     <button
       type="button"
@@ -68,6 +64,7 @@ const DrawerTools = () => (
     <a className="o-header__drawer-tools-logo" href="/" data-trackable="logo">
       <span className="o-header__visually-hidden">Financial Times</span>
     </a>
+    {editions && <EditionsSwitcher {...editions} />}
   </div>
 )
 
@@ -81,25 +78,30 @@ const Search = () => (
       data-n-topic-search
       data-n-topic-search-categories="concepts,equities"
       data-n-topic-search-view-all>
-      <label className="o-header__visually-hidden" htmlFor="o-header-drawer-search-term">
-        Search the <abbr title="Financial Times">FT</abbr>
+      <label htmlFor="o-header-drawer-search-term" className="o-forms-field o-forms-field--optional">
+        <span className="o-forms-title o-header__visually-hidden">
+          <span className="o-forms-title__main">
+            Search the <abbr title="Financial Times">FT</abbr>
+          </span>
+        </span>
+        <span className="o-forms-input o-forms-input--text o-forms-input--suffix">
+          <input
+            id="o-header-drawer-search-term"
+            name="q"
+            type="text"
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            data-trackable="search-term"
+            data-n-topic-search-input
+            placeholder="Search for stories, topics or securities"
+          />
+          <button className="o-header__drawer-search-submit" type="submit" data-trackable="search-submit">
+            <span className="o-header__visually-hidden">Search</span>
+          </button>
+        </span>
       </label>
-      <input
-        className="o-header__drawer-search-term"
-        id="o-header-drawer-search-term"
-        name="q"
-        type="text"
-        autoComplete="off"
-        autoCorrect="off"
-        autoCapitalize="off"
-        spellCheck={false}
-        placeholder="Search the FT"
-        data-trackable="search-term"
-        data-n-topic-search-input
-      />
-      <button className="o-header__drawer-search-submit" type="submit" data-trackable="search-submit">
-        <span className="o-header__visually-hidden">Search</span>
-      </button>
     </form>
   </div>
 )

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -7,7 +7,7 @@ import {
   SubscribeButton
 } from './additionalPartials'
 import { THeaderProps } from '../../interfaces'
-import { TNavMenuItem, TNavMenu, TNavEditions } from '@financial-times/dotcom-types-navigation'
+import { TNavMenuItem, TNavMenu } from '@financial-times/dotcom-types-navigation'
 import { AskFtButton } from '../ask-ft/askFtButton'
 
 const IncludeDrawer = (props) => <Drawer {...props} />
@@ -28,15 +28,22 @@ const Drawer = (props: THeaderProps) => {
       data-o-header-drawer
       data-o-header-drawer--no-js
       data-trackable="drawer"
-      data-trackable-terminate
-    >
+      data-trackable-terminate>
       <div className="o-header__drawer-inner">
-        <DrawerTools {...editions} />
-        {!props.userIsSubscribed && subscribeAction && <SubscribeButton {...subscribeAction} />}
-        <Search {...props} />
+        <DrawerTools />
+        <Search />
+
         <nav className="o-header__drawer-menu" aria-label="Edition switcher">
           {editions && <EditionsSwitcher {...editions} />}
         </nav>
+        {props.showAskButton && (
+          <AskFtButton
+            className="ft-header__drawer-ask-ft-button"
+            id="ask-ft-button-drawer"
+            dataTrackable="ask-ft-button-drawer"
+          />
+        )}
+        {!props.userIsSubscribed && subscribeAction && <SubscribeButton {...subscribeAction} />}
         <nav className="o-header__drawer-menu o-header__drawer-menu--primary">
           {primary ? <SectionPrimary {...primary} /> : null}
           {secondary ? <SectionSecondary {...secondary} /> : null}
@@ -48,25 +55,23 @@ const Drawer = (props: THeaderProps) => {
   )
 }
 
-const DrawerTools = (props: TNavEditions) => (
+const DrawerTools = () => (
   <div className="o-header__drawer-tools">
     <button
       type="button"
       className="o-header__drawer-tools-close"
       title="Close side navigation menu"
       aria-controls="o-header-drawer"
-      data-trackable="close"
-    >
+      data-trackable="close">
       <span className="o-header__visually-hidden">Close side navigation menu</span>
     </button>
     <a className="o-header__drawer-tools-logo" href="/" data-trackable="logo">
       <span className="o-header__visually-hidden">Financial Times</span>
     </a>
-    {props.current && <p className="o-header__drawer-current-edition">{`${props.current.name} Edition`}</p>}
   </div>
 )
 
-const Search = (props: Pick<THeaderProps, 'showAskButton'>) => (
+const Search = () => (
   <div className="o-header__drawer-search">
     <form
       className="o-header__drawer-search-form"
@@ -75,8 +80,7 @@ const Search = (props: Pick<THeaderProps, 'showAskButton'>) => (
       aria-label="Site search"
       data-n-topic-search
       data-n-topic-search-categories="concepts,equities"
-      data-n-topic-search-view-all
-    >
+      data-n-topic-search-view-all>
       <label className="o-header__visually-hidden" htmlFor="o-header-drawer-search-term">
         Search the <abbr title="Financial Times">FT</abbr>
       </label>
@@ -96,13 +100,6 @@ const Search = (props: Pick<THeaderProps, 'showAskButton'>) => (
       <button className="o-header__drawer-search-submit" type="submit" data-trackable="search-submit">
         <span className="o-header__visually-hidden">Search</span>
       </button>
-      {props.showAskButton && (
-        <AskFtButton
-          className="ft-header__drawer-ask-ft-button"
-          id="ask-ft-button-drawer"
-          dataTrackable="ask-ft-button-drawer"
-        />
-      )}
     </form>
   </div>
 )

--- a/packages/dotcom-ui-header/src/components/search/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/search/partials.tsx
@@ -16,33 +16,41 @@ const Search = ({ instance }) => {
           data-n-topic-search
           data-n-topic-search-categories="concepts,equities"
           data-n-topic-search-view-all>
-          <label className="o-header__visually-hidden" htmlFor={`o-header-search-term-${instance}`}>
-            Search the <abbr title="Financial Times">FT</abbr>
+          <label
+            htmlFor={`o-header-search-term-${instance}`}
+            className="o-header__search-term o-forms-field o-forms-field--optional">
+            <span className="o-forms-title o-header__visually-hidden">
+              <span className="o-forms-title__main">
+                Search the <abbr title="Financial Times">FT</abbr>
+              </span>
+            </span>
+            <span className="o-forms-input o-forms-input--text o-forms-input--suffix">
+              <input
+                className="o-header__search-term"
+                id={`o-header-search-term-${instance}`}
+                name="q"
+                type="text"
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+                data-trackable="search-term"
+                data-n-topic-search-input
+                placeholder="Search for stories, topics or securities"
+              />
+              <button className="o-header__search-submit" type="submit">
+                Search
+              </button>
+              <button
+                className="o-header__search-close o--if-js"
+                type="button"
+                aria-controls={`o-header-search-${instance}`}
+                title="Close search bar"
+                data-trackable="close">
+                <span className="o-header__visually-hidden">Close search bar</span>
+              </button>
+            </span>
           </label>
-          <input
-            className="o-header__search-term"
-            id={`o-header-search-term-${instance}`}
-            name="q"
-            type="text"
-            autoComplete="off"
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-            data-trackable="search-term"
-            placeholder="Search the FT"
-            data-n-topic-search-input
-          />
-          <button className="o-header__search-submit" type="submit" data-trackable="search-submit">
-            Search
-          </button>
-          <button
-            className="o-header__search-close o--if-js"
-            type="button"
-            aria-controls={`o-header-search-${instance}`}
-            title="Close search bar"
-            data-trackable="close">
-            <span className="o-header__visually-hidden">Close search bar</span>
-          </button>
         </form>
       </div>
     </div>

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -17,6 +17,9 @@
 .o-header__drawer {
   @include nUiZIndexFor('drawer');
   display: block;
+  .o-header__drawer-search {
+    margin-bottom: 8px;
+  }
 }
 
 .o-header--sticky {

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -67,5 +67,34 @@
 }
 
 .ft-header__drawer-ask-ft-button {
-  margin-left: 16px;
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  text-align: center;
+
+}
+
+.edition-switcher {
+  display: flex;
+  align-items: center;
+  font-size: 16px;
+  padding-left: 16px;
+  font-family: MetricWeb;
+
+  .o-header__drawer-menu-link {
+    padding-top: 6px;
+    padding-bottom: 6px;
+    font-size: 16px;
+    font-family: MetricWeb;
+    padding-left: 8px;
+    text-decoration: underline;
+    color: var(--Black-Tints-Black-60, #66605C);
+  }
+
+  .current-edition {
+    font-weight: 500;
+    padding-right: 8px;
+    color: var(--Black-Tints-Black-60, #66605C);
+  }
 }

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -86,7 +86,6 @@
     padding-top: 6px;
     padding-bottom: 6px;
     font-size: 16px;
-    font-family: MetricWeb;
     padding-left: 8px;
     text-decoration: underline;
 

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -74,25 +74,3 @@
   text-align: center;
 
 }
-
-.edition-switcher {
-  display: flex;
-  align-items: center;
-  font-size: 16px;
-  padding-left: 16px;
-  color: var(--Black-Tints-Black-60, #66605C);
-
-  .o-header__drawer-menu-link {
-    padding-top: 6px;
-    padding-bottom: 6px;
-    font-size: 16px;
-    padding-left: 8px;
-    text-decoration: underline;
-
-  }
-
-  .current-edition {
-    font-weight: 500;
-    padding-right: 8px;
-  }
-}

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -80,7 +80,7 @@
   align-items: center;
   font-size: 16px;
   padding-left: 16px;
-  font-family: MetricWeb;
+  color: var(--Black-Tints-Black-60, #66605C);
 
   .o-header__drawer-menu-link {
     padding-top: 6px;
@@ -89,12 +89,11 @@
     font-family: MetricWeb;
     padding-left: 8px;
     text-decoration: underline;
-    color: var(--Black-Tints-Black-60, #66605C);
+
   }
 
   .current-edition {
     font-weight: 500;
     padding-right: 8px;
-    color: var(--Black-Tints-Black-60, #66605C);
   }
 }

--- a/packages/dotcom-ui-header/styles.scss
+++ b/packages/dotcom-ui-header/styles.scss
@@ -11,4 +11,5 @@ $system-code: 'page-kit-header' !default;
 @import "src/header";
 
 @import "n-topic-search/main";
+@import "n-topic-search/main";
 @include nTopicSearch;

--- a/packages/dotcom-ui-header/styles.scss
+++ b/packages/dotcom-ui-header/styles.scss
@@ -12,3 +12,8 @@ $system-code: 'page-kit-header' !default;
 
 @import "n-topic-search/main";
 @include nTopicSearch;
+.n-topic-search {
+  @include oGridRespondTo($from: 'M') {
+    margin: 24px 0 0;
+  }
+}

--- a/packages/dotcom-ui-header/styles.scss
+++ b/packages/dotcom-ui-header/styles.scss
@@ -11,5 +11,4 @@ $system-code: 'page-kit-header' !default;
 @import "src/header";
 
 @import "n-topic-search/main";
-@import "n-topic-search/main";
 @include nTopicSearch;


### PR DESCRIPTION
# Description

As part of search navbar redesign we need to change design and position of ask button, design of edition switcher and position of subscribe button,
Changes from o-header:

- close button moved to left
- simplified design of edition switcher
- size and style of search bar and search button
Figma: 
https://www.figma.com/design/L6qyUFPPLRmf59OxTkz2VJ/Semantic-Search?node-id=10-629&m=dev

o-header changes PR: https://github.com/Financial-Times/origami/pull/1725

# Ticket
https://financialtimes.atlassian.net/browse/CON-3426

# Screenshots
Before:

![image](https://github.com/Financial-Times/dotcom-page-kit/assets/98393608/e09ece36-e255-49c4-af2f-b55a6acb58b1)

After:
![image](https://github.com/Financial-Times/dotcom-page-kit/assets/98393608/66c2c192-551f-44a5-96fd-1ddce0c8ff16)
![image](https://github.com/Financial-Times/dotcom-page-kit/assets/98393608/36d93c5a-9961-4510-9a13-e722b8d556bd)
![image](https://github.com/Financial-Times/dotcom-page-kit/assets/98393608/020c45ca-72c4-4074-b814-07a3c9977ed3)


