### PR TITLE
CPP-2604 feat: update resize function to image service v3 & tests

### DIFF
--- a/packages/dotcom-server-handlebars/src/__test__/helpers.spec.ts
+++ b/packages/dotcom-server-handlebars/src/__test__/helpers.spec.ts
@@ -178,7 +178,7 @@ describe('dotcom-server-handlebars/src/helpers', () => {
         const result = template({}, { helpers })
 
         expect(result).toBe(
-          'https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fwebsite.com%2Fpicture.jpg?width=640&source=next&fit=scale-down'
+          'https://images.ft.com/v3/image/raw/http%3A%2F%2Fwebsite.com%2Fpicture.jpg?width=640&source=page-kit&fit=scale-down'
         )
       })
 
@@ -187,7 +187,7 @@ describe('dotcom-server-handlebars/src/helpers', () => {
         const result = template({}, { helpers })
 
         expect(result).toBe(
-          'https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fwebsite.com%2Fpicture.jpg?width=640&source=next&fit=contain'
+          'https://images.ft.com/v3/image/raw/http%3A%2F%2Fwebsite.com%2Fpicture.jpg?width=640&source=page-kit&fit=contain'
         )
       })
 

--- a/packages/dotcom-server-handlebars/src/helpers/README.md
+++ b/packages/dotcom-server-handlebars/src/helpers/README.md
@@ -121,7 +121,7 @@ Example:
 <img src="{{#resize 640 fit="contain"}}{{image}}{{/resize}}" />
 ```
 
-[Origami Image Service]: https://www.ft.com/__origami/service/image/v2/
+[Origami Image Service]: https://images.ft.com/v3/
 
 ### slice
 

--- a/packages/dotcom-server-handlebars/src/helpers/resize.ts
+++ b/packages/dotcom-server-handlebars/src/helpers/resize.ts
@@ -1,9 +1,9 @@
 import { HelperOptions } from 'handlebars'
 import querystring from 'querystring'
 
-const host = 'https://www.ft.com/__origami/service/image/v2/images/raw'
+const host = 'https://images.ft.com/v3/image/raw'
 
-const defaults = { source: 'next', fit: 'scale-down' }
+const defaults = { source: 'page-kit', fit: 'scale-down' }
 
 export default function resize(...args) {
   if (args.length !== 2) {


### PR DESCRIPTION
[CPP-2604](https://financialtimes.atlassian.net/browse/CPP-2604)

As part of the image service v3 migration, this PR updates the resize function to handle image service v2 URLs, taking in the new v3 URL. 

It also updates the relevant tests. 



[CPP-2604]: https://financialtimes.atlassian.net/browse/CPP-2604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ