### PR TITLE
ACC-3322 Remove n-feedback references

### DIFF
--- a/packages/dotcom-build-code-splitting/src/index.ts
+++ b/packages/dotcom-build-code-splitting/src/index.ts
@@ -88,11 +88,7 @@ export class PageKitCodeSplittingPlugin {
     const addSharedVolatileCodeSplitting = createBundleWithPackages({
       compiler,
       name: 'shared.volatile',
-      packages: [
-        '@financial-times/n-tracking',
-        '@financial-times/n-syndication',
-        '@financial-times/n-feedback'
-      ],
+      packages: ['@financial-times/n-tracking', '@financial-times/n-syndication'],
       usedInUnknownWay: true
     })
 


### PR DESCRIPTION
### ✍️ Description
Given that as a company we've moved away from Qualtrics, n-feedback has been turned off for a while now and does not work anymore since it does not have anywhere to send the data to. Therefore, n-feedback is being decomissioned and references to it are being removed.

### 🎟️ Ticket
[Ticket ACC-3322](https://financialtimes.atlassian.net/browse/ACC-3322)

# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [ ] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [ ] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [x] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
