### PR TITLE
CPP-2537 feat: migrate favicon and icons to use image sevice v3

### DIFF
--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/DocumentHead.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/DocumentHead.test.tsx.snap
@@ -58,24 +58,24 @@ Array [
     name="apple-itunes-app"
   />,
   <link
-    href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=svg"
+    href="https://images.ft.com/v3/image/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=page-kit&format=svg"
     rel="icon"
     type="image/svg+xml"
   />,
   <link
-    href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=png&width=32&height=32"
+    href="https://images.ft.com/v3/image/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=page-kit&format=png&width=32&height=32"
     rel="icon"
     sizes="32x32"
     type="image/png"
   />,
   <link
-    href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=png&width=194&height=194"
+    href="https://images.ft.com/v3/image/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=page-kit&format=png&width=194&height=194"
     rel="icon"
     sizes="194x194"
     type="image/png"
   />,
   <link
-    href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=png&width=180&height=180"
+    href="https://images.ft.com/v3/image/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=page-kit&format=png&width=180&height=180"
     rel="apple-touch-icon"
     sizes="180x180"
   />,

--- a/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
+++ b/packages/dotcom-ui-shell/src/__test__/components/__snapshots__/Shell.test.tsx.snap
@@ -56,24 +56,24 @@ exports[`dotcom-ui-shell/src/components/Shell renders the GTM script when the en
       name="apple-itunes-app"
     />
     <link
-      href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=svg"
+      href="https://images.ft.com/v3/image/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=page-kit&format=svg"
       rel="icon"
       type="image/svg+xml"
     />
     <link
-      href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=png&width=32&height=32"
+      href="https://images.ft.com/v3/image/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=page-kit&format=png&width=32&height=32"
       rel="icon"
       sizes="32x32"
       type="image/png"
     />
     <link
-      href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=png&width=194&height=194"
+      href="https://images.ft.com/v3/image/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=page-kit&format=png&width=194&height=194"
       rel="icon"
       sizes="194x194"
       type="image/png"
     />
     <link
-      href="https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=update-logos&format=png&width=180&height=180"
+      href="https://images.ft.com/v3/image/raw/ftlogo-v1%3Abrand-ft-logo-square-coloured?source=page-kit&format=png&width=180&height=180"
       rel="apple-touch-icon"
       sizes="180x180"
     />

--- a/packages/dotcom-ui-shell/src/lib/imageServiceIconURL.ts
+++ b/packages/dotcom-ui-shell/src/lib/imageServiceIconURL.ts
@@ -1,10 +1,10 @@
 import querystring from 'querystring'
 
 function imageServiceIconURL(image: string, size: number, format = 'png'): string {
-  const serviceURL = 'https://www.ft.com/__origami/service/image/v2/images/raw/'
+  const serviceURL = 'https://images.ft.com/v3/image/raw/'
 
   const serviceParameters = {
-    source: 'update-logos',
+    source: 'page-kit',
     format: format,
     width: size,
     height: size


### PR DESCRIPTION
[CPP-2537](https://financialtimes.atlassian.net/browse/CPP-2537)

This PR updates favicon and icons references from using image service v2 to v3.

- Updated the serviceURL in the Image Service Builder to use v3 endpoint
- Updated the source to use [biz op system code ](https://biz-ops.in.ft.com/System/page-kit)
- Made snapshot updates to reflect these changes

[CPP-2537]: https://financialtimes.atlassian.net/browse/CPP-2537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ