### PR TITLE
ELES-1863 Update Ask FT button on the header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2326,9 +2326,9 @@
       }
     },
     "node_modules/@financial-times/o-header": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-15.0.3.tgz",
-      "integrity": "sha512-IhiFRVUr+h4Z8iwdfwgNW6D5U48Or1d90UNotQ6lkM2M0PpYCT95sKYOqiuQiq2AmTcoC5OatTOJdTMQNPPNdQ==",
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-header/-/o-header-15.0.4.tgz",
+      "integrity": "sha512-mNIKbOxS2tNz9V8td/C9dqVJkpi2PICc48KzRFHnWs8KR9eWIN4ejj+wMyPwpi76TfhnB1Y5SJXKmIdxasN8Mw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -2405,6 +2405,19 @@
       },
       "peerDependencies": {
         "@financial-times/o-utils": "^2.0.0"
+      }
+    },
+    "node_modules/@financial-times/o3-button": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o3-button/-/o3-button-3.12.1.tgz",
+      "integrity": "sha512-Dr3Z7tau22V2aylPsN2WlVWH8Rr5d8AHWRgFelKILDolurnPpsqczuNDgDsBwokMT7VBLp1eTpV55ew7/9VYdg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "npm": ">7"
+      },
+      "peerDependencies": {
+        "@financial-times/o3-foundation": "^3.0.0"
       }
     },
     "node_modules/@financial-times/o3-foundation": {
@@ -23337,7 +23350,8 @@
       },
       "peerDependencies": {
         "@financial-times/logo-images": "^1.10.1",
-        "@financial-times/o-header": "^15.0.3",
+        "@financial-times/o-header": "^15.0.4",
+        "@financial-times/o3-button": "^3.12.1",
         "n-topic-search": "^10.0.2",
         "preact": "^10.23.2",
         "react": "17.x || 18.x",

--- a/packages/dotcom-ui-header/package.json
+++ b/packages/dotcom-ui-header/package.json
@@ -30,7 +30,8 @@
   },
   "peerDependencies": {
     "@financial-times/logo-images": "^1.10.1",
-    "@financial-times/o-header": "^15.0.3",
+    "@financial-times/o-header": "^15.0.4",
+    "@financial-times/o3-button": "^3.12.1",
     "n-topic-search": "^10.0.2",
     "preact": "^10.23.2",
     "react": "17.x || 18.x",

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/Drawer.spec.tsx.snap
@@ -121,11 +121,11 @@ exports[`dotcom-ui-header/src/components/Drawer renders ASK FT button 1`] = `
       className="o-header__drawer-actions"
     >
       <a
-        className="o-header__ask-ft-button o-header__ask-ft-button--drawer"
+        className="o3-button o3-button--primary ft-header__ask-ft-button ft-header__ask-ft-button--drawer o3-button--small o3-button-icon o3-button-icon--sparkles o3-apply-focus-rings"
+        data-o3-theme="neutral"
         data-trackable="ask-ft-button-drawer"
         href="https://ask.ft.com"
         id="ask-ft-button-drawer"
-        title="ASK FT"
       >
         Ask FT
       </a>

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -48,11 +48,11 @@ exports[`dotcom-ui-header/src/components/MainHeader renders ASK FT button 1`] = 
             </span>
           </a>
           <a
-            className="o-header__ask-ft-button o-header__ask-ft-button--top"
+            className="o3-button o3-button--primary ft-header__ask-ft-button ft-header__ask-ft-button--top o3-button--small o3-button-icon o3-button-icon--sparkles o3-apply-focus-rings"
+            data-o3-theme="neutral"
             data-trackable="ask-ft-button-header"
             href="https://ask.ft.com"
             id="ask-ft-button-header"
-            title="ASK FT"
           >
             Ask FT
           </a>

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
@@ -47,11 +47,11 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders ASK FT button 1`] 
             </span>
           </a>
           <a
-            className="o-header__ask-ft-button o-header__ask-ft-button--top"
+            className="o3-button o3-button--primary ft-header__ask-ft-button ft-header__ask-ft-button--top o3-button--small o3-button-icon o3-button-icon--sparkles o3-apply-focus-rings"
+            data-o3-theme="neutral"
             data-trackable="ask-ft-button-sticky"
             href="https://ask.ft.com"
             id="ask-ft-button-sticky"
-            title="ASK FT"
           >
             Ask FT
           </a>

--- a/packages/dotcom-ui-header/src/components/ask-ft/askFtButton.scss
+++ b/packages/dotcom-ui-header/src/components/ask-ft/askFtButton.scss
@@ -1,0 +1,27 @@
+@import '@financial-times/o3-button/css/core.css';
+.ft-header__ask-ft-button {
+    display: flex;
+	align-items: center;
+    white-space: nowrap;
+}
+
+.ft-header__ask-ft-button--drawer {
+    // Same as .o-header__drawer-search
+    @include oGridRespondTo('M') {
+        display: none;
+    }
+
+    justify-content: center;
+}
+
+.ft-header__ask-ft-button--drawer + .o-header__drawer-menu {
+    margin-top: $_o-header-drawer-padding-y;
+}
+
+
+.ft-header__ask-ft-button--top {
+    @include oGridRespondTo($until: 'M') {
+        display: none;
+    }
+    margin: 0 10px;
+}

--- a/packages/dotcom-ui-header/src/components/ask-ft/askFtButton.tsx
+++ b/packages/dotcom-ui-header/src/components/ask-ft/askFtButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { LinkButton } from '@financial-times/o3-button'
 
 export interface AskFtButtonProps {
   id: string
@@ -7,13 +8,17 @@ export interface AskFtButtonProps {
 }
 
 export const AskFtButton = ({ id, variant, dataTrackable }: AskFtButtonProps) => (
-  <a
-    id={id}
-    className={`o-header__ask-ft-button o-header__ask-ft-button--${variant}`}
-    data-trackable={dataTrackable}
+  <LinkButton
     href="https://ask.ft.com"
-    title="ASK FT"
-  >
-    Ask FT
-  </a>
+    icon="sparkles"
+    label="Ask FT"
+    size="small"
+    theme="neutral"
+    type="primary"
+    attributes={{
+      id: id,
+      'data-trackable': dataTrackable,
+      className: `ft-header__ask-ft-button ft-header__ask-ft-button--${variant}`
+    }}
+  />
 )

--- a/packages/dotcom-ui-header/src/header.scss
+++ b/packages/dotcom-ui-header/src/header.scss
@@ -16,12 +16,8 @@
   display: none;
 }
 
-// Overrides <a> color style set by dotcom-ui-base-styles
-.o-header__ask-ft-button {
-  &, &:hover {
-    color: var(--o3-color-palette-black-80)
-  }
-}
-
 // Import the dropdown navigation styles
 @import 'components/dropdown-navigation/dropdownNavigation.scss';
+
+// Import the ask-ft button styles
+@import 'components/ask-ft/askFtButton.scss';


### PR DESCRIPTION
# Description
## Summary
We want to align the Ask FT button in the header with professional styles, and for this, we’d like to use the o3-button package to render it as an o3 link button.

JIRA ticket: [ELES-1863](https://financialtimes.atlassian.net/jira/software/c/projects/ELES/boards/1628?selectedIssue=ELES-1863)

## Context & Approach
- Previously, the Ask FT button relied on the `o-header__ask-ft-button` class to inherit styles from the `@financial-times/o-header` package.
- The initial goal was to use the `o3-button` package to render the button as an o3 link button for improved consistency with professional themes on both `@financial-times/o-header` and `dotcom-ui-header` packages.
- After discussion with the Origami team ([see related PR](https://github.com/Financial-Times/origami/pull/2174) and [discussion](https://financialtimes.slack.com/archives/C02FU5ARJ/p1751443141836959)), we learned that:
  - The `o-header` package can not use o3 components or themes.
  - Using o3 components within o2 (o-header) is not recommended, as it can cause brand/theming issues and would require major breaking changes.
  - link button from `o-buttons` origami package  is also not a suitable option at this time, since it does not support the "neutral" theme used for the Ask FT button in the professional header.

### Solution
- The button styles within `o-header` have been updated to closely match the o3 link button appearance, as much as possible, without introducing o3 or new Origami dependencies.
- On `dotcom-page-kit`, we have stopped using the `o-header__ask-ft-button` class names for styling.
- Instead, we now apply a custom class, `ft-header__ask-ft-button`, to the Ask FT button, using custom styles that closely replicate the updated styles in `o-header` (especially regarding spacing and visibility).
- This approach preserves visual and functional consistency between the two packages, while respecting Origami’s recommendations and avoiding disruptive changes.

## Screenshots

| | Before | After |
| --- | --- | --- |
| Top |  ![ask ft com_answer_4c5fc1fd-4ce7-4dfc-8288-f0d1710d4c05 (2)](https://github.com/user-attachments/assets/c3852341-9529-43b9-a84d-334e9cb7d911) | ![local ft com_8010_ (6)](https://github.com/user-attachments/assets/eaf73e9b-1b39-44d0-b6e1-aaac335025da) |
| Sticky | ![ask ft com_answer_4c5fc1fd-4ce7-4dfc-8288-f0d1710d4c05 (3)](https://github.com/user-attachments/assets/f8eebd9f-420e-4dda-b2d4-7b30b437da7f) | ![local ft com_8010_ (7)](https://github.com/user-attachments/assets/dc728bb4-c5a0-4548-bbf4-20667b096040) |
| Drawer | ![ask ft com_answer_4c5fc1fd-4ce7-4dfc-8288-f0d1710d4c05 (4)](https://github.com/user-attachments/assets/38491cc7-41d7-44e9-9619-20abfc96d219) | ![local ft com_8010_ (3)](https://github.com/user-attachments/assets/bcd6ec4f-db6a-4b55-b817-c973ead2a341) |


# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [ ] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [x] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [x] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)


[ELES-1863]: https://financialtimes.atlassian.net/browse/ELES-1863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ