### PR TITLE
LIF-664: Fix restart sub button size

### DIFF
--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/MainHeader.spec.tsx.snap
@@ -9667,7 +9667,7 @@ exports[`dotcom-ui-header/src/components/MainHeader renders restart subscription
           className="o-header__top-column o-header__top-column--right"
         >
           <a
-            className="o-header__top-button o3-button o3-button--primary"
+            className="o-header__top-button o3-button o3-button--primary o3-button--small o-header__top-button--hide-m"
             data-trackable="Restart Subscription"
             href="/myaccount/subscription"
             role="button"

--- a/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
+++ b/packages/dotcom-ui-header/src/__test__/components/__snapshots__/StickyHeader.spec.tsx.snap
@@ -1782,7 +1782,7 @@ exports[`dotcom-ui-header/src/components/StickyHeader renders restart subscripti
           className="o-header__top-column o-header__top-column--right"
         >
           <a
-            className="o-header__top-button o3-button o3-button--primary"
+            className="o-header__top-button o3-button o3-button--primary o3-button--small o-header__top-button--hide-m"
             data-trackable="Restart Subscription"
             href="/myaccount/subscription"
             role="button"

--- a/packages/dotcom-ui-header/src/components/top/partials.tsx
+++ b/packages/dotcom-ui-header/src/components/top/partials.tsx
@@ -120,7 +120,7 @@ const TopColumnRightLoggedIn = (props: THeaderProps) => {
         <RestartSubscriptionButton
           item={restartSubscriptionAction}
           variant={props.variant}
-          className="o3-button o3-button--primary"
+          className="o3-button o3-button--primary o3-button--small o-header__top-button--hide-m"
         />
       )}
       {!props.userIsSubscribed && subscribeAction && (


### PR DESCRIPTION
# Description

This PR add origami class to the cta button to be small instead of the default button and also add css class to hide the cta on mobile. This should only show on desktop devices.

### Hidden on mobile viewport
<img width="2535" height="984" alt="Screenshot 2025-09-03 at 11 13 10" src="https://github.com/user-attachments/assets/e6450927-a434-4fe3-b74c-5760fab5e590" />

### Small Origami Button
<img width="2559" height="834" alt="Screenshot 2025-09-03 at 11 13 27" src="https://github.com/user-attachments/assets/c919385d-3632-4788-a7a5-982c91a37b5c" />

[Jira Ticket](https://financialtimes.atlassian.net/browse/LIF-664)


# Checklist

Please read the [contributing guidelines](/contributing.md#opening-a-pull-request). In particular, please make sure:

- [x] I've discussed this feature with [the Platforms team](https://financialtimes.enterprise.slack.com/archives/C3TJ6KXEU)
- [ ] This feature is stable, i.e. is not an ongoing experiment, temporary workaround, or hack
- [x] My branch has been rebased onto the latest commit on `main` (don't merge `main` into your branch)
