### PR TITLE
CPP-2223 Add plugin to build native CSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2187,6 +2187,10 @@
       "resolved": "packages/dotcom-build-code-splitting",
       "link": true
     },
+    "node_modules/@financial-times/dotcom-build-css": {
+      "resolved": "packages/dotcom-build-css",
+      "link": true
+    },
     "node_modules/@financial-times/dotcom-build-images": {
       "resolved": "packages/dotcom-build-images",
       "link": true
@@ -22557,6 +22561,154 @@
         "webpack": "5.x"
       }
     },
+    "packages/dotcom-build-css": {
+      "name": "@financial-times/dotcom-build-css",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "css-loader": "^6.8.1",
+        "css-minimizer-webpack-plugin": "^7.0.0",
+        "mini-css-extract-plugin": "^2.9.1",
+        "webpack-remove-empty-scripts": "^1.0.4"
+      },
+      "engines": {
+        "node": "18.x || 20.x || 22.x"
+      },
+      "peerDependencies": {
+        "webpack": "5.x"
+      }
+    },
+    "packages/dotcom-build-css/node_modules/css-loader": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.11.0.tgz",
+      "integrity": "sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==",
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.4.33",
+        "postcss-modules-extract-imports": "^3.1.0",
+        "postcss-modules-local-by-default": "^4.0.5",
+        "postcss-modules-scope": "^3.2.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || 1.x",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "packages/dotcom-build-css/node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "packages/dotcom-build-css/node_modules/postcss-modules-extract-imports": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
+      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "packages/dotcom-build-css/node_modules/postcss-modules-local-by-default": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
+      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "packages/dotcom-build-css/node_modules/postcss-modules-scope": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "packages/dotcom-build-css/node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "license": "ISC",
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "packages/dotcom-build-css/node_modules/postcss-selector-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
+      "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/dotcom-build-css/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "packages/dotcom-build-images": {
       "name": "@financial-times/dotcom-build-images",
       "version": "0.0.0",
@@ -22598,112 +22750,15 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^7.0.0",
-        "mini-css-extract-plugin": "^2.9.1",
+        "@financial-times/dotcom-build-css": "file:../dotcom-build-css",
         "sass-embedded": "^1.67.0",
-        "sass-loader": "^13.3.2",
-        "webpack-remove-empty-scripts": "^1.0.4"
+        "sass-loader": "^13.3.2"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x"
       },
       "peerDependencies": {
         "webpack": "5.x"
-      }
-    },
-    "packages/dotcom-build-sass/node_modules/css-loader": {
-      "version": "6.11.0",
-      "license": "MIT",
-      "dependencies": {
-        "icss-utils": "^5.1.0",
-        "postcss": "^8.4.33",
-        "postcss-modules-extract-imports": "^3.1.0",
-        "postcss-modules-local-by-default": "^4.0.5",
-        "postcss-modules-scope": "^3.2.0",
-        "postcss-modules-values": "^4.0.0",
-        "postcss-value-parser": "^4.2.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "packages/dotcom-build-sass/node_modules/icss-utils": {
-      "version": "5.1.0",
-      "license": "ISC",
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "packages/dotcom-build-sass/node_modules/postcss-modules-extract-imports": {
-      "version": "3.1.0",
-      "license": "ISC",
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "packages/dotcom-build-sass/node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "packages/dotcom-build-sass/node_modules/postcss-modules-scope": {
-      "version": "3.2.0",
-      "license": "ISC",
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.4"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "packages/dotcom-build-sass/node_modules/postcss-modules-values": {
-      "version": "4.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "icss-utils": "^5.0.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
       }
     },
     "packages/dotcom-build-sass/node_modules/sass-loader": {
@@ -22739,16 +22794,6 @@
         "sass-embedded": {
           "optional": true
         }
-      }
-    },
-    "packages/dotcom-build-sass/node_modules/semver": {
-      "version": "7.6.3",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/dotcom-middleware-app-context": {

--- a/packages/dotcom-build-css/README.md
+++ b/packages/dotcom-build-css/README.md
@@ -1,0 +1,49 @@
+# @financial-times/dotcom-build-css
+
+This package exports a Webpack plugin to configure it with a way to load CSS source files.
+
+## Getting started
+
+This package is compatible with Node 18+ and is distributed on npm.
+
+```sh
+npm install --save-dev @financial-times/dotcom-build-css
+```
+
+After installing the package you must add it to the list of plugins in your project's `webpack.config.js` configuration file:
+
+```diff
++ const { PageKitCssPlugin } = require('@financial-times/dotcom-build-css')
+
+module.exports = {
+  plugins: [
++    new PageKitCssPlugin()
+  ]
+}
+```
+
+Once setup, this plugin will enable you to use CSS files (`.css`) as entry points into your source code.
+
+```js
+const { PageKitCssPlugin } = require('@financial-times/dotcom-build-css')
+
+module.exports = {
+   entry: {
+      styles: path/to/styles.css
+   },
+   plugins: [new PageKitCssPlugin()]
+}
+```
+
+## Scope
+
+This plugin adds a [rule] to the Webpack configuration to handle `.css` files. It calls the [css-loader] package to load and parse the source files. The CSS is optimised using [css-minimizer-webpack-plugin], which runs [cssnano] under the hood. The [mini-css-extract-plugin] is added to generate `.css` files and the [webpack-fix-style-only-entries] to clean up any empty JavaScript bundles.
+
+The CSS loader has `url()` resolution disabled as we don't use, nor recommend, the function currently.
+
+[rule]: https://webpack.js.org/configuration/module/#rule
+[css-loader]: https://github.com/webpack-contrib/css-loader
+[css-minimizer-webpack-plugin]: https://github.com/webpack-contrib/css-minimizer-webpack-plugin
+[mini-css-extract-plugin]: https://github.com/webpack-contrib/mini-css-extract-plugin
+[webpack-fix-style-only-entries]: https://github.com/fqborges/webpack-fix-style-only-entries
+[cssnano]: https://cssnano.co/

--- a/packages/dotcom-build-css/package.json
+++ b/packages/dotcom-build-css/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@financial-times/dotcom-build-css",
+  "version": "0.0.0",
+  "description": "",
+  "main": "dist/node/index.js",
+  "types": "dist/node/index.d.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "clean": "npm run clean:dist && npm run clean:node_modules",
+    "clean:dist": "rm -rf dist",
+    "clean:node_modules": "rm -rf node_modules",
+    "build:node": "tsc",
+    "build": "npm run build:node",
+    "dev": "npm run build:node -- --watch"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "peerDependencies": {
+    "webpack": "5.x"
+  },
+  "dependencies": {
+    "css-loader": "^6.8.1",
+    "css-minimizer-webpack-plugin": "^7.0.0",
+    "mini-css-extract-plugin": "^2.9.1",
+    "webpack-remove-empty-scripts": "^1.0.4"
+  },
+  "engines": {
+    "node": "18.x || 20.x || 22.x"
+  },
+  "files": [
+    "dist/",
+    "src/"
+  ],
+  "repository": {
+    "type": "git",
+    "repository": "https://github.com/Financial-Times/dotcom-page-kit.git",
+    "directory": "packages/dotcom-build-css"
+  },
+  "homepage": "https://github.com/Financial-Times/dotcom-page-kit/tree/HEAD/packages/dotcom-build-css",
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/packages/dotcom-build-css/src/index.ts
+++ b/packages/dotcom-build-css/src/index.ts
@@ -1,0 +1,46 @@
+import CSSMinimizerPlugin from 'css-minimizer-webpack-plugin'
+import MiniCssExtractPlugin from 'mini-css-extract-plugin'
+import RemoveEmptyScriptsPlugin from 'webpack-remove-empty-scripts'
+import type webpack from 'webpack'
+
+export class PageKitCssPlugin {
+  apply(compiler: webpack.Compiler) {
+    const cssLoaderOptions = {
+      // Disable Webpack from resolving url() because we do not
+      // currently use this functionality.
+      url: false
+    }
+
+    const miniCssExtractPluginOptions = {
+      // only include content hash in filename when compiling production assets
+      filename: compiler.options.mode === 'development' ? '[name].css' : '[name].[contenthash:12].css',
+      // we load CSS files ourselves in  `dotcom-ui-shell` so don't need the runtime
+      runtime: false
+    }
+
+    compiler.options.module.rules.push({
+      test: [/\.css$/],
+      use: [
+        // Extracts CSS into separate, non-JS files
+        // https://github.com/webpack-contrib/mini-css-extract-plugin
+        {
+          loader: MiniCssExtractPlugin.loader
+        },
+        // Add support for handling .css files
+        // https://github.com/webpack-contrib/css-loader
+        {
+          loader: require.resolve('css-loader'),
+          options: cssLoaderOptions
+        }
+      ]
+    })
+
+    compiler.options.optimization.minimizer = ['...', new CSSMinimizerPlugin()]
+
+    // 2024 and this is still an issue :/ mini-css-extract-plugin leaves
+    // behind empty .js bundles after extracting the CSS.
+    // https://github.com/webpack/webpack/issues/11671
+    new RemoveEmptyScriptsPlugin().apply(compiler)
+    new MiniCssExtractPlugin(miniCssExtractPluginOptions).apply(compiler)
+  }
+}

--- a/packages/dotcom-build-css/src/index.ts
+++ b/packages/dotcom-build-css/src/index.ts
@@ -3,14 +3,28 @@ import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 import RemoveEmptyScriptsPlugin from 'webpack-remove-empty-scripts'
 import type webpack from 'webpack'
 
+const cssLoaderOptions = {
+  // Disable Webpack from resolving url() because we do not
+  // currently use this functionality.
+  url: false
+}
+
+export const cssRule = (additionalLoaderOptions: Record<string, any> = {}) => [
+  // Extracts CSS into separate, non-JS files
+  // https://github.com/webpack-contrib/mini-css-extract-plugin
+  {
+    loader: MiniCssExtractPlugin.loader
+  },
+  // Add support for handling .css files
+  // https://github.com/webpack-contrib/css-loader
+  {
+    loader: require.resolve('css-loader'),
+    options: { ...cssLoaderOptions, ...additionalLoaderOptions }
+  }
+]
+
 export class PageKitCssPlugin {
   apply(compiler: webpack.Compiler) {
-    const cssLoaderOptions = {
-      // Disable Webpack from resolving url() because we do not
-      // currently use this functionality.
-      url: false
-    }
-
     const miniCssExtractPluginOptions = {
       // only include content hash in filename when compiling production assets
       filename: compiler.options.mode === 'development' ? '[name].css' : '[name].[contenthash:12].css',
@@ -20,19 +34,7 @@ export class PageKitCssPlugin {
 
     compiler.options.module.rules.push({
       test: [/\.css$/],
-      use: [
-        // Extracts CSS into separate, non-JS files
-        // https://github.com/webpack-contrib/mini-css-extract-plugin
-        {
-          loader: MiniCssExtractPlugin.loader
-        },
-        // Add support for handling .css files
-        // https://github.com/webpack-contrib/css-loader
-        {
-          loader: require.resolve('css-loader'),
-          options: cssLoaderOptions
-        }
-      ]
+      use: cssRule()
     })
 
     compiler.options.optimization.minimizer = ['...', new CSSMinimizerPlugin()]

--- a/packages/dotcom-build-css/tsconfig.json
+++ b/packages/dotcom-build-css/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/node",
+
+    "strict": true,
+  }
+}

--- a/packages/dotcom-build-sass/README.md
+++ b/packages/dotcom-build-sass/README.md
@@ -39,7 +39,7 @@ module.exports = {
 
 ## Scope
 
-This plugin adds a [rule] to the Webpack configuration to handle `.scss` files. It first uses the [sass-loader] to transpile Sass source code, and then the [css-loader] to handle native CSS files that have been imported. The CSS is optimised using [css-minimizer-webpack-plugin], which runs [cssnano] under the hood. The [mini-css-extract-plugin] is added to generate `.css` files and the [webpack-fix-style-only-entries] to clean up any empty JavaScript bundles.
+This plugin adds a [rule] to the Webpack configuration to handle `.scss` files. It first uses the [sass-loader] to transpile Sass source code. It will then process the CSS using the same logic as [@financial-times/dotcom-build-css]. So we'll first call [css-loader] to handle the native CSS files that have been generated. The CSS is optimised using [css-minimizer-webpack-plugin], which runs [cssnano] under the hood. The [mini-css-extract-plugin] is added to generate `.css` files and the [webpack-fix-style-only-entries] to clean up any empty JavaScript bundles.
 
 Sass supports both relative paths and paths that can be resolved within your `node_modules`. It can be configured to look in additional locations by passing the relevant paths to the plugin as absolute paths.
 
@@ -50,6 +50,7 @@ new PageKitSassPlugin({ includePaths: [path.resolve('./path-to-sass-files')] })
 The CSS loader has `url()` resolution disabled as we don't use, nor recommend, the function currently.
 
 [rule]: https://webpack.js.org/configuration/module/#rule
+[@financial-times/dotcom-build-css]: ../dotcom-build-css
 [sass-loader]: https://github.com/webpack-contrib/sass-loader
 [css-loader]: https://github.com/webpack-contrib/css-loader
 [css-minimizer-webpack-plugin]: https://github.com/webpack-contrib/css-minimizer-webpack-plugin

--- a/packages/dotcom-build-sass/package.json
+++ b/packages/dotcom-build-sass/package.json
@@ -20,12 +20,9 @@
     "webpack": "5.x"
   },
   "dependencies": {
-    "css-loader": "^6.8.1",
-    "css-minimizer-webpack-plugin": "^7.0.0",
-    "mini-css-extract-plugin": "^2.9.1",
+    "@financial-times/dotcom-build-css": "file:../dotcom-build-css",
     "sass-embedded": "^1.67.0",
-    "sass-loader": "^13.3.2",
-    "webpack-remove-empty-scripts": "^1.0.4"
+    "sass-loader": "^13.3.2"
   },
   "engines": {
     "node": "18.x || 20.x || 22.x"

--- a/packages/dotcom-build-sass/tsconfig.json
+++ b/packages/dotcom-build-sass/tsconfig.json
@@ -4,5 +4,10 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist/node"
-  }
+  },
+  "references": [
+    {
+      "path": "../dotcom-build-css"
+    }
+  ]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,6 +8,9 @@
       "path": "packages/dotcom-build-code-splitting"
     },
     {
+      "path": "packages/dotcom-build-css"
+    },
+    {
       "path": "packages/dotcom-build-images"
     },
     {


### PR DESCRIPTION
# Description

We used to have a plugin with the same name, but that was deprecated as there was not much demand for it. Now that Origami is moving towards a native CSS approach, and it encouraging others to do the same, it makes sense to bring this plugin back.

Much of the code is shared between the Sass and CSS plugins, as once the Sass is compiled to CSS we want to do the same set of transformations to both.

# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [x] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [x] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [x] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
