### PR TITLE
[AG-194] chore: bump oAds to consume mvt2 flag changes

### DIFF
--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -11,7 +11,7 @@
     "test": "../../node_modules/.bin/jest"
   },
   "dependencies": {
-    "@financial-times/ads-display": "^6.3.0",
+    "@financial-times/ads-display": "^6.5.0",
     "@financial-times/dotcom-middleware-app-context": "file:../../packages/dotcom-middleware-app-context",
     "@financial-times/dotcom-middleware-asset-loader": "file:../../packages/dotcom-middleware-asset-loader",
     "@financial-times/dotcom-middleware-navigation": "file:../../packages/dotcom-middleware-navigation",

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,7 +163,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@financial-times/ads-display": "^6.3.0",
+        "@financial-times/ads-display": "^6.5.0",
         "@financial-times/dotcom-middleware-app-context": "file:../../packages/dotcom-middleware-app-context",
         "@financial-times/dotcom-middleware-asset-loader": "file:../../packages/dotcom-middleware-asset-loader",
         "@financial-times/dotcom-middleware-navigation": "file:../../packages/dotcom-middleware-navigation",
@@ -2195,13 +2195,13 @@
       }
     },
     "node_modules/@financial-times/ads-display": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/ads-display/-/ads-display-6.3.0.tgz",
-      "integrity": "sha512-nL6gwxK30qRdxUgSbt42J764zKox0tesKSKqIbgJj7JeBkuvHbkMjBSDw7/EfuOwiZjPa4vEvHpJnKrejTHvsw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/ads-display/-/ads-display-6.5.0.tgz",
+      "integrity": "sha512-elJ7XgHwHP5H3jRZO4BaQ5v7oCaPoAULdYMO/Umx+ND6o2Ygv0+gHh9ZqmV1HacLmqKim23jb3sES5YHr9LGLw==",
       "dependencies": {
-        "@financial-times/ads-legacy-o-ads": "^6.3.0",
-        "@financial-times/ads-permutive": "^6.3.0",
-        "@financial-times/ads-personalised-consent": "^6.3.0",
+        "@financial-times/ads-legacy-o-ads": "^6.5.0",
+        "@financial-times/ads-permutive": "^6.5.0",
+        "@financial-times/ads-personalised-consent": "^6.5.0",
         "@financial-times/n-tracking": "^4.0.1",
         "@financial-times/o-tracking": "^4.0.0",
         "@financial-times/o-viewport": "^5.1.1",
@@ -2209,9 +2209,9 @@
       }
     },
     "node_modules/@financial-times/ads-display/node_modules/@financial-times/ads-personalised-consent": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/ads-personalised-consent/-/ads-personalised-consent-6.3.0.tgz",
-      "integrity": "sha512-HBRSixFCICGYceGvYODKZI2EtHkBz2zG0/ZqLZJa2uLc3QsI3tDC8mYVEP/asLTLLDGQcO7TmBpJaXT46U3h5A==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/ads-personalised-consent/-/ads-personalised-consent-6.5.0.tgz",
+      "integrity": "sha512-BpxCZZGZq8Qr8GwDfXvM/OMAPT5/2zr38shjAYLMsZL1VxkqHzlJzLDlivTpP0cn1lOvoEtklqEijtC5YXqNwQ==",
       "dependencies": {
         "@financial-times/privacy-legislation-client": "^1.0.0"
       }
@@ -2276,18 +2276,18 @@
       }
     },
     "node_modules/@financial-times/ads-legacy-o-ads": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/ads-legacy-o-ads/-/ads-legacy-o-ads-6.3.0.tgz",
-      "integrity": "sha512-Vtapb7H3dT2QuWGvnNavMaddn0nnb1GWjs5LcCDCrWhlpuk3ZJ/0vWkKUySqErTuuJXq/FOkj/6+tyiWmAEzag==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/ads-legacy-o-ads/-/ads-legacy-o-ads-6.5.0.tgz",
+      "integrity": "sha512-h3prpSkTbdghVVJrgoRLf6sTuHJyXI6BVSSat9iqw8h90UHlzQmsED+nof4RAgSaYWHkjxQhT0HD4vspSeD5Rw==",
       "dependencies": {
         "@financial-times/o-utils": "^2.1.1",
         "@financial-times/o-viewport": "^5.1.1"
       }
     },
     "node_modules/@financial-times/ads-permutive": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/ads-permutive/-/ads-permutive-6.3.0.tgz",
-      "integrity": "sha512-DazMosLe3lixMiT7zhxxM1++II118rEE/FASILazTuRQrTYgDQDIdULRkLP5aRbbW92w2SOYwkeYFnpciQFzHg=="
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/ads-permutive/-/ads-permutive-6.5.0.tgz",
+      "integrity": "sha512-DD5HSLqiGpifKk1rnX6sDBgcxEkT4FLLDyK5fC9nSHaABiowiu4SvqmcGYSO3bQd1jIac/7yL5hzF4vBpusnsw=="
     },
     "node_modules/@financial-times/ads-personalised-consent": {
       "version": "5.3.0",


### PR DESCRIPTION
# Description
Consumes https://github.com/Financial-Times/advertising/pull/373 so that changes to the mvt2 flag are applied.

# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [ ] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [x] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [x] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
