### PR TITLE
Update `n-topic-seach`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15592,7 +15592,9 @@
       }
     },
     "node_modules/n-topic-search": {
-      "version": "8.0.5",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/n-topic-search/-/n-topic-search-9.0.0.tgz",
+      "integrity": "sha512-q7SATBqTv7AjbmJYAqAM45G3Wouee5htaXXq5oHlrcqBBYPFVOiL1/f0HbzAyKdZFbynE34abmSUpdz0xi5xfQ==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -23120,7 +23122,7 @@
       "peerDependencies": {
         "@financial-times/logo-images": "^1.10.1",
         "@financial-times/o-header": "^14.0.4",
-        "n-topic-search": "^8.0.5",
+        "n-topic-search": "^9.0.0",
         "n-ui-foundations": "^9.0.0 || ^10.0.0",
         "preact": "^10.23.2",
         "react": "17.x || 18.x",

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@financial-times/logo-images": "^1.10.1",
     "@financial-times/o-header": "^14.0.4",
-    "n-topic-search": "^8.0.5",
+    "n-topic-search": "^9.0.0",
     "n-ui-foundations": "^9.0.0 || ^10.0.0",
     "preact": "^10.23.2",
     "react": "17.x || 18.x",


### PR DESCRIPTION
# Description

`n-topic-search` version 9 removes scss variable `$o-spacing-relative-units` that overrides unit measurements for consuming applications. 

# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [ ] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [ ] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [ ] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
