### PR TITLE
CPP-2222 Use Webpack's native import resolution for S/CSS and drop Postcss

### DIFF
--- a/examples/building-sass-files/README.md
+++ b/examples/building-sass-files/README.md
@@ -1,6 +1,6 @@
 # Building Sass Files Example
 
-This example demonstrates how to compile Sass source code using the [Page Kit CLI] and the [Sass plugin]. It also shows some of the useful optimisations provided by PostCSS.
+This example demonstrates how to compile Sass source code using the [Page Kit CLI] and the [Sass plugin]. It also shows some of the useful optimisations provided by cssnano.
 
 Source files are stored in the `src/` directory and the output will be stored in a directory named `public/`. To run the build script run `npm run build`.
 

--- a/examples/building-sass-files/__test__/integration.test.js
+++ b/examples/building-sass-files/__test__/integration.test.js
@@ -20,7 +20,7 @@ describe('examples/building-sass-files', () => {
     })
   })
 
-  describe('PostCSS', () => {
+  describe('Optimisation', () => {
     it('uses cssnano to minify the output', () => {
       const result = outputContents.match(/\.selector/g)
       expect(result.length).toBe(1)

--- a/examples/building-sass-files/src/main.scss
+++ b/examples/building-sass-files/src/main.scss
@@ -9,7 +9,7 @@ $bg-color: #fff1e5;
   background: $bg-color;
 }
 
-// This ruleset should be de-duplicated by PostCSS minification
+// This ruleset should be de-duplicated by minification
 .selector {
   color: $text-color;
   background: $bg-color;

--- a/examples/ft-ui/webpack.config.js
+++ b/examples/ft-ui/webpack.config.js
@@ -9,11 +9,5 @@ module.exports = {
     styles: './client/main.scss',
     'page-kit-layout-styles': require.resolve('@financial-times/dotcom-ui-layout/styles.scss')
   },
-  plugins: [
-    new PageKitBasePlugin(),
-    new PageKitJsPlugin(),
-    new PageKitSassPlugin({
-      includePaths: [path.resolve('../../node_modules')]
-    })
-  ]
+  plugins: [new PageKitBasePlugin(), new PageKitJsPlugin(), new PageKitSassPlugin()]
 }

--- a/examples/kitchen-sink/webpack.config.js
+++ b/examples/kitchen-sink/webpack.config.js
@@ -15,8 +15,6 @@ module.exports = {
     new PageKitBasePlugin(),
     new PageKitJsPlugin(),
     new PageKitCodeSplittingPlugin(),
-    new PageKitSassPlugin({
-      includePaths: [path.resolve('../../node_modules')]
-    })
+    new PageKitSassPlugin()
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17340,21 +17340,6 @@
         "postcss": "^8.4.31"
       }
     },
-    "node_modules/postcss-import": {
-      "version": "16.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
     "node_modules/postcss-merge-longhand": {
       "version": "7.0.4",
       "license": "MIT",
@@ -18311,20 +18296,6 @@
       },
       "peerDependencies": {
         "react": "17.0.2"
-      }
-    },
-    "node_modules/read-cache": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^2.3.0"
-      }
-    },
-    "node_modules/read-cache/node_modules/pify": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {
@@ -22630,7 +22601,6 @@
         "css-minimizer-webpack-plugin": "^7.0.0",
         "mini-css-extract-plugin": "^2.9.1",
         "postcss": "^8.4.20",
-        "postcss-import": "^16.1.0",
         "postcss-loader": "^7.3.3",
         "sass-embedded": "^1.67.0",
         "sass-loader": "^13.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5957,6 +5957,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8029,6 +8030,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -10505,6 +10507,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -10519,6 +10522,7 @@
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -10686,6 +10690,7 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-bigint": {
@@ -14468,13 +14473,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/jiti": {
-      "version": "1.21.6",
-      "license": "MIT",
-      "bin": {
-        "jiti": "bin/jiti.js"
-      }
-    },
     "node_modules/joi": {
       "version": "17.13.3",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
@@ -16736,6 +16734,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -16746,6 +16745,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -16938,6 +16938,7 @@
     },
     "node_modules/path-type": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21331,7 +21332,7 @@
     },
     "node_modules/typescript": {
       "version": "5.6.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -22600,8 +22601,6 @@
         "css-loader": "^6.8.1",
         "css-minimizer-webpack-plugin": "^7.0.0",
         "mini-css-extract-plugin": "^2.9.1",
-        "postcss": "^8.4.20",
-        "postcss-loader": "^7.3.3",
         "sass-embedded": "^1.67.0",
         "sass-loader": "^13.3.2",
         "webpack-remove-empty-scripts": "^1.0.4"
@@ -22611,34 +22610,6 @@
       },
       "peerDependencies": {
         "webpack": "5.x"
-      }
-    },
-    "packages/dotcom-build-sass/node_modules/argparse": {
-      "version": "2.0.1",
-      "license": "Python-2.0"
-    },
-    "packages/dotcom-build-sass/node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "packages/dotcom-build-sass/node_modules/css-loader": {
@@ -22682,36 +22653,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
-    },
-    "packages/dotcom-build-sass/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "packages/dotcom-build-sass/node_modules/postcss-loader": {
-      "version": "7.3.4",
-      "license": "MIT",
-      "dependencies": {
-        "cosmiconfig": "^8.3.5",
-        "jiti": "^1.20.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "postcss": "^7.0.0 || ^8.0.1",
-        "webpack": "^5.0.0"
       }
     },
     "packages/dotcom-build-sass/node_modules/postcss-modules-extract-imports": {

--- a/packages/dotcom-build-sass/README.md
+++ b/packages/dotcom-build-sass/README.md
@@ -39,26 +39,22 @@ module.exports = {
 
 ## Scope
 
-This plugin adds a [rule] to the Webpack configuration to handle `.scss` files. It first uses the [sass-loader] to transpile Sass source code, then sends the output through to the [postcss-loader] for optimisations, and finally the [css-loader]. The [mini-css-extract-plugin] is added to generate `.css` files and the [webpack-fix-style-only-entries] to clean up any empty JavaScript bundles.
+This plugin adds a [rule] to the Webpack configuration to handle `.scss` files. It first uses the [sass-loader] to transpile Sass source code, and then the [css-loader] to handle native CSS files that have been imported. The CSS is optimised using [css-minimizer-webpack-plugin], which runs [cssnano] under the hood. The [mini-css-extract-plugin] is added to generate `.css` files and the [webpack-fix-style-only-entries] to clean up any empty JavaScript bundles.
 
-Sass has been configured to find packages installed with npm by looking in the `'node_modules/@financial-times'` directories. It can be configured to look in additional locations by passing the relevant paths to the plugin as absolute paths.
+Sass supports both relative paths and paths that can be resolved within your `node_modules`. It can be configured to look in additional locations by passing the relevant paths to the plugin as absolute paths.
 
 ```js
 new PageKitSassPlugin({ includePaths: [path.resolve('./path-to-sass-files')] })
 ```
 
-_Please note_ that by default Sass will resolve all bare `@import` statements from the current working directory rather than relative to the file being processed. This means it will not find dependencies in nested `node_modules` directories.
-
-The CSS loader has `@import` and `url()` resolution disabled as these should be handled by Sass.
+The CSS loader has `url()` resolution disabled as we don't use, nor recommend, the function currently.
 
 [rule]: https://webpack.js.org/configuration/module/#rule
 [sass-loader]: https://github.com/webpack-contrib/sass-loader
-[postcss-loader]: https://github.com/postcss/postcss-loader
 [css-loader]: https://github.com/webpack-contrib/css-loader
+[css-minimizer-webpack-plugin]: https://github.com/webpack-contrib/css-minimizer-webpack-plugin
 [mini-css-extract-plugin]: https://github.com/webpack-contrib/mini-css-extract-plugin
 [webpack-fix-style-only-entries]: https://github.com/fqborges/webpack-fix-style-only-entries
-[PostCSS]: https://postcss.org/
-[Autoprefixer]: https://github.com/postcss/autoprefixer
 [cssnano]: https://cssnano.co/
 
 

--- a/packages/dotcom-build-sass/package.json
+++ b/packages/dotcom-build-sass/package.json
@@ -23,8 +23,6 @@
     "css-loader": "^6.8.1",
     "css-minimizer-webpack-plugin": "^7.0.0",
     "mini-css-extract-plugin": "^2.9.1",
-    "postcss": "^8.4.20",
-    "postcss-loader": "^7.3.3",
     "sass-embedded": "^1.67.0",
     "sass-loader": "^13.3.2",
     "webpack-remove-empty-scripts": "^1.0.4"

--- a/packages/dotcom-build-sass/package.json
+++ b/packages/dotcom-build-sass/package.json
@@ -24,7 +24,6 @@
     "css-minimizer-webpack-plugin": "^7.0.0",
     "mini-css-extract-plugin": "^2.9.1",
     "postcss": "^8.4.20",
-    "postcss-import": "^16.1.0",
     "postcss-loader": "^7.3.3",
     "sass-embedded": "^1.67.0",
     "sass-loader": "^13.3.2",

--- a/packages/dotcom-build-sass/src/index.ts
+++ b/packages/dotcom-build-sass/src/index.ts
@@ -48,13 +48,6 @@ export class PageKitSassPlugin {
     }
 
     const postcssLoaderOptions = {
-      postcssOptions: {
-        plugins: [
-          // Allow @import of CSS files from node_modules
-          // https://github.com/postcss/postcss-import
-          require('postcss-import')()
-        ]
-      },
       implementation: require('postcss')
     }
 

--- a/packages/dotcom-build-sass/src/index.ts
+++ b/packages/dotcom-build-sass/src/index.ts
@@ -42,8 +42,8 @@ export class PageKitSassPlugin {
       sassOptions: {
         // Disable formatting so that we don't spend time pretty printing
         outputStyle: 'compressed',
-        // Enable Sass to @import source files from installed dependencies
-        includePaths: ['node_modules/@financial-times', 'node_modules', ...this.includePaths]
+        // Enable Sass to @import source files from additional relative paths
+        includePaths: this.includePaths
       }
     }
 

--- a/packages/dotcom-build-sass/src/index.ts
+++ b/packages/dotcom-build-sass/src/index.ts
@@ -47,14 +47,10 @@ export class PageKitSassPlugin {
       }
     }
 
-    const postcssLoaderOptions = {
-      implementation: require('postcss')
-    }
-
     const cssLoaderOptions = {
-      // sass-loader then postcss-loader run first
-      // https://github.com/webpack-contrib/css-loader/blob/22e16e2fc88f920571219570953d3da5702d4fdb/README.md?plain=1#L921
-      importLoaders: 2,
+      // sass-loader runs first
+      // https://github.com/webpack-contrib/css-loader/blob/22e16e2fc88f920571219570953d3da5702d4fdb/README.md?plain=1#L920
+      importLoaders: 1,
       // Allow css-loader to resolve @import because the sass-loader
       // does not successfully resolve files with a .css extension.
       import: true,
@@ -83,12 +79,6 @@ export class PageKitSassPlugin {
         {
           loader: require.resolve('css-loader'),
           options: cssLoaderOptions
-        },
-        // Enable use of PostCSS for CSS postprocessing
-        // https://github.com/postcss/postcss-loader
-        {
-          loader: require.resolve('postcss-loader'),
-          options: postcssLoaderOptions
         },
         // Enable use of Sass for CSS preprocessing
         // https://github.com/webpack-contrib/sass-loader


### PR DESCRIPTION
# Description

With Webpack 5 we've been able to update to a newer version of the `sass-loader` loader. The newer version [no longer](https://github.com/webpack-contrib/sass-loader/releases/tag/v11.0.0) requires imports to be prefixed with a `~` if they want to use Webpack's resolution logic (i.e., traversing `node_modules`.) This is particularly good for stylesheets that import stylesheets that themselves import stylesheets, as the transitive imports are no longer required to use the non-standard `~` prefix to work.

This means we no longer need to use the `postcss-import` plugin to work around the import behaviour. Importing using `sass-loader` makes native use of Webpack's resolution logic so should be better equipped to handle de-duping etc., though that has not been thoroughly tested: the main motivation here is to use fewer plugins and be more native.

Now that we no longer use `postcss-import`, we no longer require PostCSS at all. Let's remove it entirely from the Sass plugin (though it's still used transitively by the `css-loader`.)

# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [x] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [x] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [x] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
