### PR TITLE
DO NOT MERGE prevent importing Sass/CSS from JS

### DIFF
--- a/packages/dotcom-build-css/README.md
+++ b/packages/dotcom-build-css/README.md
@@ -39,7 +39,7 @@ module.exports = {
 
 This plugin adds a [rule] to the Webpack configuration to handle `.css` files. It calls the [css-loader] package to load and parse the source files. The CSS is optimised using [css-minimizer-webpack-plugin], which runs [cssnano] under the hood. The [mini-css-extract-plugin] is added to generate `.css` files and the [webpack-fix-style-only-entries] to clean up any empty JavaScript bundles.
 
-The CSS loader has `url()` resolution disabled as we don't use, nor recommend, the function currently.
+The CSS loader has `url()` resolution disabled as we don't use, nor recommend, the function currently.  We also prevent importing CSS from Javascript files, as that's incompatible with the Asset Loader in production.
 
 [rule]: https://webpack.js.org/configuration/module/#rule
 [css-loader]: https://github.com/webpack-contrib/css-loader

--- a/packages/dotcom-build-css/src/index.ts
+++ b/packages/dotcom-build-css/src/index.ts
@@ -34,6 +34,9 @@ export class PageKitCssPlugin {
 
     compiler.options.module.rules.push({
       test: [/\.css$/],
+      issuer: {
+        not: [/\.(js|ts)x?$/],
+      },
       use: cssRule()
     })
 

--- a/packages/dotcom-build-sass/README.md
+++ b/packages/dotcom-build-sass/README.md
@@ -47,7 +47,7 @@ Sass supports both relative paths and paths that can be resolved within your `no
 new PageKitSassPlugin({ includePaths: [path.resolve('./path-to-sass-files')] })
 ```
 
-The CSS loader has `url()` resolution disabled as we don't use, nor recommend, the function currently.
+The CSS loader has `url()` resolution disabled as we don't use, nor recommend, the function currently. We also prevent importing Sass from Javascript files, as that's incompatible with the Asset Loader in production.
 
 [rule]: https://webpack.js.org/configuration/module/#rule
 [@financial-times/dotcom-build-css]: ../dotcom-build-css

--- a/packages/dotcom-build-sass/src/index.ts
+++ b/packages/dotcom-build-sass/src/index.ts
@@ -53,6 +53,9 @@ export class PageKitSassPlugin {
 
     compiler.options.module.rules.push({
       test: [/\.sass|scss$/],
+      issuer: {
+        not: [/\.(js|ts)x?$/],
+      },
       use: [
         // Load generated CSS using the same logic as
         // @financial-times/dotcom-build-css


### PR DESCRIPTION
this is currently "possible", as that's just what `css-loader` does, but it's seemingly not compatible with the asset loader (not entirely sure why; `mini-css-extract-plugin` should be able to extract these and output them in the asset manifest just fine. i will do some more testing).

since this is broken, and not an intended use case, i think it's best to prevent engineers doing this, so they can get earlier feedback about something that's not going to work.

however!i have no idea if anybody's actually relying on this in apps! if they are, this is a breaking change, if not (since we don't document importing CSS from JS as a feature, and it's not an intended use case) then we can release it as a patch. it's practically impossible to search for this on Github so i'm going to discuss it at dev huddle.