### PR TITLE
chore: bump `o-header` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2710,9 +2710,9 @@
       }
     },
     "node_modules/@financial-times/o-header": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-14.0.2.tgz",
-      "integrity": "sha512-2xKCDAy2JCrYwQSrvDhouMIu2l/fJC5yMN/8TDPxvR9KMP9K7MZGCCVD+kEDE7y81ncZWzxN3fCDs2gpv3tKkg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-14.0.4.tgz",
+      "integrity": "sha512-c3F5nG9DE5mf3eE3L8fYgPpUhBSdcJX9p6UmWy520q+Lm0nn+CUpWjfB8GjI18JlsisBnYZiRhs6owEGrzEVvQ==",
       "peer": true,
       "engines": {
         "npm": ">7"
@@ -34738,7 +34738,7 @@
       },
       "peerDependencies": {
         "@financial-times/logo-images": "^1.10.1",
-        "@financial-times/o-header": "^14.0.2",
+        "@financial-times/o-header": "^14.0.4",
         "n-ui-foundations": "^9.0.0 || ^10.0.0",
         "preact": "^10.23.2",
         "react": "17.x || 18.x",

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -33,11 +33,11 @@
   },
   "peerDependencies": {
     "@financial-times/logo-images": "^1.10.1",
-    "@financial-times/o-header": "^14.0.2",
+    "@financial-times/o-header": "^14.0.4",
     "n-ui-foundations": "^9.0.0 || ^10.0.0",
+    "preact": "^10.23.2",
     "react": "17.x || 18.x",
-    "react-dom": "17.x || 18.x",
-    "preact": "^10.23.2"
+    "react-dom": "17.x || 18.x"
   },
   "engines": {
     "node": "18.x || 20.x",


### PR DESCRIPTION
# Description

* 14.0.3 The new `o-header` version increases `z-index` for mega nav menu. It should fix issues where content below nav menu was appearing above the nav menu items.
* In addition 14.0.4 fixes an issue with sub items scrolling. https://github.com/Financial-Times/origami/releases/tag/o-header-v14.0.4

 
