### PR TITLE
chore: update myft wording in tests

### DIFF
--- a/examples/ft-ui/__test__/logged-in-user.test.js
+++ b/examples/ft-ui/__test__/logged-in-user.test.js
@@ -6,7 +6,7 @@ describe('examples/ft-ui', () => {
 
   describe('Header link elements', () => {
     it('renders the expected loggin-in user Header link elements', async () => {
-      await expect(page).toMatchElement('.o-header__nav-item a[href$="/myft"]', { text: 'myFT Feed' })
+      await expect(page).toMatchElement('.o-header__nav-item a[href$="/myft"]', { text: 'myFT' })
       await expect(page).toMatchElement('.o-header__top-column--right a[href$="/myaccount"]', {
         text: 'My Account'
       })

--- a/examples/ft-ui/__test__/subscribed-user.test.js
+++ b/examples/ft-ui/__test__/subscribed-user.test.js
@@ -6,7 +6,7 @@ describe('examples/ft-ui', () => {
 
   describe('Header link elements', () => {
     it('renders the expected loggin-in user Header link elements', async () => {
-      await expect(page).toMatchElement('.o-header__nav-item a[href$="/myft"]', { text: 'myFT Feed' })
+      await expect(page).toMatchElement('.o-header__nav-item a[href$="/myft"]', { text: 'myFT' })
       await expect(page).toMatchElement('.o-header__top-column--right a[href$="/myaccount"]', {
         text: 'My Account'
       })


### PR DESCRIPTION
# Description

Update the link text for myFT in the tests

# Justification

The link text was recently changed in the origami navigation service as these tests use real data these also need updating.

Original navigation service change https://github.com/Financial-Times/origami-navigation-service/pull/976