### PR TITLE
Change Search Container position for core experience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23311,9 +23311,9 @@
       }
     },
     "node_modules/n-topic-search": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/n-topic-search/-/n-topic-search-8.0.4.tgz",
-      "integrity": "sha512-I4ODxU2QKGCxhlZtvXim3TM/l3NNXmPjV/kB7DhLdZK2dZ0RnhrKlaiE2svB4uGOsNW+CAxljPb0vCTwEM1d6Q==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/n-topic-search/-/n-topic-search-8.0.5.tgz",
+      "integrity": "sha512-IWF7cxdeOQ6owjS2XxvIvfm6cXQ9EsQD15lO17u8P8TAwc4pWBins7XGqlOL1BhvCTckGJ5sYsQh0hfsetIrRg==",
       "dependencies": {
         "lodash.debounce": "^4.0.8",
         "preact": "^10.23.2"
@@ -34724,7 +34724,7 @@
       "license": "MIT",
       "dependencies": {
         "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
-        "n-topic-search": "^8.0.4"
+        "n-topic-search": "^8.0.5"
       },
       "devDependencies": {
         "@financial-times/logo-images": "^1.10.1",

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
-    "n-topic-search": "^8.0.4"
+    "n-topic-search": "^8.0.5"
   },
   "devDependencies": {
     "@financial-times/logo-images": "^1.10.1",

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -7,6 +7,8 @@
 // experience if needed.
 .core [data-o-header-search] {
   display: block;
+  box-shadow: none;
+  position: relative;
 }
 
 // Search typeahead


### PR DESCRIPTION
## Why?

Recently @fenglish reported that Navigation bar is no longer accessible if user disables JavaScript. This change is caused by recent designs decisions to the search bar container. It started overlaying the content.

| Before | After |
|--------|-------|
 | <img width="1342" alt="Screenshot 2024-09-26 at 16 34 53" src="https://github.com/user-attachments/assets/209264c6-99ca-43bb-9911-96ecaf32a3fb"> |  <img width="1340" alt="Screenshot 2024-09-26 at 16 34 14" src="https://github.com/user-attachments/assets/c50d8cb0-d174-4be3-b0bb-2615a22b20c7">

* `n-topic-search` bump adds `data-trackable` attribute to clickable links in typeahead. - https://github.com/Financial-Times/n-topic-search/releases/tag/v8.0.5