### PR TITLE
[CON-3348] o-header and typeahead

### DIFF
--- a/.storybook/.browserslistrc
+++ b/.storybook/.browserslistrc
@@ -1,4 +1,4 @@
 last 2 Chrome versions
 last 2 FF versions
 last 2 Edge versions
-Safari >= 12
+Safari >= 15

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,5 +4,9 @@ module.exports = {
     '../packages/dotcom-ui-footer/src/**/story.tsx',
     '../packages/dotcom-ui-layout/src/**/story.tsx'
   ],
-  addons: ['@storybook/addon-essentials']
+  framework: '@storybook/react',
+  addons: ['@storybook/addon-essentials'],
+  core: {
+    builder: '@storybook/builder-webpack4'
+  }
 }

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,7 +1,7 @@
 // This configuration extends the existing Storybook Webpack config.
 // See https://storybook.js.org/configurations/custom-webpack-config/ for more info.
 
-const excludePaths = [/node_modules/, /dist/]
+const excludePaths = [/dist/]
 
 module.exports = ({ config }) => {
   // Use real file paths for symlinked dependencies do avoid including them multiple times
@@ -13,17 +13,16 @@ module.exports = ({ config }) => {
     mainFiles: ['index', 'main']
   })
 
-  // HACK: extend existing JS rule to ensure all dependencies are correctly ignored
-  // https://github.com/storybooks/storybook/issues/3346#issuecomment-459439438
-  const jsRule = config.module.rules.find((rule) => rule.test.test('.jsx'))
-  jsRule.exclude = excludePaths
-
-  // HACK: Instruct Babel to check module type before injecting Core JS polyfills
-  // https://github.com/i-like-robots/broken-webpack-bundle-test-case
-  const babelConfig = jsRule.use.find(({ loader }) => loader === 'babel-loader') || {
-    options: { presets: [] }
-  }
-  babelConfig.options.sourceType = 'unambiguous'
+  // Separate rule for JavaScript Files
+  config.module.rules.push({
+    test: /\.(js|jsx)$/,
+    loader: require.resolve('babel-loader'),
+    options: {
+      presets: [require.resolve('@babel/preset-env'), require.resolve('@babel/preset-react')],
+      plugins: [require.resolve('@babel/plugin-transform-optional-chaining')]
+    },
+    exclude: excludePaths
+  })
 
   // Add support for TypeScript source code
   // https://storybook.js.org/configurations/typescript-config/

--- a/examples/kitchen-sink/__test__/build.test.js
+++ b/examples/kitchen-sink/__test__/build.test.js
@@ -18,6 +18,7 @@ describe('examples/kitchen-sink/build', () => {
         "manifest.json",
         "page-kit-components.bundle.js",
         "page-kit-layout-styles.css",
+        "preact.bundle.js",
         "privacy-components.bundle.js",
         "scripts.bundle.js",
         "shared.stable.bundle.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.8.0",
+        "@babel/plugin-transform-optional-chaining": "^7.24.8",
         "@babel/preset-env": "^7.22.20",
         "@babel/preset-react": "^7.8.0",
         "@babel/preset-typescript": "^7.8.0",
@@ -264,12 +265,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.7",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -313,13 +314,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.25.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.5.tgz",
+      "integrity": "sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==",
       "dependencies": {
-        "@babel/types": "^7.23.0",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
+        "@babel/types": "^7.25.4",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -499,9 +500,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -550,11 +551,12 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
-      "integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
+      "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -572,17 +574,17 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -622,22 +624,26 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
+      "integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
+      "dependencies": {
+        "@babel/types": "^7.25.4"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1617,12 +1623,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.0.tgz",
-      "integrity": "sha512-sBBGXbLJjxTzLBF5rFWaikMnOGOk/BmK6vVByIdEggZ7Vn6CvWXZyRkkLFK6WE0IF8jSliyOkUN6SScFgzCM0g==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.8.tgz",
+      "integrity": "sha512-5cTOLSMs9eypEy8JUVvIKOu6NgvbJMnpG62VpIHrTmROdQ+L5mDAaI40g25k5vXti55JWNX5jCkq3HZxXBQANw==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
+        "@babel/helper-plugin-utils": "^7.24.8",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       },
       "engines": {
@@ -2144,32 +2150,29 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.24.7",
+        "@babel/parser": "^7.25.0",
+        "@babel/types": "^7.25.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.4.tgz",
+      "integrity": "sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.25.4",
+        "@babel/parser": "^7.25.4",
+        "@babel/template": "^7.25.0",
+        "@babel/types": "^7.25.4",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -2177,12 +2180,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
+      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.8",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -2671,6 +2674,7 @@
       "version": "9.12.1",
       "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.12.1.tgz",
       "integrity": "sha512-qnlLZYwdysDt7HNRZjy890gQZ+bWRBAAIGra/qm5MjXO2D23R1+3L+WUZLQ62Xo5kEmp0k2e2wjoj2oANNLXFg==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "@types/lodash.uniqueid": "^4.0.7",
@@ -2710,7 +2714,7 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-14.0.1.tgz",
       "integrity": "sha512-5EJvsW0t968s24U7GxxKHBebwGIPo+QhCHgoDVipT8XR3yIAe4einmuY3VJqhDDycDBZff3zPVKLpJO0B3ZfGA==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "npm": ">7"
       },
@@ -2743,6 +2747,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@financial-times/o-loading/-/o-loading-5.2.3.tgz",
       "integrity": "sha512-rVK6WVCnf2VIDKdA2upIDLmYSSy49qxuEQOxuH1XhagvagYximCNE04F3ZXdQAUyKbdsR+BqFKr3SUp+N/5v0w==",
+      "dev": true,
       "peer": true,
       "engines": {
         "npm": ">7"
@@ -2782,6 +2787,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/@financial-times/o-toggle/-/o-toggle-3.2.6.tgz",
       "integrity": "sha512-jbbGz202yMLvYOOUQAg4BTqDOx2dNWkgenlE2BA2US2frsFdPX9Uv7vMdxRPbTGs8/RjsQiMiAiVlgh9BRFT7Q==",
+      "dev": true,
       "peer": true,
       "engines": {
         "npm": ">7"
@@ -2872,6 +2878,22 @@
       },
       "peerDependencies": {
         "@financial-times/math": "^1.0.0"
+      }
+    },
+    "node_modules/@financial-times/x-engine": {
+      "version": "14.7.5",
+      "resolved": "https://registry.npmjs.org/@financial-times/x-engine/-/x-engine-14.7.5.tgz",
+      "integrity": "sha512-O+JJobanxk1FSLxnbQ2b7s1CZsKtyGgdNQMMlhBzt52T+cD1HSPMluZ/xvckysw7zNAdlnVzuoDNkHRj0QhXsw==",
+      "dev": true,
+      "dependencies": {
+        "assign-deep": "^1.0.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x || 10.x"
+      },
+      "peerDependencies": {
+        "webpack": ">=4.0.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -4469,13 +4491,13 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -4490,9 +4512,9 @@
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -4513,9 +4535,9 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -7929,12 +7951,14 @@
     "node_modules/@types/lodash": {
       "version": "4.14.200",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q=="
+      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
+      "dev": true
     },
     "node_modules/@types/lodash.uniqueid": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/lodash.uniqueid/-/lodash.uniqueid-4.0.9.tgz",
       "integrity": "sha512-SEzkJBS8t+tqAUnSmyqbuWqxKU+Z/Xu2cgPtD+Ik0l+M7L2q7So9VoN2rQ8H0mmL87lJ00ykxal8oB54QRet6g==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "@types/lodash": "*"
@@ -10816,9 +10840,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001559",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001559.tgz",
-      "integrity": "sha512-cPiMKZgqgkg5LY3/ntGeLFUpi6tzddBNS58A4tnTgQw1zON7u2sZMU7SzOeVH4tj20++9ggL+V6FDOFMTaFFYA==",
+      "version": "1.0.30001653",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001653.tgz",
+      "integrity": "sha512-XGWQVB8wFQ2+9NZwZ10GxTYC5hk0Fa+q8cSkr0tgvMhYhMHP/QC+WTgrePMDBWiWc/pV+1ik82Al20XOK25Gcw==",
       "funding": [
         {
           "type": "opencollective",
@@ -11759,6 +11783,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "deprecated": "This package is no longer supported.",
       "dependencies": {
         "aproba": "^1.1.1",
         "fs-write-stream-atomic": "^1.0.8",
@@ -11788,6 +11813,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -14724,7 +14750,8 @@
     "node_modules/figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
-      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
+      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
+      "deprecated": "This module is no longer supported."
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -15680,6 +15707,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha512-gehEzmPn2nAwr39eay+x3X34Ra+M2QlVUTLhkXPjWdeO8RF9kszk116avgBJM3ZyNHgHXBNx+VmPaFC36k0PzA==",
+      "deprecated": "This package is no longer supported.",
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "iferr": "^0.1.5",
@@ -22196,6 +22224,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
       "integrity": "sha512-GQQWaIeGlL6DIIr06kj1j6sSmBxyNMwI8kaX9aKpHR/XsMTiaXDVPNPAkiboOTK9OJpTJF/dXT3xYoFQnj386Q==",
+      "dev": true,
       "peer": true
     },
     "node_modules/log-symbols": {
@@ -23232,6 +23261,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha512-hdrFxZOycD/g6A6SoI2bB5NA/5NEqD0569+S47WZhPvm46sD50ZHdYaFmnua5lndde9rCHGjmfK7Z8BuCt/PcQ==",
+      "deprecated": "This package is no longer supported.",
       "dependencies": {
         "aproba": "^1.1.1",
         "copy-concurrently": "^1.0.0",
@@ -23261,6 +23291,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -29653,9 +29684,9 @@
       }
     },
     "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
     },
     "node_modules/strict-uri-encode": {
       "version": "1.1.0",
@@ -33697,6 +33728,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -33734,9 +33766,9 @@
       }
     },
     "node_modules/webpack/node_modules/terser-webpack-plugin": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
-      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.6.tgz",
+      "integrity": "sha512-2lBVf/VMVIddjSn3GqbT90GvIJ/eYXJkt8cTzU7NbjKqK8fwv18Ftr4PlbF46b/e88743iZFL5Dtr/rC4hjIeA==",
       "dependencies": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
@@ -34718,6 +34750,8 @@
       },
       "devDependencies": {
         "@financial-times/logo-images": "^1.10.1",
+        "@financial-times/o-header": "^14.0.1",
+        "@financial-times/x-engine": "^14.7.5",
         "@svgr/core": "^5.0.0",
         "camelcase": "^6.0.0",
         "check-engine": "^1.10.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2707,9 +2707,9 @@
       }
     },
     "node_modules/@financial-times/o-header": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-13.0.3.tgz",
-      "integrity": "sha512-gNY5zObcm307x6Saj+2nFhKQ0/o08216gACp35BSKV6/ZqGVqFuiHT6aqdEetmLQOVVBdo0aFhKtwiVVh2BE8Q==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-14.0.0.tgz",
+      "integrity": "sha512-spmbvL1KEGQjv03I1YyDqp3zgzIoCgu84dyBP4OmySu/zUgbE4nyZmu1K/K+mDhmyB93ru5bvqlvMC9aZu59pg==",
       "peer": true,
       "engines": {
         "npm": ">7"
@@ -34732,7 +34732,7 @@
       },
       "peerDependencies": {
         "@financial-times/logo-images": "^1.10.1",
-        "@financial-times/o-header": "13.0.3",
+        "@financial-times/o-header": "14.0.0",
         "n-ui-foundations": "^9.0.0 || ^10.0.0",
         "react": "17.x || 18.x",
         "react-dom": "17.x || 18.x"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2707,9 +2707,9 @@
       }
     },
     "node_modules/@financial-times/o-header": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-14.0.0.tgz",
-      "integrity": "sha512-spmbvL1KEGQjv03I1YyDqp3zgzIoCgu84dyBP4OmySu/zUgbE4nyZmu1K/K+mDhmyB93ru5bvqlvMC9aZu59pg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-14.0.1.tgz",
+      "integrity": "sha512-5EJvsW0t968s24U7GxxKHBebwGIPo+QhCHgoDVipT8XR3yIAe4einmuY3VJqhDDycDBZff3zPVKLpJO0B3ZfGA==",
       "peer": true,
       "engines": {
         "npm": ">7"
@@ -23225,7 +23225,8 @@
     "node_modules/morphdom": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.1.tgz",
-      "integrity": "sha512-LwrrjplMolniWtOGluKF1EHZ0y78Fa4sq7f/MXCydyNkDof+POf+ruCn+k08l7H7b/JISfRo8Zd0HazuqySY9w=="
+      "integrity": "sha512-LwrrjplMolniWtOGluKF1EHZ0y78Fa4sq7f/MXCydyNkDof+POf+ruCn+k08l7H7b/JISfRo8Zd0HazuqySY9w==",
+      "dev": true
     },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
@@ -23301,20 +23302,16 @@
       }
     },
     "node_modules/n-topic-search": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/n-topic-search/-/n-topic-search-4.0.0.tgz",
-      "integrity": "sha512-AjfDQVkPe7QEnYRHFWFJ4zmH5at8sQiazCXcS7/9WJUHPbDZ4gUq+1rRmKfBxCy0JCXK3tKthKOD+Mtj1amdrQ==",
-      "hasInstallScript": true,
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/n-topic-search/-/n-topic-search-7.0.1.tgz",
+      "integrity": "sha512-22FkfNGEcB6vqMqZdPRbu5V0jq0y8/EsfbOdE+OAvPJDjj0CfFbgWouH+6OU7JvN8w8ROBrbS+De3FsiBCDcAA==",
       "dependencies": {
-        "ftdomdelegate": "^5.0.0",
-        "morphdom": "^2.5.4"
+        "lodash.debounce": "^4.0.8",
+        "preact": "^10.23.2"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x"
-      },
-      "peerDependencies": {
-        "n-ui-foundations": "^9.0.0"
+        "node": "18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/n-ui-foundations": {
@@ -26549,10 +26546,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/preact": {
-      "version": "10.18.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.18.2.tgz",
-      "integrity": "sha512-X/K43vocUHDg0XhWVmTTMbec4LT/iBMh+csCEqJk+pJqegaXsvjdqN80ZZ3L+93azWCnWCZ+WGwYb8SplxeNjA==",
-      "peer": true,
+      "version": "10.23.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.23.2.tgz",
+      "integrity": "sha512-kKYfePf9rzKnxOAKDpsWhg/ysrHPqT+yQ7UW4JjdnqjFIeNUnNcEJvhuA8fDenxAGWzUqtd51DfVg7xp/8T9NA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -34718,7 +34714,7 @@
       "license": "MIT",
       "dependencies": {
         "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
-        "n-topic-search": "^4.0.0"
+        "n-topic-search": "^7.0.1"
       },
       "devDependencies": {
         "@financial-times/logo-images": "^1.10.1",
@@ -34732,7 +34728,7 @@
       },
       "peerDependencies": {
         "@financial-times/logo-images": "^1.10.1",
-        "@financial-times/o-header": "14.0.0",
+        "@financial-times/o-header": "^14.0.1",
         "n-ui-foundations": "^9.0.0 || ^10.0.0",
         "react": "17.x || 18.x",
         "react-dom": "17.x || 18.x"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2674,7 +2674,6 @@
       "version": "9.12.1",
       "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.12.1.tgz",
       "integrity": "sha512-qnlLZYwdysDt7HNRZjy890gQZ+bWRBAAIGra/qm5MjXO2D23R1+3L+WUZLQ62Xo5kEmp0k2e2wjoj2oANNLXFg==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@types/lodash.uniqueid": "^4.0.7",
@@ -2714,7 +2713,7 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-14.0.1.tgz",
       "integrity": "sha512-5EJvsW0t968s24U7GxxKHBebwGIPo+QhCHgoDVipT8XR3yIAe4einmuY3VJqhDDycDBZff3zPVKLpJO0B3ZfGA==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "npm": ">7"
       },
@@ -2747,7 +2746,6 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@financial-times/o-loading/-/o-loading-5.2.3.tgz",
       "integrity": "sha512-rVK6WVCnf2VIDKdA2upIDLmYSSy49qxuEQOxuH1XhagvagYximCNE04F3ZXdQAUyKbdsR+BqFKr3SUp+N/5v0w==",
-      "dev": true,
       "peer": true,
       "engines": {
         "npm": ">7"
@@ -2787,7 +2785,6 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/@financial-times/o-toggle/-/o-toggle-3.2.6.tgz",
       "integrity": "sha512-jbbGz202yMLvYOOUQAg4BTqDOx2dNWkgenlE2BA2US2frsFdPX9Uv7vMdxRPbTGs8/RjsQiMiAiVlgh9BRFT7Q==",
-      "dev": true,
       "peer": true,
       "engines": {
         "npm": ">7"
@@ -2878,22 +2875,6 @@
       },
       "peerDependencies": {
         "@financial-times/math": "^1.0.0"
-      }
-    },
-    "node_modules/@financial-times/x-engine": {
-      "version": "14.7.5",
-      "resolved": "https://registry.npmjs.org/@financial-times/x-engine/-/x-engine-14.7.5.tgz",
-      "integrity": "sha512-O+JJobanxk1FSLxnbQ2b7s1CZsKtyGgdNQMMlhBzt52T+cD1HSPMluZ/xvckysw7zNAdlnVzuoDNkHRj0QhXsw==",
-      "dev": true,
-      "dependencies": {
-        "assign-deep": "^1.0.1"
-      },
-      "engines": {
-        "node": "16.x || 18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
-      },
-      "peerDependencies": {
-        "webpack": ">=4.0.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -7951,14 +7932,12 @@
     "node_modules/@types/lodash": {
       "version": "4.14.200",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
-      "dev": true
+      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q=="
     },
     "node_modules/@types/lodash.uniqueid": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/lodash.uniqueid/-/lodash.uniqueid-4.0.9.tgz",
       "integrity": "sha512-SEzkJBS8t+tqAUnSmyqbuWqxKU+Z/Xu2cgPtD+Ik0l+M7L2q7So9VoN2rQ8H0mmL87lJ00ykxal8oB54QRet6g==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@types/lodash": "*"
@@ -22224,7 +22203,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
       "integrity": "sha512-GQQWaIeGlL6DIIr06kj1j6sSmBxyNMwI8kaX9aKpHR/XsMTiaXDVPNPAkiboOTK9OJpTJF/dXT3xYoFQnj386Q==",
-      "dev": true,
       "peer": true
     },
     "node_modules/log-symbols": {
@@ -23333,9 +23311,9 @@
       }
     },
     "node_modules/n-topic-search": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/n-topic-search/-/n-topic-search-7.0.1.tgz",
-      "integrity": "sha512-22FkfNGEcB6vqMqZdPRbu5V0jq0y8/EsfbOdE+OAvPJDjj0CfFbgWouH+6OU7JvN8w8ROBrbS+De3FsiBCDcAA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/n-topic-search/-/n-topic-search-8.0.0.tgz",
+      "integrity": "sha512-b85Bx2R+R0reVnmrTFF/tkYDNC9/BAfBi81i9jdMXGMUVoUgXeq7ukq50LRVrn4rmUPcfvRLicsKoodKOCl4+Q==",
       "dependencies": {
         "lodash.debounce": "^4.0.8",
         "preact": "^10.23.2"
@@ -34746,12 +34724,10 @@
       "license": "MIT",
       "dependencies": {
         "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
-        "n-topic-search": "^7.0.1"
+        "n-topic-search": "^8.0.0"
       },
       "devDependencies": {
         "@financial-times/logo-images": "^1.10.1",
-        "@financial-times/o-header": "^14.0.1",
-        "@financial-times/x-engine": "^14.7.5",
         "@svgr/core": "^5.0.0",
         "camelcase": "^6.0.0",
         "check-engine": "^1.10.1"

--- a/package.json
+++ b/package.json
@@ -44,11 +44,12 @@
   "homepage": "https://github.com/Financial-Times/dotcom-page-kit#readme",
   "devDependencies": {
     "@babel/core": "^7.8.0",
+    "@babel/plugin-transform-optional-chaining": "^7.24.8",
     "@babel/preset-env": "^7.22.20",
     "@babel/preset-react": "^7.8.0",
     "@babel/preset-typescript": "^7.8.0",
-    "@storybook/addon-essentials": "^6.0.27",
     "@storybook/addon-docs": "^6.0.27",
+    "@storybook/addon-essentials": "^6.0.27",
     "@storybook/react": "^6.0.27",
     "@storybook/storybook-deployer": "^2.8.7",
     "@testing-library/jest-dom": "^5.17.0",

--- a/packages/dotcom-ui-header/browser.js
+++ b/packages/dotcom-ui-header/browser.js
@@ -1,5 +1,6 @@
 import Header from '@financial-times/o-header'
-import TopicSearch from 'n-topic-search'
+import TypeAhead from 'n-topic-search'
+import { h, render } from 'preact'
 
 /**
  * @typedef HeaderOptions
@@ -16,7 +17,29 @@ export const init = (headerOptions = {}) => {
     '.o-header [data-n-topic-search], .o-header__drawer [data-n-topic-search]'
   )
   topicSearchElements.forEach((element) => {
-    new TopicSearch(element, headerOptions)
+    const oheaderContainer = element.parentElement
+    const oheaderContainerParent = oheaderContainer?.parentElement
+    const isDrawer = oheaderContainerParent?.parentElement?.getAttribute('data-o-header-drawer') === 'true'
+
+    const form = oheaderContainer?.querySelector('form')
+    const input = form?.querySelector('input')
+    const typeaheadContainer = document.createElement('div')
+    typeaheadContainer.id = `suggestions-${input?.id}`
+    typeaheadContainer.className = 'typeahead__main-container'
+    typeaheadContainer.role = 'listbox'
+
+    if (!form || !input) return
+
+    if (isDrawer) {
+      const mobileDrawer = oheaderContainerParent?.parentElement
+      element.appendChild(typeaheadContainer)
+
+      render(<TypeAhead container={mobileDrawer} inputId={input.id} />, typeaheadContainer)
+    } else {
+      form.after(typeaheadContainer)
+
+      render(<TypeAhead container={oheaderContainerParent} inputId={input.id} />, typeaheadContainer)
+    }
   })
 
   Header.init(headerOptions.rootElement)

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@financial-times/logo-images": "^1.10.1",
-    "@financial-times/o-header": "13.0.3",
+    "@financial-times/o-header": "14.0.0",
     "n-ui-foundations": "^9.0.0 || ^10.0.0",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x"

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
-    "n-topic-search": "^4.0.0"
+    "n-topic-search": "^7.0.1"
   },
   "devDependencies": {
     "@financial-times/logo-images": "^1.10.1",
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@financial-times/logo-images": "^1.10.1",
-    "@financial-times/o-header": "14.0.0",
+    "@financial-times/o-header": "^14.0.1",
     "n-ui-foundations": "^9.0.0 || ^10.0.0",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x"

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
-    "n-topic-search": "^7.0.1"
+    "n-topic-search": "^8.0.0"
   },
   "devDependencies": {
     "@financial-times/logo-images": "^1.10.1",

--- a/packages/dotcom-ui-header/src/__stories__/story.tsx
+++ b/packages/dotcom-ui-header/src/__stories__/story.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import * as header from '../../browser.js'
+import Header from '@financial-times/o-header'
 import { OnReady } from '../../../../.storybook/components/OnReady'
 import {
   Header as HeaderSimple,
@@ -15,10 +15,7 @@ import '../../styles.scss'
 import './demos.scss'
 
 const onReadyCallback = () => {
-  // Passing a cors-anywhere hostname to n-topic-search
-  // An 'origin' request header will be set on the subsequent fetch request to next-search-api
-  // This satisfies the api's cors rules allowing a response to be sent and rendered on localhost
-  header.init({ hostName: 'cors-anywhere.herokuapp.com/www.ft.com' })
+  Header.init()
 }
 
 export default {
@@ -98,7 +95,7 @@ LargeHeaderWithDrawer.args = {
 }
 
 export const _StickyHeader = (args) => (
-  <OnReady callback={() => header.init()}>
+  <OnReady callback={onReadyCallback}>
     <StickyHeader {...storyData} {...args} />
     <p className="demo-sticky-message demo-sticky-message--scroll">Scroll down</p>
   </OnReady>

--- a/packages/dotcom-ui-header/src/__test__/components/TypeaheadIntegration.test.tsx
+++ b/packages/dotcom-ui-header/src/__test__/components/TypeaheadIntegration.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import fixture from '../../__stories__/story-data/index'
+import { Drawer, MainHeader } from '../../index'
+
+const propsAnonymous = { ...fixture, userIsAnonymous: true, userIsLoggedIn: false }
+
+const components = [
+  { name: 'Drawer', Component: Drawer },
+  { name: 'MainHeader', Component: MainHeader }
+]
+
+describe('page-kit-header and typeahead (n-topic-search) integration', () => {
+  components.forEach(({ name, Component }) => {
+    describe(`${name} component`, () => {
+      it(`should render the Typeahead component with the correct attribute that indicates the input field is inside the ${name.toLowerCase()}`, () => {
+        render(<Component {...propsAnonymous} />)
+        const searchInput = screen.getByRole('combobox')
+
+        expect(searchInput).toBeInTheDocument()
+        expect(searchInput).toHaveAttribute('type', 'search')
+      })
+
+      it('should semantically connect the suggestions wrapper by setting aria-controls attribute', () => {
+        render(<Component {...propsAnonymous} />)
+        const searchInput = screen.getByRole('combobox')
+
+        expect(searchInput).toHaveAttribute('aria-controls', `suggestions-${searchInput.id}`)
+      })
+
+      if (name === 'Drawer') {
+        it('should indicate that search input belongs inside a drawer', () => {
+          render(<Component {...propsAnonymous} />)
+          const searchInput = screen.getByRole('combobox')
+
+          expect(searchInput).toHaveAttribute('data-n-topic-search-drawer')
+        })
+      }
+    })
+  })
+})

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -64,8 +64,6 @@ exports[`dotcom-ui-header/src/components/Drawer renders ASK FT button 1`] = `
         aria-label="Site search"
         className="o-header__drawer-search-form"
         data-n-topic-search={true}
-        data-n-topic-search-categories="concepts,equities"
-        data-n-topic-search-view-all={true}
         role="search"
       >
         <label
@@ -90,16 +88,19 @@ exports[`dotcom-ui-header/src/components/Drawer renders ASK FT button 1`] = `
             className="o-forms-input o-forms-input--text o-forms-input--suffix"
           >
             <input
+              aria-controls="suggestions-o-header-drawer-search-term"
               autoCapitalize="off"
               autoComplete="off"
               autoCorrect="off"
+              data-n-topic-search-drawer="true"
               data-n-topic-search-input={true}
               data-trackable="search-term"
               id="o-header-drawer-search-term"
               name="q"
               placeholder="Search for stories, topics or securities"
+              role="combobox"
               spellCheck={false}
-              type="text"
+              type="search"
             />
             <button
               className="o-header__drawer-search-submit"
@@ -1433,8 +1434,6 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
         aria-label="Site search"
         className="o-header__drawer-search-form"
         data-n-topic-search={true}
-        data-n-topic-search-categories="concepts,equities"
-        data-n-topic-search-view-all={true}
         role="search"
       >
         <label
@@ -1459,16 +1458,19 @@ exports[`dotcom-ui-header/src/components/Drawer renders as a logged in user 1`] 
             className="o-forms-input o-forms-input--text o-forms-input--suffix"
           >
             <input
+              aria-controls="suggestions-o-header-drawer-search-term"
               autoCapitalize="off"
               autoComplete="off"
               autoCorrect="off"
+              data-n-topic-search-drawer="true"
               data-n-topic-search-input={true}
               data-trackable="search-term"
               id="o-header-drawer-search-term"
               name="q"
               placeholder="Search for stories, topics or securities"
+              role="combobox"
               spellCheck={false}
-              type="text"
+              type="search"
             />
             <button
               className="o-header__drawer-search-submit"
@@ -2793,8 +2795,6 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
         aria-label="Site search"
         className="o-header__drawer-search-form"
         data-n-topic-search={true}
-        data-n-topic-search-categories="concepts,equities"
-        data-n-topic-search-view-all={true}
         role="search"
       >
         <label
@@ -2819,16 +2819,19 @@ exports[`dotcom-ui-header/src/components/Drawer renders as an anonymous user 1`]
             className="o-forms-input o-forms-input--text o-forms-input--suffix"
           >
             <input
+              aria-controls="suggestions-o-header-drawer-search-term"
               autoCapitalize="off"
               autoComplete="off"
               autoCorrect="off"
+              data-n-topic-search-drawer="true"
               data-n-topic-search-input={true}
               data-trackable="search-term"
               id="o-header-drawer-search-term"
               name="q"
               placeholder="Search for stories, topics or securities"
+              role="combobox"
               spellCheck={false}
-              type="text"
+              type="search"
             />
             <button
               className="o-header__drawer-search-submit"

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -116,23 +116,15 @@ exports[`dotcom-ui-header/src/components/Drawer renders ASK FT button 1`] = `
         </label>
       </form>
     </div>
-    <div
-      className="o-header__drawer-actions"
+    <a
+      className="o-header__ask-ft-button o-header__ask-ft-button--drawer"
+      data-trackable="ask-ft-button-drawer"
+      href="https://ask.ft.com"
+      id="ask-ft-button-drawer"
+      title="ASK FT"
     >
-      <a
-        className="ft-header__ask-ft-button ft-header__drawer-ask-ft-button"
-        data-trackable="ask-ft-button-drawer"
-        href="https://ask.ft.com"
-        id="ask-ft-button-drawer"
-        title="ASK FT"
-      >
-        <span
-          className="ft-header__ask-ft-button-label"
-        >
-          Ask FT
-        </span>
-      </a>
-    </div>
+      Ask FT
+    </a>
     <div
       className="o-header__drawer-actions"
     >

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -47,23 +47,15 @@ exports[`dotcom-ui-header/src/components/MainHeader renders ASK FT button 1`] = 
               Open search bar
             </span>
           </a>
-          <div
-            className="o-header__drawer-actions"
+          <a
+            className="o-header__ask-ft-button o-header__ask-ft-button--top"
+            data-trackable="ask-ft-button-header"
+            href="https://ask.ft.com"
+            id="ask-ft-button-header"
+            title="ASK FT"
           >
-            <a
-              className="ft-header__ask-ft-button ft-header__top-ask-ft-button"
-              data-trackable="ask-ft-button-header"
-              href="https://ask.ft.com"
-              id="ask-ft-button-header"
-              title="ASK FT"
-            >
-              <span
-                className="ft-header__ask-ft-button-label"
-              >
-                Ask FT
-              </span>
-            </a>
-          </div>
+            Ask FT
+          </a>
         </div>
         <div
           className="o-header__top-column o-header__top-column--center"

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -124,8 +124,6 @@ exports[`dotcom-ui-header/src/components/MainHeader renders ASK FT button 1`] = 
         aria-label="Site search"
         className="o-header__search-form"
         data-n-topic-search={true}
-        data-n-topic-search-categories="concepts,equities"
-        data-n-topic-search-view-all={true}
         role="search"
       >
         <label
@@ -150,23 +148,28 @@ exports[`dotcom-ui-header/src/components/MainHeader renders ASK FT button 1`] = 
             className="o-forms-input o-forms-input--text o-forms-input--suffix"
           >
             <input
+              aria-controls="suggestions-o-header-search-term-primary"
               autoCapitalize="off"
               autoComplete="off"
               autoCorrect="off"
-              className="o-header__search-term"
-              data-n-topic-search-input={true}
-              data-trackable="search-term"
               id="o-header-search-term-primary"
               name="q"
               placeholder="Search for stories, topics or securities"
+              role="combobox"
               spellCheck={false}
-              type="text"
+              type="search"
             />
             <button
               className="o-header__search-submit"
               type="submit"
             >
-              Search
+              <span
+                aria-hidden="true"
+                className="o-header__search-icon"
+              />
+              <span>
+                Search
+              </span>
             </button>
             <button
               aria-controls="o-header-search-primary"
@@ -179,6 +182,9 @@ exports[`dotcom-ui-header/src/components/MainHeader renders ASK FT button 1`] = 
                 className="o-header__visually-hidden"
               >
                 Close search bar
+              </span>
+              <span>
+                Close
               </span>
             </button>
           </span>
@@ -1979,8 +1985,6 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
         aria-label="Site search"
         className="o-header__search-form"
         data-n-topic-search={true}
-        data-n-topic-search-categories="concepts,equities"
-        data-n-topic-search-view-all={true}
         role="search"
       >
         <label
@@ -2005,23 +2009,28 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
             className="o-forms-input o-forms-input--text o-forms-input--suffix"
           >
             <input
+              aria-controls="suggestions-o-header-search-term-primary"
               autoCapitalize="off"
               autoComplete="off"
               autoCorrect="off"
-              className="o-header__search-term"
-              data-n-topic-search-input={true}
-              data-trackable="search-term"
               id="o-header-search-term-primary"
               name="q"
               placeholder="Search for stories, topics or securities"
+              role="combobox"
               spellCheck={false}
-              type="text"
+              type="search"
             />
             <button
               className="o-header__search-submit"
               type="submit"
             >
-              Search
+              <span
+                aria-hidden="true"
+                className="o-header__search-icon"
+              />
+              <span>
+                Search
+              </span>
             </button>
             <button
               aria-controls="o-header-search-primary"
@@ -2034,6 +2043,9 @@ exports[`dotcom-ui-header/src/components/MainHeader renders a right aligned subn
                 className="o-header__visually-hidden"
               >
                 Close search bar
+              </span>
+              <span>
+                Close
               </span>
             </button>
           </span>
@@ -3829,8 +3841,6 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
         aria-label="Site search"
         className="o-header__search-form"
         data-n-topic-search={true}
-        data-n-topic-search-categories="concepts,equities"
-        data-n-topic-search-view-all={true}
         role="search"
       >
         <label
@@ -3855,23 +3865,28 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
             className="o-forms-input o-forms-input--text o-forms-input--suffix"
           >
             <input
+              aria-controls="suggestions-o-header-search-term-primary"
               autoCapitalize="off"
               autoComplete="off"
               autoCorrect="off"
-              className="o-header__search-term"
-              data-n-topic-search-input={true}
-              data-trackable="search-term"
               id="o-header-search-term-primary"
               name="q"
               placeholder="Search for stories, topics or securities"
+              role="combobox"
               spellCheck={false}
-              type="text"
+              type="search"
             />
             <button
               className="o-header__search-submit"
               type="submit"
             >
-              Search
+              <span
+                aria-hidden="true"
+                className="o-header__search-icon"
+              />
+              <span>
+                Search
+              </span>
             </button>
             <button
               aria-controls="o-header-search-primary"
@@ -3884,6 +3899,9 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as a logged in user 
                 className="o-header__visually-hidden"
               >
                 Close search bar
+              </span>
+              <span>
+                Close
               </span>
             </button>
           </span>
@@ -5684,8 +5702,6 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
         aria-label="Site search"
         className="o-header__search-form"
         data-n-topic-search={true}
-        data-n-topic-search-categories="concepts,equities"
-        data-n-topic-search-view-all={true}
         role="search"
       >
         <label
@@ -5710,23 +5726,28 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
             className="o-forms-input o-forms-input--text o-forms-input--suffix"
           >
             <input
+              aria-controls="suggestions-o-header-search-term-primary"
               autoCapitalize="off"
               autoComplete="off"
               autoCorrect="off"
-              className="o-header__search-term"
-              data-n-topic-search-input={true}
-              data-trackable="search-term"
               id="o-header-search-term-primary"
               name="q"
               placeholder="Search for stories, topics or securities"
+              role="combobox"
               spellCheck={false}
-              type="text"
+              type="search"
             />
             <button
               className="o-header__search-submit"
               type="submit"
             >
-              Search
+              <span
+                aria-hidden="true"
+                className="o-header__search-icon"
+              />
+              <span>
+                Search
+              </span>
             </button>
             <button
               aria-controls="o-header-search-primary"
@@ -5739,6 +5760,9 @@ exports[`dotcom-ui-header/src/components/MainHeader renders as an anonymous user
                 className="o-header__visually-hidden"
               >
                 Close search bar
+              </span>
+              <span>
+                Close
               </span>
             </button>
           </span>

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
@@ -46,23 +46,15 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders ASK FT button 1`] 
               Search
             </span>
           </a>
-          <div
-            className="o-header__drawer-actions"
+          <a
+            className="o-header__ask-ft-button o-header__ask-ft-button--top"
+            data-trackable="ask-ft-button-sticky"
+            href="https://ask.ft.com"
+            id="ask-ft-button-sticky"
+            title="ASK FT"
           >
-            <a
-              className="ft-header__ask-ft-button ft-header__top-ask-ft-button"
-              data-trackable="ask-ft-button-sticky"
-              href="https://ask.ft.com"
-              id="ask-ft-button-sticky"
-              title="ASK FT"
-            >
-              <span
-                className="ft-header__ask-ft-button-label"
-              >
-                Ask FT
-              </span>
-            </a>
-          </div>
+            Ask FT
+          </a>
         </div>
         <div
           className="o-header__top-column o-header__top-column--center"

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
@@ -259,8 +259,6 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders ASK FT button 1`] 
         aria-label="Site search"
         className="o-header__search-form"
         data-n-topic-search={true}
-        data-n-topic-search-categories="concepts,equities"
-        data-n-topic-search-view-all={true}
         role="search"
       >
         <label
@@ -285,23 +283,28 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders ASK FT button 1`] 
             className="o-forms-input o-forms-input--text o-forms-input--suffix"
           >
             <input
+              aria-controls="suggestions-o-header-search-term-sticky"
               autoCapitalize="off"
               autoComplete="off"
               autoCorrect="off"
-              className="o-header__search-term"
-              data-n-topic-search-input={true}
-              data-trackable="search-term"
               id="o-header-search-term-sticky"
               name="q"
               placeholder="Search for stories, topics or securities"
+              role="combobox"
               spellCheck={false}
-              type="text"
+              type="search"
             />
             <button
               className="o-header__search-submit"
               type="submit"
             >
-              Search
+              <span
+                aria-hidden="true"
+                className="o-header__search-icon"
+              />
+              <span>
+                Search
+              </span>
             </button>
             <button
               aria-controls="o-header-search-sticky"
@@ -314,6 +317,9 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders ASK FT button 1`] 
                 className="o-header__visually-hidden"
               >
                 Close search bar
+              </span>
+              <span>
+                Close
               </span>
             </button>
           </span>
@@ -574,8 +580,6 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as a logged in use
         aria-label="Site search"
         className="o-header__search-form"
         data-n-topic-search={true}
-        data-n-topic-search-categories="concepts,equities"
-        data-n-topic-search-view-all={true}
         role="search"
       >
         <label
@@ -600,23 +604,28 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as a logged in use
             className="o-forms-input o-forms-input--text o-forms-input--suffix"
           >
             <input
+              aria-controls="suggestions-o-header-search-term-sticky"
               autoCapitalize="off"
               autoComplete="off"
               autoCorrect="off"
-              className="o-header__search-term"
-              data-n-topic-search-input={true}
-              data-trackable="search-term"
               id="o-header-search-term-sticky"
               name="q"
               placeholder="Search for stories, topics or securities"
+              role="combobox"
               spellCheck={false}
-              type="text"
+              type="search"
             />
             <button
               className="o-header__search-submit"
               type="submit"
             >
-              Search
+              <span
+                aria-hidden="true"
+                className="o-header__search-icon"
+              />
+              <span>
+                Search
+              </span>
             </button>
             <button
               aria-controls="o-header-search-sticky"
@@ -629,6 +638,9 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as a logged in use
                 className="o-header__visually-hidden"
               >
                 Close search bar
+              </span>
+              <span>
+                Close
               </span>
             </button>
           </span>
@@ -888,8 +900,6 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as an anonymous us
         aria-label="Site search"
         className="o-header__search-form"
         data-n-topic-search={true}
-        data-n-topic-search-categories="concepts,equities"
-        data-n-topic-search-view-all={true}
         role="search"
       >
         <label
@@ -914,23 +924,28 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as an anonymous us
             className="o-forms-input o-forms-input--text o-forms-input--suffix"
           >
             <input
+              aria-controls="suggestions-o-header-search-term-sticky"
               autoCapitalize="off"
               autoComplete="off"
               autoCorrect="off"
-              className="o-header__search-term"
-              data-n-topic-search-input={true}
-              data-trackable="search-term"
               id="o-header-search-term-sticky"
               name="q"
               placeholder="Search for stories, topics or securities"
+              role="combobox"
               spellCheck={false}
-              type="text"
+              type="search"
             />
             <button
               className="o-header__search-submit"
               type="submit"
             >
-              Search
+              <span
+                aria-hidden="true"
+                className="o-header__search-icon"
+              />
+              <span>
+                Search
+              </span>
             </button>
             <button
               aria-controls="o-header-search-sticky"
@@ -943,6 +958,9 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders as an anonymous us
                 className="o-header__visually-hidden"
               >
                 Close search bar
+              </span>
+              <span>
+                Close
               </span>
             </button>
           </span>

--- a/packages/dotcom-ui-header/src/components/ask-ft/askFtButton.tsx
+++ b/packages/dotcom-ui-header/src/components/ask-ft/askFtButton.tsx
@@ -2,19 +2,18 @@ import React from 'react'
 
 export interface AskFtButtonProps {
   id: string
-  className: string
+  variant: 'top' | 'drawer'
   dataTrackable: string
 }
 
-export const AskFtButton = ({ id, className, dataTrackable }: AskFtButtonProps) => (
-  <div className="o-header__drawer-actions">
-    <a
-      id={id}
-      className={`ft-header__ask-ft-button ${className}`}
-      data-trackable={dataTrackable}
-      href="https://ask.ft.com"
-      title="ASK FT">
-      <span className="ft-header__ask-ft-button-label">Ask FT</span>
-    </a>
-  </div>
+export const AskFtButton = ({ id, variant, dataTrackable }: AskFtButtonProps) => (
+  <a
+    id={id}
+    className={`o-header__ask-ft-button o-header__ask-ft-button--${variant}`}
+    data-trackable={dataTrackable}
+    href="https://ask.ft.com"
+    title="ASK FT"
+  >
+    Ask FT
+  </a>
 )

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -63,44 +63,48 @@ const DrawerTools = (editions: TNavEditions) => (
   </div>
 )
 
-const Search = () => (
-  <div className="o-header__drawer-search">
-    <form
-      className="o-header__drawer-search-form"
-      action="/search"
-      role="search"
-      aria-label="Site search"
-      data-n-topic-search
-      data-n-topic-search-categories="concepts,equities"
-      data-n-topic-search-view-all
-    >
-      <label htmlFor="o-header-drawer-search-term" className="o-forms-field o-forms-field--optional">
-        <span className="o-forms-title o-header__visually-hidden">
-          <span className="o-forms-title__main">
-            Search the <abbr title="Financial Times">FT</abbr>
+const Search = () => {
+  const inputId = 'o-header-drawer-search-term'
+  return (
+    <div className="o-header__drawer-search">
+      <form
+        className="o-header__drawer-search-form"
+        action="/search"
+        role="search"
+        aria-label="Site search"
+        data-n-topic-search
+      >
+        <label htmlFor={inputId} className="o-forms-field o-forms-field--optional">
+          <span className="o-forms-title o-header__visually-hidden">
+            <span className="o-forms-title__main">
+              Search the <abbr title="Financial Times">FT</abbr>
+            </span>
           </span>
-        </span>
-        <span className="o-forms-input o-forms-input--text o-forms-input--suffix">
-          <input
-            id="o-header-drawer-search-term"
-            name="q"
-            type="text"
-            autoComplete="off"
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-            data-trackable="search-term"
-            data-n-topic-search-input
-            placeholder="Search for stories, topics or securities"
-          />
-          <button className="o-header__drawer-search-submit" type="submit" data-trackable="search-submit">
-            <span className="o-header__visually-hidden">Search</span>
-          </button>
-        </span>
-      </label>
-    </form>
-  </div>
-)
+          <span className="o-forms-input o-forms-input--text o-forms-input--suffix">
+            <input
+              id={inputId}
+              name="q"
+              type="search"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              data-trackable="search-term"
+              data-n-topic-search-input
+              placeholder="Search for stories, topics or securities"
+              role="combobox"
+              aria-controls={`suggestions-${inputId}`}
+              data-n-topic-search-drawer="true"
+            />
+            <button className="o-header__drawer-search-submit" type="submit" data-trackable="search-submit">
+              <span className="o-header__visually-hidden">Search</span>
+            </button>
+          </span>
+        </label>
+      </form>
+    </div>
+  )
+}
 
 const SectionPrimary = (props: TNavMenuItem) => {
   const sectionId = props.label.toLowerCase().replace(' ', '-')

--- a/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
+++ b/packages/dotcom-ui-header/src/components/drawer/topLevelPartials.tsx
@@ -28,16 +28,13 @@ const Drawer = (props: THeaderProps) => {
       data-o-header-drawer
       data-o-header-drawer--no-js
       data-trackable="drawer"
-      data-trackable-terminate>
+      data-trackable-terminate
+    >
       <div className="o-header__drawer-inner">
         <DrawerTools {...editions} />
         <Search />
         {props.showAskButton && (
-          <AskFtButton
-            className="ft-header__drawer-ask-ft-button"
-            id="ask-ft-button-drawer"
-            dataTrackable="ask-ft-button-drawer"
-          />
+          <AskFtButton variant="drawer" dataTrackable="ask-ft-button-drawer" id="ask-ft-button-drawer" />
         )}
         {!props.userIsSubscribed && subscribeAction && <SubscribeButton {...subscribeAction} />}
         <nav className="o-header__drawer-menu o-header__drawer-menu--primary">
@@ -58,7 +55,8 @@ const DrawerTools = (editions: TNavEditions) => (
       className="o-header__drawer-tools-close"
       title="Close side navigation menu"
       aria-controls="o-header-drawer"
-      data-trackable="close">
+      data-trackable="close"
+    >
       <span className="o-header__visually-hidden">Close side navigation menu</span>
     </button>
     {editions && <EditionsSwitcher {...editions} />}
@@ -74,7 +72,8 @@ const Search = () => (
       aria-label="Site search"
       data-n-topic-search
       data-n-topic-search-categories="concepts,equities"
-      data-n-topic-search-view-all>
+      data-n-topic-search-view-all
+    >
       <label htmlFor="o-header-drawer-search-term" className="o-forms-field o-forms-field--optional">
         <span className="o-forms-title o-header__visually-hidden">
           <span className="o-forms-title__main">

--- a/packages/dotcom-ui-header/src/components/search/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/search/partials.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
 
 const Search = ({ instance }) => {
+  const inputId = `o-header-search-term-${instance}`
   return (
     <div
       id={`o-header-search-${instance}`}
       className={`o-header__row o-header__search o-header__search--${instance}`}
       data-trackable="header-search"
-      data-o-header-search>
+      data-o-header-search
+    >
       <div className="o-header__container">
         <form
           className="o-header__search-form"
@@ -14,11 +16,8 @@ const Search = ({ instance }) => {
           role="search"
           aria-label="Site search"
           data-n-topic-search
-          data-n-topic-search-categories="concepts,equities"
-          data-n-topic-search-view-all>
-          <label
-            htmlFor={`o-header-search-term-${instance}`}
-            className="o-header__search-term o-forms-field o-forms-field--optional">
+        >
+          <label htmlFor={inputId} className="o-header__search-term o-forms-field o-forms-field--optional">
             <span className="o-forms-title o-header__visually-hidden">
               <span className="o-forms-title__main">
                 Search the <abbr title="Financial Times">FT</abbr>
@@ -26,28 +25,30 @@ const Search = ({ instance }) => {
             </span>
             <span className="o-forms-input o-forms-input--text o-forms-input--suffix">
               <input
-                className="o-header__search-term"
-                id={`o-header-search-term-${instance}`}
+                id={inputId}
                 name="q"
-                type="text"
+                type="search"
                 autoComplete="off"
                 autoCorrect="off"
                 autoCapitalize="off"
                 spellCheck={false}
-                data-trackable="search-term"
-                data-n-topic-search-input
                 placeholder="Search for stories, topics or securities"
+                role="combobox"
+                aria-controls={`suggestions-${inputId}`}
               />
               <button className="o-header__search-submit" type="submit">
-                Search
+                <span aria-hidden="true" className="o-header__search-icon"></span>
+                <span>Search</span>
               </button>
               <button
                 className="o-header__search-close o--if-js"
                 type="button"
                 aria-controls={`o-header-search-${instance}`}
                 title="Close search bar"
-                data-trackable="close">
+                data-trackable="close"
+              >
                 <span className="o-header__visually-hidden">Close search bar</span>
+                <span>Close</span>
               </button>
             </span>
           </label>

--- a/packages/dotcom-ui-header/src/components/sticky/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/sticky/partials.tsx
@@ -88,11 +88,7 @@ const TopColumnLeftSticky = (props: Pick<THeaderProps, 'showAskButton'>) => {
       <DrawerIconSticky />
       <SearchIconSticky />
       {props.showAskButton && (
-        <AskFtButton
-          className="ft-header__top-ask-ft-button"
-          id="ask-ft-button-sticky"
-          dataTrackable="ask-ft-button-sticky"
-        />
+        <AskFtButton variant="top" dataTrackable="ask-ft-button-sticky" id="ask-ft-button-sticky" />
       )}
     </div>
   )

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -79,11 +79,7 @@ const TopColumnLeft = (props: Pick<THeaderProps, 'showAskButton'>) => (
     <DrawerIcon />
     <SearchIcon />
     {props.showAskButton && (
-      <AskFtButton
-        className="ft-header__top-ask-ft-button"
-        id="ask-ft-button-header"
-        dataTrackable="ask-ft-button-header"
-      />
+      <AskFtButton variant="top" dataTrackable="ask-ft-button-header" id="ask-ft-button-header" />
     )}
   </div>
 )

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -14,6 +14,9 @@
   display: none;
 }
 
+#site-navigation {
+  position: relative;
+}
 
 .o-header__ask-ft-button {
   &, &:hover {

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -9,31 +9,11 @@
   display: block;
 }
 
-// z-indexes
-.o-header__mega {
-  @include nUiZIndexFor('meganav');
-}
-
-.o-header__drawer {
-  @include nUiZIndexFor('drawer');
-  display: block;
-  .o-header__drawer-search {
-    margin-bottom: 8px;
-  }
-}
-
-.o-header--sticky {
-  @include nUiZIndexFor('sticky-header');
-}
-
 // Search typeahead
 .n-typeahead {
   display: none;
 }
 
-.o-header__drawer-search-term {
-  width: 100%;
-}
 
 .o-header__ask-ft-button {
   &, &:hover {

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -34,48 +34,9 @@
 .o-header__drawer-search-term {
   width: 100%;
 }
-.o-header__top-wrapper .ft-header__ask-ft-button {
-  padding: 8px;
-}
-.ft-header__ask-ft-button {
-  @include oTypographySans(-1, $weight: 'semibold');
-  color: oColorsByName('ft-grey');
-  background-color: oColorsMix('black', 'paper', 5);
-  border-radius: 4px;
-  padding-right: 8px;
-  text-transform: uppercase;
-  text-decoration: none;
-  white-space: nowrap;
 
-  &::before {
-    content: '';
-    display: block;
-    @include oIconsContent(
-      $icon-name: 'sparkles',
-      $color: oColorsByName('black'),
-      $size: 32
-    );
-    vertical-align: top;
+.o-header__ask-ft-button {
+  &, &:hover {
+    color: oColorsByName('black-80');
   }
-
-  .ft-header__ask-ft-button-label {
-    display: inline-block;
-    padding: 8px 0;
-    line-height: 15px;
-  }
-}
-
-.ft-header__top-ask-ft-button {
-  @include oGridRespondTo($until: 'L') {
-    display: none;
-  }
-}
-
-.ft-header__drawer-ask-ft-button {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  margin: 0;
-  text-align: center;
-
 }

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -19,6 +19,7 @@
   position: relative;
 }
 
+// Overrides <a> color style set by n-ui-foundations
 .o-header__ask-ft-button {
   &, &:hover {
     color: oColorsByName('black-80');

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -14,6 +14,7 @@
   display: none;
 }
 
+// Please remove this rule once the following PR (https://github.com/Financial-Times/origami/pull/1808) is merged and o-header version is updated
 #site-navigation {
   position: relative;
 }

--- a/packages/dotcom-ui-header/styles.scss
+++ b/packages/dotcom-ui-header/styles.scss
@@ -1,17 +1,18 @@
 // This will be overridden by dotcom-ui-layout, it's necessary here for storybook builds
 $system-code: 'page-kit-header' !default;
 
-@import "n-ui-foundations/mixins";
+@import 'n-ui-foundations/mixins';
 
 // We don't need the sub-brand or transparent header styles so disable them.
 // TODO: move drawer styles into a separate stylesheet which can be lazy loaded?
-@import "@financial-times/o-header/main";
+@import '@financial-times/o-header/main';
 @include oHeader(('top', 'nav', 'subnav', 'search', 'megamenu', 'drawer', 'anon', 'sticky', 'simple'));
 
-@import "src/header";
+@import 'src/header';
 
-@import "n-topic-search/main";
+@import 'n-topic-search/main';
 @include nTopicSearch;
-.o-header__search--primary .n-topic-search, .o-header__search--sticky .n-topic-search {
+.o-header__search--primary .n-topic-search,
+.o-header__search--sticky .n-topic-search {
   margin: 24px 0 0;
 }

--- a/packages/dotcom-ui-header/styles.scss
+++ b/packages/dotcom-ui-header/styles.scss
@@ -12,7 +12,3 @@ $system-code: 'page-kit-header' !default;
 
 @import 'n-topic-search/main';
 @include nTopicSearch;
-.o-header__search--primary .n-topic-search,
-.o-header__search--sticky .n-topic-search {
-  margin: 24px 0 0;
-}


### PR DESCRIPTION
# Note 

This PR includes changes from https://github.com/Financial-Times/dotcom-page-kit/pull/1051. It has been rebased and merge conflicts has been resolved. These two features has to be released at the same time. Please, see the very first commit https://github.com/Financial-Times/dotcom-page-kit/pull/1052/commits/7f8be8ea084c447db46d503396938ae11521c017

cc: @Ventzy 

# Description

1. Mark-up changes to accommodate `o-header` v.14.0.1. (https://github.com/Financial-Times/origami/pull/1777)
1.1 Changing input search field to `type="search"`. This should improve the screen reader experience, also reflect true sematic meaning of the input field.
1.2 Input search field now has [`role="combobox"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role) to indicate that an element as an input that controls another element, such as a listbox or grid, that can dynamically pop up to help the user set the value of that input. 
In our case - typeahead (https://github.com/Financial-Times/n-topic-search/releases/tag/v7.0.0)
1.3 `aria-controls` attribute references typeahead wrapper
1.4 Close and Search buttons have undergone slight changes.
2. The initialization of the Typeahead component has been updated. Previously, it was implemented as a plain JavaScript class, it was re-written as a Preact functional component.
3. Added a bit of testing around the new mark-up.
4. New typeahead is written in Preact, so it seems like it's getting bundled as well. That's why the ci was failing previously. https://github.com/Financial-Times/dotcom-page-kit/pull/1052/commits/ede633b6034654eb4d971cc28a5cc1e8b20fbdca
5. Safari version was bumped accordingly to our [browser support policy](https://docs.google.com/document/d/1z6kecy_o9qHYIznTmqQ-IJqre72jhfd0nVa4JMsS7Q4/edit#heading=h.er7no6jwfim1)
6. `o-header` [fix](https://github.com/Financial-Times/origami/pull/1797/files) contained optional chaining syntax. That's why I needed to make a change to the webpack config and make sure webpack understands it.

# Demos 

<details>
<summary>
Interactivity demo [mobile]
</summary>

https://financialtimes.enterprise.slack.com/files/U04T4CBAV6C/F07GK51SZSP/screenrecording_08-12-2024_16-39-20_1.mp4

</details>

<details>
<summary>
Interactivity demo [desktop]
</summary>

https://github.com/user-attachments/assets/99b70260-8b16-4a85-b508-9ec59afdcaa9

</details>


# Relevant Releases
 - https://github.com/Financial-Times/origami/releases/tag/o-header-v14.0.0
 - https://github.com/Financial-Times/n-topic-search/releases/tag/v7.0.0

# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [ ] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [ ] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [ ] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
