### PR TITLE
ELES-1863 Increase specificity of ask ft button selectors

### DIFF
--- a/packages/dotcom-ui-header/src/components/ask-ft/askFtButton.scss
+++ b/packages/dotcom-ui-header/src/components/ask-ft/askFtButton.scss
@@ -1,11 +1,16 @@
 @import '@financial-times/o3-button/css/core.css';
-.ft-header__ask-ft-button {
+// The o3-button class selector has higher specificity due to its default styling rules,
+// which can override custom styles applied to the button. To ensure our styles take precedence,
+// we use an ID selector combined with a class selector to increase specificity and avoid conflicts.
+#ask-ft-button-drawer.ft-header__ask-ft-button,
+#ask-ft-button-header.ft-header__ask-ft-button,
+#ask-ft-button-sticky.ft-header__ask-ft-button {
     display: flex;
 	align-items: center;
     white-space: nowrap;
 }
 
-.ft-header__ask-ft-button--drawer {
+#ask-ft-button-drawer.ft-header__ask-ft-button--drawer {
     // Same as .o-header__drawer-search
     @include oGridRespondTo('M') {
         display: none;
@@ -14,12 +19,13 @@
     justify-content: center;
 }
 
-.ft-header__ask-ft-button--drawer + .o-header__drawer-menu {
+#ask-ft-button-drawer.ft-header__ask-ft-button--drawer + .o-header__drawer-menu {
     margin-top: $_o-header-drawer-padding-y;
 }
 
 
-.ft-header__ask-ft-button--top {
+#ask-ft-button-header.ft-header__ask-ft-button--top,
+#ask-ft-button-sticky.ft-header__ask-ft-button--top {
     @include oGridRespondTo($until: 'M') {
         display: none;
     }


### PR DESCRIPTION
# Description
The o3-button class selectors have higher specificity on some pages due to its default styling rules, which override custom styles applied to the button. To ensure our styles take precedence, we need to use an ID selector combined with a class selector to increase specificity and avoid conflicts.

## Screen record
On the screen record bellow is shown how o3 button styles override our custom styles on next-article

https://github.com/user-attachments/assets/27b3cae4-c955-4e8b-a6a1-deff8c8341bf



# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [ ] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [x] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [x] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
