### PR TITLE
Add component view event to the Dropdown component

### DIFF
--- a/packages/dotcom-ui-header/src/__test__/components/DropdownNavigation.spec.tsx
+++ b/packages/dotcom-ui-header/src/__test__/components/DropdownNavigation.spec.tsx
@@ -91,6 +91,5 @@ describe('DropdownNavigation', () => {
       expect(link.getAttribute('data-trackable')).toContain(trackingKey)
     })
     expect(contentContainer).toBeInTheDocument()
-    expect(contentContainer.getAttribute('data-o-tracking-view')).toContain(trackingKey)
   })
 })

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/DropdownNavigation.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/DropdownNavigation.spec.tsx.snap
@@ -32,7 +32,6 @@ exports[`DropdownNavigation renders button props 1`] = `
       <div
         class="o-header__dropdown-content"
         data-id="dropdown-content"
-        data-o-tracking-view="test_tracking_component_view"
         id="dropdown-options"
         role="group"
         tabindex="-1"
@@ -303,7 +302,6 @@ exports[`DropdownNavigation renders correctly 1`] = `
       <div
         class="o-header__dropdown-content"
         data-id="dropdown-content"
-        data-o-tracking-view="test_tracking_component_view"
         id="dropdown-options"
         role="group"
         tabindex="-1"
@@ -574,7 +572,6 @@ exports[`DropdownNavigation renders label 1`] = `
       <div
         class="o-header__dropdown-content"
         data-id="dropdown-content"
-        data-o-tracking-view="test_tracking_component_view"
         id="dropdown-options"
         role="group"
         tabindex="-1"

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -1986,7 +1986,6 @@ exports[`dotcom-ui-header/src/components/MainHeader renders FT Pro Dropdown menu
             <div
               className="o-header__dropdown-content"
               data-id="dropdown-content"
-              data-o-tracking-view="pro_navigation_component_view"
               id="dropdown-options"
               role="group"
               tabIndex={-1}

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
@@ -580,7 +580,6 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders FT Pro dropdown me
             <div
               className="o-header__dropdown-content"
               data-id="dropdown-content"
-              data-o-tracking-view="pro_navigation_component_view"
               id="dropdown-options"
               role="group"
               tabIndex={-1}

--- a/packages/dotcom-ui-header/src/components/dropdown-navigation/dropdownNavigation.js
+++ b/packages/dotcom-ui-header/src/components/dropdown-navigation/dropdownNavigation.js
@@ -97,6 +97,44 @@ const enhanceInteractivity = () => {
   stickyHeaderObserver.observe(stickyHeader)
 }
 
+const trackContent = (options) => {
+  if (!window.IntersectionObserver) {
+    return
+  }
+
+  const selector = options && options.selector
+  const elementsToTrack = document.querySelectorAll(selector)
+  if (elementsToTrack.length === 0) {
+    return
+  }
+
+  const onChange = (changes, observer) => {
+    changes.forEach((change) => {
+      if (change.isIntersecting || change.intersectionRatio > 0) {
+        const viewedEl = change.target
+        const eventData = {
+          action: 'view',
+          category: 'component',
+          className: viewedEl.className,
+          componentContentId: viewedEl.dataset.id,
+          url: window.document.location.href || null,
+          nodeName: viewedEl.nodeName,
+          href: viewedEl.href || false,
+          text: viewedEl.text || false,
+          role: viewedEl.role || false
+        }
+
+        document.body.dispatchEvent(new CustomEvent('oTracking.event', { detail: eventData, bubbles: true }))
+        observer.unobserve(viewedEl)
+      }
+    })
+  }
+
+  const observer = new IntersectionObserver(onChange, { threshold: [1.0] })
+
+  elementsToTrack.forEach((el) => observer.observe(el))
+}
+
 const updateProNavigationLinks = async (options) => {
   const { selector, trackingKey, defaultLinks, proNavigationApi } = options
 
@@ -123,11 +161,8 @@ const updateProNavigationLinks = async (options) => {
     const eventData = {
       action: isFetchError ? 'fetch' : 'update',
       category: 'error',
-      context: {
-        component_name: 'dropdown-navigation',
-        errorMessage: error.message,
-        errorStack: error.stack
-      }
+      component_name: 'dropdown-navigation',
+      errorMessage: error.message
     }
     document.body.dispatchEvent(new CustomEvent('oTracking.event', { detail: eventData, bubbles: true }))
   }
@@ -208,7 +243,16 @@ const init = () => {
   enhanceInteractivity()
 
   /**
+   * Dispatches a custom event with tracking data when the dropdown content becomes visible.
+   *
+   * @param {Object} options - Configuration options for tracking.
+   * @param {string} options.selector - The CSS selector used to identify the elements to track.
+   */
+  trackContent({ selector: '.o-header__dropdown-content' })
+
+  /**
    * Updates the links in the Pro Navigation dropdown.
+   *
    * @param {Object} options - Configuration options for updating the dropdown links.
    * @param {string} options.selector - The CSS class selector used to identify the dropdown(s) to update. This property is required when initializing the dropdown component
    * @param {string} options.trackingKey - A key used for tracking user interactions with the dropdown links and toggler.

--- a/packages/dotcom-ui-header/src/components/dropdown-navigation/dropdownNavigation.tsx
+++ b/packages/dotcom-ui-header/src/components/dropdown-navigation/dropdownNavigation.tsx
@@ -46,7 +46,6 @@ export const DropdownNavigation = ({
         id="dropdown-options"
         role="group" // Needed for VoiceOver navigation in Chrome
         data-id="dropdown-content"
-        data-o-tracking-view={`${trackingKey}_component_view`}
       >
         <DropdownNavigationHeader headerContent={headerContent} />
         <DropdownNavigationList options={options} label={label} trackingKey={trackingKey} />


### PR DESCRIPTION
# Description

This PR adds support for dispatching component view events for the Dropdown content.

Context
As part of an ongoing experiment, the tracking functionality is implemented directly within the Dropdown component to avoid introducing changes for consumers who do not have view tracking enabled.

# Checklist
	•	Component view event dispatched from the JS init function.
	•	Remove tracking attributes from Dropdown jsx

Notes
This is an experimental addition and may be refactored or removed based on the outcomes of the tracking initiative.

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [ ] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [ ] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [ ] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
