### PR TITLE
fix: update to o3-foundation v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2510,9 +2510,10 @@
       }
     },
     "node_modules/@financial-times/o3-foundation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/o3-foundation/-/o3-foundation-2.1.0.tgz",
-      "integrity": "sha512-8XOuROofEQJs6HazBhhUmRno6+Om/nkc3njPqX0nl/FVLErmdYf67Qwa+TEYIWxvbmP3PgX1jLII9AD0pwxG0A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o3-foundation/-/o3-foundation-3.0.0.tgz",
+      "integrity": "sha512-+o0Tpyf20NlwxLjr7o//MB0LhaAKaHJzjoPYheeF0ZlYbESCMT/7+DTOZaWH+PUahXpEUa7wEJ2IEg10QDck8w==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "npm": ">7"
@@ -23305,7 +23306,7 @@
       },
       "peerDependencies": {
         "@financial-times/o-typography": "^7.2.0",
-        "@financial-times/o3-foundation": "^2.1.0",
+        "@financial-times/o3-foundation": "^3.0.0",
         "react": "17.x || 18.x"
       }
     },

--- a/packages/dotcom-ui-base-styles/package.json
+++ b/packages/dotcom-ui-base-styles/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@financial-times/o-typography": "^7.2.0",
-    "@financial-times/o3-foundation": "^2.1.0",
+    "@financial-times/o3-foundation": "^3.0.0",
     "react": "17.x || 18.x"
   },
   "engines": {


### PR DESCRIPTION
required for o3 migration to avoid peer dependency conflicts in `n-topic-search` (which is a dependency of Page Kit, but also depends on Page Kit for demos)