### PR TITLE
fix: use rel="icon" instead of rel="alternate icon" for PNG fallbacks

### DIFF
--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/DocumentHead.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/DocumentHead.test.tsx.snap
@@ -64,13 +64,13 @@ Array [
   />,
   <link
     href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=png&width=32&height=32"
-    rel="alternate icon"
+    rel="icon"
     sizes="32x32"
     type="image/png"
   />,
   <link
     href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=png&width=194&height=194"
-    rel="alternate icon"
+    rel="icon"
     sizes="194x194"
     type="image/png"
   />,

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -62,13 +62,13 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
     />
     <link
       href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=png&width=32&height=32"
-      rel="alternate icon"
+      rel="icon"
       sizes="32x32"
       type="image/png"
     />
     <link
       href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=png&width=194&height=194"
-      rel="alternate icon"
+      rel="icon"
       sizes="194x194"
       type="image/png"
     />

--- a/packages/dotcom-ui-shell/src/components/DocumentHead.tsx
+++ b/packages/dotcom-ui-shell/src/components/DocumentHead.tsx
@@ -61,13 +61,13 @@ const DocumentHead = (props: TDocumentHeadProps) => (
       href={imageServiceIconURL('ftlogo-v1:brand-ft-logo-square-coloured', 0, 'svg')}
     />
     <link
-      rel="alternate icon"
+      rel="icon"
       type="image/png"
       href={imageServiceIconURL('ftlogo-v1:brand-ft-logo-square-coloured', 32)}
       sizes="32x32"
     />
     <link
-      rel="alternate icon"
+      rel="icon"
       type="image/png"
       href={imageServiceIconURL('ftlogo-v1:brand-ft-logo-square-coloured', 194)}
       sizes="194x194"


### PR DESCRIPTION
`rel="alternate icon"` isn't a thing (looks to have been conflated with `rel="alternate stylesheet"`). with multiple `rel="icon"` tags [browsers prioritise them](https://html.spec.whatwg.org/multipage/links.html#rel-icon) based on what `type` they can render and what `sizes` they want.
