### PR TITLE
Fix pro navigation flashing behavior when moving back after redirect

### DIFF
--- a/packages/dotcom-ui-header/README.md
+++ b/packages/dotcom-ui-header/README.md
@@ -79,7 +79,6 @@ All header components with the exception of `<LogoOnly />` require the following
 | showAskButton      | boolean                            | true     | false    | Enable rendering of the ASK button                                             |
 | showProNavigation  | boolean - experimental             | true     | false    | Experimental Feature: Enable rendering of FT pro dropdown.                     |
 | data               | object                             | false    |          | Navigation data for rendering the header links fetched from the navigation API |
-| metadata           | object                             | true     |          | Additional data context for side effects. Do not use for visible rendering effects |
 
 
 

--- a/packages/dotcom-ui-header/src/__test__/components/MainHeader.spec.tsx
+++ b/packages/dotcom-ui-header/src/__test__/components/MainHeader.spec.tsx
@@ -8,7 +8,7 @@ const propsAnonymous = { ...fixture, userIsAnonymous: true, userIsLoggedIn: fals
 const propsLoggedIn = { ...fixture, userIsAnonymous: false, userIsLoggedIn: true }
 const propsRightAligned = { ...profileFixture }
 const propsAskFt = { ...fixture, showAskButton: true }
-const propsProDropdown = { ...fixture, showProNavigation: true , metadata: { 'pro-navigation': 'treatment' } }
+const propsProDropdown = { ...fixture, showProNavigation: true }
 
 describe('dotcom-ui-header/src/components/MainHeader', () => {
   it('renders as an anonymous user', () => {

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -2245,10 +2245,6 @@ exports[`dotcom-ui-header/src/components/MainHeader renders FT Pro Dropdown menu
               </ul>
             </div>
           </nav>
-          <span
-            data-flag-pro-navigation="treatment"
-            hidden={true}
-          />
         </div>
       </div>
     </div>

--- a/packages/dotcom-ui-header/src/components/dropdown-navigation/dropdownNavigation.js
+++ b/packages/dotcom-ui-header/src/components/dropdown-navigation/dropdownNavigation.js
@@ -173,57 +173,6 @@ const trackDropdownView = (options) => {
 }
 
 /**
- * Dispatches a custom exposure event for Amplitude experiment.
- *
- * Remove all relevant code when the experiment is complete.
- */
-const trackDropdownExposure = () => {
-  const flagDataProNavigation =
-    document.querySelector('[data-flag-pro-navigation]')?.dataset.flagProNavigation ||
-    (document.querySelector('#page-kit-app-context') &&
-      JSON.parse(document.querySelector('#page-kit-app-context').innerText).abTestState?.match(
-        /pro-navigation:([^,]+)/
-      )?.[1])
-
-  if (flagDataProNavigation !== undefined && flagDataProNavigation !== 'no-experiment') {
-    const maxRetries = 2
-    const delay = 200
-    let attempt = 0
-    let eventDispatched = false
-
-    function dispatchWithDelay() {
-      if (eventDispatched) {
-        return
-      }
-
-      if (window.oTracking) {
-        document.body.dispatchEvent(
-          new CustomEvent('oTracking.event', {
-            detail: {
-              category: 'amplitudeExperiment',
-              action: 'exposure',
-              event_properties: {
-                flag_key: 'pro-navigation',
-                variant: flagDataProNavigation,
-                experiment_key: 'exp-1'
-              }
-            },
-            bubbles: true
-          })
-        )
-
-        eventDispatched = true
-      } else if (attempt < maxRetries) {
-        attempt++
-        setTimeout(dispatchWithDelay, delay)
-      }
-    }
-
-    dispatchWithDelay()
-  }
-}
-
-/**
  * Updates the links in the Pro Navigation dropdown.
  *
  * @param {Object} options - Configuration options for updating the dropdown links.
@@ -340,7 +289,6 @@ const buildListItem = (listItem, label, link, trackingKey) => {
 
 const init = () => {
   trackDropdownView({ selector: '.o-header__dropdown-content', intersectionObserverThreshold: 0.3 })
-  trackDropdownExposure()
 
   updateProNavigationLinks({
     selector: 'pro_navigation',

--- a/packages/dotcom-ui-header/src/components/dropdown-navigation/dropdownNavigation.js
+++ b/packages/dotcom-ui-header/src/components/dropdown-navigation/dropdownNavigation.js
@@ -18,6 +18,24 @@ const enhanceInteractivity = () => {
     const dropdownButton = dropdownContainer.querySelector('.o-header__dropdown-button')
     const closeDropdownButton = dropdownContainer.querySelector('.o-header__dropdown-close-button-mobile')
 
+    // For each link in the dropdown, add an event listener to handle clicks
+    const links = dropdownContainer.querySelectorAll('.o-header__dropdown-list-item-link')
+    links.forEach((link) => {
+      link.addEventListener('click', (event) => {
+        if (!event.metaKey && !event.ctrlKey) {
+          event.preventDefault()
+          // When the link is clicked, remove the data attribute from the dropdown button
+          // to enable the dropdown to be opened correctly again
+          dropdownButton.removeAttribute('data-dropdown-button-active')
+          // Blur the link to remove focus and hide the dropdown before redirecting.
+          // This prevents the dropdown from flashing if the user goes back to the page.
+          const redirectUrl = event.target.closest('a').getAttribute('href')
+          document.activeElement.blur()
+          window.location.href = redirectUrl
+        }
+      })
+    })
+
     // For Non-JS users the pointer events on the dropdown button are
     // disabled by default as it is the only way to enable the button
     // to both open and close the dropdown. This will not be needed for JS
@@ -53,12 +71,22 @@ const enhanceInteractivity = () => {
     })
   })
 
-  // When clicking outside the dropdown, reset the dropdown button by
+  // When clicking outside the dropdown or on the links inside, reset the dropdown button by
   // removing the data attribute from the dropdown button to enable the dropdown to be opened correctly again
   document.addEventListener('click', (event) => {
     dropdowns.forEach((dropdownContainer) => {
       const dropdownButton = dropdownContainer.querySelector('.o-header__dropdown-button')
-      if (!dropdownContainer.contains(event.target)) {
+      const dropdownContentHeader = dropdownContainer.querySelector('.o-header__dropdown-header')
+
+      // Ensure that clicking on the dropdown button or the dropdown content header
+      // does not remove the attribute. Additionally, check for metaKey (cmd) and ctrlKey to allow
+      // opening links in a new tab without breaking the opening/closing of the dropdown.
+      if (
+        !dropdownButton.contains(event.target) &&
+        !dropdownContentHeader.contains(event.target) &&
+        !event.metaKey &&
+        !event.ctrlKey
+      ) {
         dropdownButton && dropdownButton.removeAttribute('data-dropdown-button-active')
       }
     })
@@ -234,6 +262,8 @@ const updateProNavigationLinks = async (options) => {
       errorMessage: error.message
     }
     document.body.dispatchEvent(new CustomEvent('oTracking.event', { detail: eventData, bubbles: true }))
+  } finally {
+    enhanceInteractivity()
   }
 }
 
@@ -309,8 +339,6 @@ const buildListItem = (listItem, label, link, trackingKey) => {
 }
 
 const init = () => {
-  enhanceInteractivity()
-
   trackDropdownView({ selector: '.o-header__dropdown-content', intersectionObserverThreshold: 0.3 })
   trackDropdownExposure()
 

--- a/packages/dotcom-ui-header/src/components/dropdown-navigation/dropdownNavigation.scss
+++ b/packages/dotcom-ui-header/src/components/dropdown-navigation/dropdownNavigation.scss
@@ -57,7 +57,6 @@
     width: var(--o3-spacing-l);
     background: linear-gradient(153deg, #262a33 54.99%, #434958 99.56%);
     border-radius: var(--o3-spacing-m);
-    border: 2px solid #262a33;
     align-content: center;
 
     .o-header__dropdown-icon {

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -123,7 +123,6 @@ const TopColumnRightLoggedIn = (props: THeaderProps) => {
       {signInAction && (
         <MenuButton
           showProNavigation={props.showProNavigation}
-          proNavigationVariant={props.metadata?.['pro-navigation']}
           signInAction={signInAction}
           variant={props.variant}
         />
@@ -132,7 +131,7 @@ const TopColumnRightLoggedIn = (props: THeaderProps) => {
   )
 }
 
-const MenuButton = ({ proNavigationVariant, showProNavigation, signInAction, variant }) => {
+const MenuButton = ({ showProNavigation, signInAction, variant }) => {
   const isSticky = variant === 'sticky'
   return (
     <React.Fragment>
@@ -148,7 +147,6 @@ const MenuButton = ({ proNavigationVariant, showProNavigation, signInAction, var
       ) : (
         <MyAccountLink item={signInAction} signedIn={true} variant={variant} />
       )}
-      {(proNavigationVariant && !isSticky) && <span hidden data-flag-pro-navigation={proNavigationVariant}></span>}
     </React.Fragment>
   )
 }

--- a/packages/dotcom-ui-header/src/interfaces.d.ts
+++ b/packages/dotcom-ui-header/src/interfaces.d.ts
@@ -16,9 +16,6 @@ export type THeaderOptions = {
 
 export type THeaderProps = THeaderOptions & {
   data: TNavigationData
-  metadata?: {
-    'pro-navigation': string | undefined 
-  }
 }
 
 export type THeaderVariant = 'simple' | 'large-logo' | 'sticky'

--- a/packages/dotcom-ui-layout/README.md
+++ b/packages/dotcom-ui-layout/README.md
@@ -86,7 +86,6 @@ This component includes styles written in Sass which includes the styles the [he
 | footerOptions   | TFooterProps                                    | true     | `undefined` | Pass options to the footer component                                                         |
 | footerComponent | ReactElement                                    | true     | `undefined` | Pass a custom footer                                                                         |
 | contents        | string                                          | true     | `undefined` | A prerendered string of HTML used to insert the page contents when not using JSX composition |
-| metadata        | object                                          | true     | `undefined` | Additional data context for side effects. Do not use for visible rendering effects |
 
 \* Navigation data is required to render all [header] variants except for `"logo-only"`. Navigation data is required to render all built in [footer] components. It is recommended to integrate the [navigation package] with your application to get navigation data.
 

--- a/packages/dotcom-ui-layout/src/components/Layout.tsx
+++ b/packages/dotcom-ui-layout/src/components/Layout.tsx
@@ -37,9 +37,6 @@ export type TLayoutProps = {
   footerAfter?: string | React.ReactNode
   children?: React.ReactNode
   contents?: string
-  metadata?: {
-    'pro-navigation': string | undefined 
-  }
 }
 
 export function Layout({
@@ -55,15 +52,14 @@ export function Layout({
   footerComponent,
   footerAfter,
   children,
-  contents,
-  metadata
+  contents
 }: TLayoutProps) {
   let header = null
   let drawer = null
 
   if (headerVariant && Headers[headerVariant] && !headerComponent) {
     const Header = Headers[headerVariant]
-    header = <Header {...headerOptions} data={navigationData} metadata={metadata} variant={headerVariant} />
+    header = <Header {...headerOptions} data={navigationData} variant={headerVariant} />
 
     if (Header === HeaderSimple || Header === HeaderLarge) {
       drawer = <Drawer {...headerOptions} data={navigationData} />


### PR DESCRIPTION
# Description
This PR resolves an issue with pro navigation (pro dropdown), where after using a link to go to a page and coming back to the last page would result in the dropdown visibly flashing for a second, as well as on some pages resulting in the first click on the dropdown button after returning to the page leading to the dropdown opening and immediately closing. 

This issue has now been resolved and when a user clicks on a link we ensure that we would close the dropdown before we redirect to the new page.

Additionally this PR removes the exposure event added last time, since after speaking with Emilio who conversed with Amplitude it was found we would not need it, as an Amplitude setup with page:view-s can be used instead.

# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [ ] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [ ] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [ ] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
