### PR TITLE
backstage: remove extraneous peer dependencies from dotcom-build-code-splitting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16912,15 +16912,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/hyperons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hyperons/-/hyperons-2.0.0.tgz",
-      "integrity": "sha512-jS6YaZxTZnlzA0FDHmi6CsiLfPpGlGLJpEC4cwh+gjbvu/orRiSvIGHSTFd+P3juw2klGhgcT83p1FK1RiIaNQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -34248,15 +34239,6 @@
         "npm": "8.x || 9.x || 10.x"
       },
       "peerDependencies": {
-        "dateformat": "^3.0.0 || ^4.0.0",
-        "focus-visible": "^5.0.0",
-        "fontfaceobserver": "^2.0.9",
-        "ftdomdelegate": "^5.0.0",
-        "hyperons": "2.0.0",
-        "preact": "^10.18.2",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "ready-state": "^2.0.5",
-        "regenerator-runtime": "^0.14.0",
         "webpack": "^4.39.2"
       }
     },

--- a/packages/dotcom-build-code-splitting/package.json
+++ b/packages/dotcom-build-code-splitting/package.json
@@ -18,15 +18,6 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "dateformat": "^3.0.0 || ^4.0.0",
-    "focus-visible": "^5.0.0",
-    "fontfaceobserver": "^2.0.9",
-    "ftdomdelegate": "^5.0.0",
-    "hyperons": "2.0.0",
-    "preact": "^10.18.2",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "ready-state": "^2.0.5",
-    "regenerator-runtime" : "^0.14.0",
     "webpack": "^4.39.2"
   },
   "dependencies": {
@@ -44,7 +35,10 @@
     "node": "18.x || 20.x",
     "npm": "8.x || 9.x || 10.x"
   },
-  "files": ["dist/", "src/"],
+  "files": [
+    "dist/",
+    "src/"
+  ],
   "repository": {
     "type": "git",
     "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",


### PR DESCRIPTION
mistakenly added in #1012. the packages are only mentioned in this plugin as things to bundle when code splitting, they're not actually dependencies of this plugin.