### PR TITLE
HIVE-2004-Decommission-Community-tour-page-and-links

### DIFF
--- a/__fixtures__/menus.json
+++ b/__fixtures__/menus.json
@@ -1150,7 +1150,6 @@
           "label": null,
           "items": [
             [
-              { "label": "FT Community", "url": "https://www.ft.com/tour/community", "submenu": null },
               { "label": "FT Live", "url": "http://live.ft.com/", "submenu": null },
               {
                 "label": "FT Forums",
@@ -1173,7 +1172,6 @@
           "label": null,
           "items": [
             [
-              { "label": "FT Community", "url": "https://www.ft.com/tour/community", "submenu": null },
               { "label": "FT Live", "url": "http://live.ft.com/", "submenu": null },
               {
                 "label": "FT Forums",

--- a/packages/dotcom-ui-footer/src/__stories__/footer.ts
+++ b/packages/dotcom-ui-footer/src/__stories__/footer.ts
@@ -205,7 +205,6 @@ const data: TNavMenu = {
         label: null,
         items: [
           [
-            { label: 'FT Community', url: 'https://www.ft.com/tour/community', submenu: null },
             { label: 'FT Live', url: 'http://live.ft.com/', submenu: null },
             {
               label: 'FT Forums',


### PR DESCRIPTION
# Description

We will be decommissioning the page --> https://www.ft.com/tour/community.
We need to remove the links pointing to it.

Part of --> https://financialtimes.atlassian.net/browse/HIVE-2004

# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [ ] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [x] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [x] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
