### PR TITLE
fix: update n-topic-search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21528,7 +21528,9 @@
       }
     },
     "node_modules/n-topic-search": {
-      "version": "8.0.5",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/n-topic-search/-/n-topic-search-9.0.0.tgz",
+      "integrity": "sha512-q7SATBqTv7AjbmJYAqAM45G3Wouee5htaXXq5oHlrcqBBYPFVOiL1/f0HbzAyKdZFbynE34abmSUpdz0xi5xfQ==",
       "license": "ISC",
       "dependencies": {
         "lodash.debounce": "^4.0.8",
@@ -31711,7 +31713,7 @@
       "license": "MIT",
       "dependencies": {
         "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
-        "n-topic-search": "^8.0.5"
+        "n-topic-search": "^9.0.0"
       },
       "devDependencies": {
         "@financial-times/logo-images": "^1.10.1",

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@financial-times/dotcom-types-navigation": "file:../dotcom-types-navigation",
-    "n-topic-search": "^8.0.5"
+    "n-topic-search": "^9.0.0"
   },
   "devDependencies": {
     "@financial-times/logo-images": "^1.10.1",


### PR DESCRIPTION
This update removes `$o-spacing-relative-units`
that is globally overriding unit measurements for
consuming apps