### PR TITLE
[Update] source_code of Origami Build service URLs

### DIFF
--- a/packages/dotcom-ui-base-styles/src/lib/fontFaces.ts
+++ b/packages/dotcom-ui-base-styles/src/lib/fontFaces.ts
@@ -1,8 +1,8 @@
 // NOTE: please also update dotcom-ui-base-styles/styles.scss $o-fonts-path when updating the URLs defined below. They
 // need to stay in-sync to ensure our CSS output matches the resource hints we set.
 export const fontFaceURLs = [
-  'https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=MetricWeb-Regular&system_code=origami&version=1.12',
-  'https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=MetricWeb-Semibold&system_code=origami&version=1.12',
-  'https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Regular&system_code=origami&version=1.12',
-  'https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Bold&system_code=origami&version=1.12'
+  'https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=MetricWeb-Regular&system_code=page-kit&version=1.12',
+  'https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=MetricWeb-Semibold&system_code=page-kit&version=1.12',
+  'https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Regular&system_code=page-kit&version=1.12',
+  'https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Bold&system_code=page-kit&version=1.12'
 ]

--- a/packages/dotcom-ui-shell/src/__test__/components/ResourceHints.test.tsx
+++ b/packages/dotcom-ui-shell/src/__test__/components/ResourceHints.test.tsx
@@ -8,7 +8,7 @@ describe('dotcom-ui-shell/src/components/ResourceHints', () => {
       'www.example.com/assets/style.css',
       'www.example.com/images/graphic.svg#icon',
       '/assets/public/style.as83hd99.css',
-      '/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Bold&system_code=origami&version=1.12'
+      '/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Bold&system_code=page-kit&version=1.12'
     ]
 
     const tree = renderer.create(<Subject resourceHints={fixture} />).toJSON()

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/ResourceHints.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/ResourceHints.test.tsx.snap
@@ -40,7 +40,7 @@ Array [
   <link
     as="font"
     crossOrigin="anonymous"
-    href="/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Bold&system_code=origami&version=1.12"
+    href="/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Bold&system_code=page-kit&version=1.12"
     rel="preload"
     type="font/woff2"
   />,

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -102,28 +102,28 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=MetricWeb-Regular&system_code=origami&version=1.12"
+      href="https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=MetricWeb-Regular&system_code=page-kit&version=1.12"
       rel="preload"
       type="font/woff2"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=MetricWeb-Semibold&system_code=origami&version=1.12"
+      href="https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=MetricWeb-Semibold&system_code=page-kit&version=1.12"
       rel="preload"
       type="font/woff2"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Regular&system_code=origami&version=1.12"
+      href="https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Regular&system_code=page-kit&version=1.12"
       rel="preload"
       type="font/woff2"
     />
     <link
       as="font"
       crossOrigin="anonymous"
-      href="https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Bold&system_code=origami&version=1.12"
+      href="https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=FinancierDisplayWeb-Bold&system_code=page-kit&version=1.12"
       rel="preload"
       type="font/woff2"
     />

--- a/packages/dotcom-ui-shell/src/__test__/lib/getResourceType.spec.ts
+++ b/packages/dotcom-ui-shell/src/__test__/lib/getResourceType.spec.ts
@@ -7,7 +7,7 @@ describe('dotcom-ui-shell/src/lib/getResourceType', () => {
     expect(subject('image.png')).toEqual('image')
     expect(
       subject(
-        'https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=MetricWeb-Regular&system_code=origami&version=1.12'
+        'https://www.ft.com/__origami/service/build/v3/font?font_format=woff2&font_name=MetricWeb-Regular&system_code=page-kit&version=1.12'
       )
     ).toEqual('font')
   })


### PR DESCRIPTION

# Description

Updating all Origami Build Service URLs in **dotcom-page-kit** that used `source_code=origami`, to use `source_code=page-kit` instead. This gives a accurate reporting on the source of the build service request.

# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [X] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [X] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [X] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
