### PR TITLE
[Fix] README link to contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Please note that Page Kit has only been tested in Mac and Linux environments. If
 
 4. You can now choose to run an example application or start Storybook to view UI component demos. Examples are located in the `examples/` directory and each have their own instructions. To use Storybook you can follow [the guide below](#using-storybook).
 
-Before writing any new code you may also find it useful to refer to the [architecture overview](architecture.md) and [contribution guide](contribution.md) which covers coding standards and expectations.
+Before writing any new code you may also find it useful to refer to the [architecture overview](architecture.md) and [contribution guide](contributing.md) which covers coding standards and expectations.
 
 
 ### Project structure


### PR DESCRIPTION
# Description

Noticed the link was broken when trying to access the contribution guides through the README

- Correct the spelling of the contribution guide link in README

# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [X] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [X] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [X] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
