### PR TITLE
Fix compression-webpack-plugin filename option

### DIFF
--- a/examples/ft-ui/__test__/integration.test.js
+++ b/examples/ft-ui/__test__/integration.test.js
@@ -14,7 +14,7 @@ describe('examples/ft-ui', () => {
     })
 
     it('loads the configured scripts', async () => {
-      await expect(page).toMatchElement('script[src="public/scripts.bundle.js"]')
+      await expect(page).toMatchElement('script[src^="/public/scripts"]')
     })
   })
 

--- a/examples/ft-ui/package.json
+++ b/examples/ft-ui/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "webpack --mode=development",
+    "build": "webpack --mode=production",
     "dev": "nodemon --ext js,jsx",
     "start": "node server/start.js",
     "pretest": "npm run build",

--- a/examples/ft-ui/package.json
+++ b/examples/ft-ui/package.json
@@ -12,6 +12,7 @@
     "test:ci": "../../node_modules/.bin/jest --runInBand --forceExit"
   },
   "dependencies": {
+    "@financial-times/dotcom-middleware-asset-loader": "file:../../packages/dotcom-middleware-asset-loader",
     "@financial-times/dotcom-middleware-navigation": "file:../../packages/dotcom-middleware-navigation",
     "@financial-times/dotcom-ui-layout": "file:../../packages/dotcom-ui-layout",
     "@financial-times/dotcom-ui-shell": "file:../../packages/dotcom-ui-shell",

--- a/examples/ft-ui/server/app.js
+++ b/examples/ft-ui/server/app.js
@@ -1,10 +1,12 @@
 import express from 'express'
 import * as navigation from '@financial-times/dotcom-middleware-navigation'
+import * as assets from '@financial-times/dotcom-middleware-asset-loader'
 import { homeController } from './controllers/home.jsx'
 
 export const app = express()
 
 app.use(navigation.init())
+app.use(assets.init({ hostStaticAssets: true }))
 
 app.use('/public', express.static('./public'))
 

--- a/examples/ft-ui/server/controllers/home.jsx
+++ b/examples/ft-ui/server/controllers/home.jsx
@@ -25,9 +25,14 @@ export function homeController(request, response, next) {
     appContext.appName = 'home-page'
   }
 
+  const { assetLoader } = response.locals
+
   const shellProps = {
-    scripts: ['public/scripts.bundle.js'],
-    stylesheets: ['public/page-kit-layout-styles.css', 'public/styles.css'],
+    scripts: assetLoader.getScriptURLsFor('scripts'),
+    stylesheets: [
+      ...assetLoader.getStylesheetURLsFor('page-kit-layout-styles'),
+      ...assetLoader.getStylesheetURLsFor('styles')
+    ],
     pageTitle: pageData.title,
     appContext,
     flags

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@financial-times/dotcom-middleware-asset-loader": "file:../../packages/dotcom-middleware-asset-loader",
         "@financial-times/dotcom-middleware-navigation": "file:../../packages/dotcom-middleware-navigation",
         "@financial-times/dotcom-ui-layout": "file:../../packages/dotcom-ui-layout",
         "@financial-times/dotcom-ui-shell": "file:../../packages/dotcom-ui-shell",

--- a/packages/dotcom-build-base/src/index.ts
+++ b/packages/dotcom-build-base/src/index.ts
@@ -14,7 +14,6 @@ export class PageKitBasePlugin {
 
     const gzipCompressionPluginOptions = {
       test: /\.(js|css)$/,
-      filename: '[path].gz',
       algorithm: 'gzip',
       compressionOptions: { level: 9 },
       minRatio: 1
@@ -22,7 +21,6 @@ export class PageKitBasePlugin {
 
     const brotliCompressionPluginOptions = {
       test: /\.(js|css)$/,
-      filename: '[path].br',
       algorithm: 'brotliCompress',
       compressionOptions: { level: 11 },
       minRatio: 1


### PR DESCRIPTION
the semantics of the `[path]` placeholder changed in [version 5 of the plugin](https://github.com/webpack-contrib/compression-webpack-plugin/blob/master/CHANGELOG.md#600-2020-09-14), which causes `Conflict: Multiple assets emit different content to the same filename .gz` errors with a production build.

also changes the `ft-ui` example to build in production mode, so we've at least got something that's testing that.