### PR TITLE
Include ex-n-ui-foundations Sass files in dotcom-ui-base-styles' npm package

### DIFF
--- a/packages/dotcom-ui-base-styles/package.json
+++ b/packages/dotcom-ui-base-styles/package.json
@@ -34,6 +34,7 @@
   "files": [
     "dist/",
     "src/",
+    "sass/",
     "browser.js",
     "component.js",
     "styles.scss"


### PR DESCRIPTION
# Description

The new `sass` directory was not added to the `files` filter in the `package.json` so wasn't being included in npm releases.

# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [x] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [x] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [x] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
