### PR TITLE
CON-3426: fix padding on ask to ft in header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2707,9 +2707,9 @@
       }
     },
     "node_modules/@financial-times/o-header": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-13.0.1.tgz",
-      "integrity": "sha512-wtrgMc4WDyzZsidrlx9lYXQaS8nSq9zt6GjEDBO18K4wV7vaN4dH1tCPSLG2lbPtJQS3GrCGuxQ/ZXE8jVz73Q==",
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-13.0.3.tgz",
+      "integrity": "sha512-gNY5zObcm307x6Saj+2nFhKQ0/o08216gACp35BSKV6/ZqGVqFuiHT6aqdEetmLQOVVBdo0aFhKtwiVVh2BE8Q==",
       "peer": true,
       "engines": {
         "npm": ">7"
@@ -34732,7 +34732,7 @@
       },
       "peerDependencies": {
         "@financial-times/logo-images": "^1.10.1",
-        "@financial-times/o-header": "13.0.1",
+        "@financial-times/o-header": "13.0.3",
         "n-ui-foundations": "^9.0.0 || ^10.0.0",
         "react": "17.x || 18.x",
         "react-dom": "17.x || 18.x"

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@financial-times/logo-images": "^1.10.1",
-    "@financial-times/o-header": "13.0.1",
+    "@financial-times/o-header": "13.0.3",
     "n-ui-foundations": "^9.0.0 || ^10.0.0",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x"

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -34,6 +34,10 @@
 .o-header__drawer-search-term {
   width: 100%;
 }
+.o-header__top-wrapper .ft-header__ask-ft-button {
+  padding: 8px;
+  margin-left: -12px;
+}
 .ft-header__ask-ft-button {
   @include oTypographySans(-1, $weight: 'semibold');
   color: oColorsByName('ft-grey');

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -34,7 +34,6 @@
 .o-header__drawer-search-term {
   width: 100%;
 }
-
 .ft-header__ask-ft-button {
   @include oTypographySans(-1, $weight: 'semibold');
   color: oColorsByName('ft-grey');

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -36,7 +36,6 @@
 }
 .o-header__top-wrapper .ft-header__ask-ft-button {
   padding: 8px;
-  margin-left: -12px;
 }
 .ft-header__ask-ft-button {
   @include oTypographySans(-1, $weight: 'semibold');

--- a/packages/dotcom-ui-header/styles.scss
+++ b/packages/dotcom-ui-header/styles.scss
@@ -12,8 +12,6 @@ $system-code: 'page-kit-header' !default;
 
 @import "n-topic-search/main";
 @include nTopicSearch;
-.n-topic-search {
-  @include oGridRespondTo($from: 'M') {
+.o-header__search--primary .n-topic-search {
     margin: 24px 0 0;
-  }
 }

--- a/packages/dotcom-ui-header/styles.scss
+++ b/packages/dotcom-ui-header/styles.scss
@@ -12,6 +12,6 @@ $system-code: 'page-kit-header' !default;
 
 @import "n-topic-search/main";
 @include nTopicSearch;
-.o-header__search--primary .n-topic-search {
+.o-header__search--primary .n-topic-search, o-header__search--sticky .n-topic-search{
     margin: 24px 0 0;
 }

--- a/packages/dotcom-ui-header/styles.scss
+++ b/packages/dotcom-ui-header/styles.scss
@@ -12,6 +12,6 @@ $system-code: 'page-kit-header' !default;
 
 @import "n-topic-search/main";
 @include nTopicSearch;
-.o-header__search--primary .n-topic-search, o-header__search--sticky .n-topic-search{
-    margin: 24px 0 0;
+.o-header__search--primary .n-topic-search, .o-header__search--sticky .n-topic-search {
+  margin: 24px 0 0;
 }


### PR DESCRIPTION
# Description
in the new search bar design on header we had the issue with ask to ft button that the style looks incorrect
this PR fixed it
it fix too the problems with typeahead results box

# ScreenShot
Before:
<img width="854" alt="Captura de pantalla 2024-07-10 a las 14 54 18" src="https://github.com/Financial-Times/dotcom-page-kit/assets/98393608/73118e58-e450-4c15-8205-4550113cb76a">
![image](https://github.com/Financial-Times/dotcom-page-kit/assets/98393608/fc427d65-2dbe-4b1c-806c-ba1a378caa88)
![image](https://github.com/Financial-Times/dotcom-page-kit/assets/98393608/9d43065e-a252-4c3e-b370-72a97059cedb)


After:
![image](https://github.com/Financial-Times/dotcom-page-kit/assets/98393608/44ea6784-6ca1-4b13-af8e-efa74fb45324)
![image](https://github.com/Financial-Times/dotcom-page-kit/assets/98393608/9fb85b9b-26ca-45fe-8574-f3a117ac0ae1)
![image](https://github.com/Financial-Times/dotcom-page-kit/assets/98393608/fc681324-288a-41a9-957b-a92ae2dc00a2)


