### PR TITLE
fix: don't revert to core experience on error from third-party script

### DIFF
--- a/packages/dotcom-ui-bootstrap/README.md
+++ b/packages/dotcom-ui-bootstrap/README.md
@@ -125,7 +125,7 @@ If JavaScript is available the `no-js` class on the document element will be rep
 
 If the browser passes the [cuts the mustard](#cutting-the-mustard) test then the `core` class name on the document element will be replaced with `enhanced`.
 
-If any scripts fail to load a tracking pixel will be loaded to send a JavaScript loading failure event to [Spoor].
+If any scripts fail to load a tracking pixel will be loaded to send a JavaScript loading failure event to [Spoor]. With enhanced experience, if any first-party scripts (i.e. scripts on an `www.ft.com` hostname) fail to load, the bootstrap will fall back to core experience.
 
 [Spoor]: https://spoor-docs.herokuapp.com/
 

--- a/packages/dotcom-ui-bootstrap/lib/bootstrap.js
+++ b/packages/dotcom-ui-bootstrap/lib/bootstrap.js
@@ -25,9 +25,15 @@
       console.error('The script ' + script + ' failed to load') // eslint-disable-line no-console
     }
 
+    const scriptHost = new URL(script).hostname
+
     if (/enhanced/.test(doc.className)) {
-      console.warn('Script loading failed, reverting to core experience') // eslint-disable-line no-console
-      doc.className = doc.className.replace('enhanced', 'core')
+      if (scriptHost === 'www.ft.com') {
+        console.warn('Script loading failed, reverting to core experience') // eslint-disable-line no-console
+        doc.className = doc.className.replace('enhanced', 'core')
+      } else {
+        console.warn('Third-party script, not reverting to core experience') // eslint-disable-line no-console
+      }
     }
 
     if (scriptsConfig.trackErrors) {

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -175,9 +175,15 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
       console.error('The script ' + script + ' failed to load') // eslint-disable-line no-console
     }
 
+    const scriptHost = new URL(script).hostname
+
     if (/enhanced/.test(doc.className)) {
-      console.warn('Script loading failed, reverting to core experience') // eslint-disable-line no-console
-      doc.className = doc.className.replace('enhanced', 'core')
+      if (scriptHost === 'www.ft.com') {
+        console.warn('Script loading failed, reverting to core experience') // eslint-disable-line no-console
+        doc.className = doc.className.replace('enhanced', 'core')
+      } else {
+        console.warn('Third-party script, not reverting to core experience') // eslint-disable-line no-console
+      }
     }
 
     if (scriptsConfig.trackErrors) {


### PR DESCRIPTION
https://financialtimes.enterprise.slack.com/archives/C08CDEJCVCN
