### PR TITLE
chore: remove obsolete scss declaration

### DIFF
--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -14,11 +14,6 @@
   display: none;
 }
 
-// Please remove this rule once the following PR (https://github.com/Financial-Times/origami/pull/1808) is merged and o-header version is updated
-#site-navigation {
-  position: relative;
-}
-
 // Overrides <a> color style set by n-ui-foundations
 .o-header__ask-ft-button {
   &, &:hover {


### PR DESCRIPTION
# Description

Relative position is declared in `o-header` css rule sets. See https://github.com/Financial-Times/origami/pull/1808/files#diff-e174d6ea6859969799730b2996e108172a5897a1e2efc779198a26bc6023afacR3